### PR TITLE
Add `TypeNode#all_methods` that includes the type's ancestor's methods

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1965,6 +1965,7 @@ module Crystal
       end
 
       it "executes methods" do
+        # Only includes methods defined on the type itself, excluding ancestors.
         assert_macro("{{x.methods.map &.name}}", %([foo])) do |program|
           parent = NonGenericClassType.new(program, program, "Parent", program.reference)
           parent.add_def Def.new "parent_method"
@@ -1976,8 +1977,8 @@ module Crystal
         end
       end
 
-      it "executes methods (all: true)" do
-        assert_macro("{{x.methods(all: true).map &.name}}", %([child_method, parent_method, mixin_method])) do |program|
+      it "executes all_methods" do
+        assert_macro("{{x.all_methods.map &.name}}", %([child_method, parent_method, mixin_method])) do |program|
           mixin = NonGenericModuleType.new(program, program, "Mixin")
           mixin.add_def Def.new "mixin_method"
 
@@ -1989,25 +1990,6 @@ module Crystal
           child.add_def Def.new "child_method"
 
           {x: TypeNode.new(child)}
-        end
-      end
-
-      it "executes methods (all: false)" do
-        assert_macro("{{x.methods(all: false).map &.name}}", %([child_method])) do |program|
-          parent = NonGenericClassType.new(program, program, "Parent", program.reference)
-          parent.add_def Def.new "parent_method"
-
-          child = NonGenericClassType.new(program, program, "Child", parent)
-          child.add_def Def.new "child_method"
-
-          {x: TypeNode.new(child)}
-        end
-      end
-
-      it "errors when methods 'all' named arg is not a BoolLiteral" do
-        assert_macro_error("{{x.methods(all: 1)}}", "named argument 'all' to TypeNode#methods must be a BoolLiteral, not NumberLiteral") do |program|
-          klass = NonGenericClassType.new(program, program, "SomeType", program.reference)
-          {x: TypeNode.new(klass)}
         end
       end
 

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1966,9 +1966,47 @@ module Crystal
 
       it "executes methods" do
         assert_macro("{{x.methods.map &.name}}", %([foo])) do |program|
+          parent = NonGenericClassType.new(program, program, "Parent", program.reference)
+          parent.add_def Def.new "parent_method"
+
+          child = NonGenericClassType.new(program, program, "Child", parent)
+          child.add_def Def.new "foo"
+
+          {x: TypeNode.new(child)}
+        end
+      end
+
+      it "executes methods (all: true)" do
+        assert_macro("{{x.methods(all: true).map &.name}}", %([child_method, parent_method, mixin_method])) do |program|
+          mixin = NonGenericModuleType.new(program, program, "Mixin")
+          mixin.add_def Def.new "mixin_method"
+
+          parent = NonGenericClassType.new(program, program, "Parent", program.reference)
+          parent.add_def Def.new "parent_method"
+          parent.include mixin
+
+          child = NonGenericClassType.new(program, program, "Child", parent)
+          child.add_def Def.new "child_method"
+
+          {x: TypeNode.new(child)}
+        end
+      end
+
+      it "executes methods (all: false)" do
+        assert_macro("{{x.methods(all: false).map &.name}}", %([child_method])) do |program|
+          parent = NonGenericClassType.new(program, program, "Parent", program.reference)
+          parent.add_def Def.new "parent_method"
+
+          child = NonGenericClassType.new(program, program, "Child", parent)
+          child.add_def Def.new "child_method"
+
+          {x: TypeNode.new(child)}
+        end
+      end
+
+      it "errors when methods 'all' named arg is not a BoolLiteral" do
+        assert_macro_error("{{x.methods(all: 1)}}", "named argument 'all' to TypeNode#methods must be a BoolLiteral, not NumberLiteral") do |program|
           klass = NonGenericClassType.new(program, program, "SomeType", program.reference)
-          a_def = Def.new "foo"
-          klass.add_def a_def
           {x: TypeNode.new(klass)}
         end
       end

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1964,32 +1964,55 @@ module Crystal
         end
       end
 
-      it "executes methods" do
-        # Only includes methods defined on the type itself, excluding ancestors.
-        assert_macro("{{x.methods.map &.name}}", %([foo])) do |program|
-          parent = NonGenericClassType.new(program, program, "Parent", program.reference)
-          parent.add_def Def.new "parent_method"
+      describe "#methods" do
+        it "only includes methods defined on the type itself, excluding descendants and ancestors" do
+          assert_macro("{{x.methods.map &.name}}", %([parent_method])) do |program|
+            mixin = NonGenericModuleType.new(program, program, "Mixin")
+            mixin.add_def Def.new "mixin_method"
 
-          child = NonGenericClassType.new(program, program, "Child", parent)
-          child.add_def Def.new "foo"
+            ancestor_type = NonGenericClassType.new(program, program, "AncestorType", program.reference)
+            ancestor_type.add_def Def.new "parent_method"
+            ancestor_type.include mixin
 
-          {x: TypeNode.new(child)}
+            some_type = NonGenericClassType.new(program, program, "SomeType", ancestor_type)
+            some_type.add_def Def.new "foo"
+
+            {x: TypeNode.new(ancestor_type)}
+          end
         end
       end
 
-      it "executes all_methods" do
-        assert_macro("{{x.all_methods.map &.name}}", %([child_method, parent_method, mixin_method])) do |program|
-          mixin = NonGenericModuleType.new(program, program, "Mixin")
-          mixin.add_def Def.new "mixin_method"
+      describe "#all_methods" do
+        it "includes methods defined on a type and its ancestors" do
+          assert_macro("{{x.all_methods.map &.name}}", %([child_method, parent_method, mixin_method])) do |program|
+            mixin = NonGenericModuleType.new(program, program, "Mixin")
+            mixin.add_def Def.new "mixin_method"
 
-          parent = NonGenericClassType.new(program, program, "Parent", program.reference)
-          parent.add_def Def.new "parent_method"
-          parent.include mixin
+            ancestor_type = NonGenericClassType.new(program, program, "AncestorType", program.reference)
+            ancestor_type.add_def Def.new "parent_method"
+            ancestor_type.include mixin
 
-          child = NonGenericClassType.new(program, program, "Child", parent)
-          child.add_def Def.new "child_method"
+            some_type = NonGenericClassType.new(program, program, "SomeType", ancestor_type)
+            some_type.add_def Def.new "child_method"
 
-          {x: TypeNode.new(child)}
+            {x: TypeNode.new(some_type)}
+          end
+        end
+
+        it "only includes methods defined on the type itself and ancestors, but excludes descendants" do
+          assert_macro("{{x.all_methods.map &.name}}", %([parent_method, mixin_method])) do |program|
+            mixin = NonGenericModuleType.new(program, program, "Mixin")
+            mixin.add_def Def.new "mixin_method"
+
+            ancestor_type = NonGenericClassType.new(program, program, "AncestorType", program.reference)
+            ancestor_type.add_def Def.new "parent_method"
+            ancestor_type.include mixin
+
+            some_type = NonGenericClassType.new(program, program, "SomeType", ancestor_type)
+            some_type.add_def Def.new "foo"
+
+            {x: TypeNode.new(ancestor_type)}
+          end
         end
       end
 

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -2898,9 +2898,10 @@ module Crystal::Macros
     def has_constant?(name : StringLiteral | SymbolLiteral) : BoolLiteral
     end
 
-    # Returns the instance methods defined by this type, without including
-    # inherited methods.
-    def methods : ArrayLiteral(Def)
+    # Returns the instance methods defined by this type.
+    #
+    # If *all* is `true`, methods inherited from ancestors, including base types (`Reference`, `Value`, and `Object`), are also included.
+    def methods(*, all : BoolLiteral = false) : ArrayLiteral(Def)
     end
 
     # Returns `true` if this type has a method. For example `default_options`

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -2898,10 +2898,13 @@ module Crystal::Macros
     def has_constant?(name : StringLiteral | SymbolLiteral) : BoolLiteral
     end
 
-    # Returns the instance methods defined by this type.
-    #
-    # If *all* is `true`, methods inherited from ancestors, including base types (`Reference`, `Value`, and `Object`), are also included.
-    def methods(*, all : BoolLiteral = false) : ArrayLiteral(Def)
+    # Returns the instance methods defined by this type, without including
+    # inherited methods.
+    def methods : ArrayLiteral(Def)
+    end
+
+    # Returns the instance methods defined by this type, including those inherited from ancestors and base types (`Reference`, `Value`, and `Object`).
+    def all_methods : ArrayLiteral(Def)
     end
 
     # Returns `true` if this type has a method. For example `default_options`

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2110,7 +2110,17 @@ module Crystal
           TypeNode.has_constant?(type, value)
         end
       when "methods"
-        interpret_check_args { TypeNode.methods(type) }
+        interpret_check_args(named_params: ["all"]) do
+          all = if named_args && (all_arg = named_args["all"]?)
+                  unless all_arg.is_a?(BoolLiteral)
+                    all_arg.raise "named argument 'all' to TypeNode#methods must be a BoolLiteral, not #{all_arg.class_desc}"
+                  end
+                  all_arg.value
+                else
+                  false
+                end
+          TypeNode.methods(type, all: all)
+        end
       when "has_method?"
         interpret_check_args do |arg|
           value = arg.to_string("argument to 'TypeNode#has_method?'")
@@ -2418,14 +2428,25 @@ module Crystal
       end
     end
 
-    def self.methods(type)
+    def self.methods(type, *, all : Bool = false)
       defs = [] of ASTNode
-      type.defs.try &.each do |name, metadatas|
+      collect_methods(defs, type)
+
+      if all
+        type.ancestors.each do |ancestor|
+          collect_methods(defs, ancestor)
+        end
+      end
+
+      ArrayLiteral.new(defs)
+    end
+
+    private def self.collect_methods(defs, type)
+      type.defs.try &.each_value do |metadatas|
         metadatas.each do |metadata|
           defs << metadata.def
         end
       end
-      ArrayLiteral.new(defs)
     end
 
     def self.has_method?(type, name)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2110,17 +2110,9 @@ module Crystal
           TypeNode.has_constant?(type, value)
         end
       when "methods"
-        interpret_check_args(named_params: ["all"]) do
-          all = if named_args && (all_arg = named_args["all"]?)
-                  unless all_arg.is_a?(BoolLiteral)
-                    all_arg.raise "named argument 'all' to TypeNode#methods must be a BoolLiteral, not #{all_arg.class_desc}"
-                  end
-                  all_arg.value
-                else
-                  false
-                end
-          TypeNode.methods(type, all: all)
-        end
+        interpret_check_args { TypeNode.methods(type) }
+      when "all_methods"
+        interpret_check_args { TypeNode.all_methods(type) }
       when "has_method?"
         interpret_check_args do |arg|
           value = arg.to_string("argument to 'TypeNode#has_method?'")
@@ -2428,16 +2420,18 @@ module Crystal
       end
     end
 
-    def self.methods(type, *, all : Bool = false)
+    def self.methods(type)
       defs = [] of ASTNode
       collect_methods(defs, type)
+      ArrayLiteral.new(defs)
+    end
 
-      if all
-        type.ancestors.each do |ancestor|
-          collect_methods(defs, ancestor)
-        end
+    def self.all_methods(type)
+      defs = [] of ASTNode
+      collect_methods(defs, type)
+      type.ancestors.each do |ancestor|
+        collect_methods(defs, ancestor)
       end
-
       ArrayLiteral.new(defs)
     end
 


### PR DESCRIPTION
Resolves #8586 