### PR TITLE
Replace `not_nil!` with `should_not(be_nil)` in spec suite

### DIFF
--- a/spec/compiler/crystal/tools/doc/directives_spec.cr
+++ b/spec/compiler/crystal/tools/doc/directives_spec.cr
@@ -42,7 +42,7 @@ describe Crystal::Doc::Generator do
         CRYSTAL
 
       generator = Doc::Generator.new program, [""]
-      a_def = generator.type(program.types["Foo"]).lookup_method("foo").not_nil!
+      a_def = generator.type(program.types["Foo"]).lookup_method("foo").should_not(be_nil)
       a_def.doc.should eq("Some docs")
       a_def.visibility.should eq("private")
     end
@@ -59,7 +59,7 @@ describe Crystal::Doc::Generator do
         CRYSTAL
 
       generator = Doc::Generator.new program, [""]
-      a_macro = generator.type(program.types["Foo"]).lookup_macro("foo").not_nil!
+      a_macro = generator.type(program.types["Foo"]).lookup_macro("foo").should_not(be_nil)
       a_macro.doc.should eq("Some docs")
       a_macro.visibility.should eq("private")
     end

--- a/spec/compiler/crystal/tools/doc/generator_spec.cr
+++ b/spec/compiler/crystal/tools/doc/generator_spec.cr
@@ -280,13 +280,13 @@ describe Doc::Generator do
       pseudo_def.doc = "Foo"
       doc_method = Doc::Method.new generator, doc_type, pseudo_def, false
       doc_method.name.should eq "typeof"
-      doc_method.doc.not_nil!.should contain %(NOTE: This is a pseudo-method)
+      doc_method.doc.should_not(be_nil).should contain %(NOTE: This is a pseudo-method)
 
       regular_def = Def.new "pseudo_bar"
       regular_def.doc = "Foo"
       doc_method = Doc::Method.new generator, doc_type, regular_def, false
       doc_method.name.should eq "pseudo_bar"
-      doc_method.doc.not_nil!.should_not contain %(NOTE: This is a pseudo-method)
+      doc_method.doc.should_not(be_nil).should_not contain %(NOTE: This is a pseudo-method)
     end
   end
 

--- a/spec/compiler/crystal/tools/doc/method_spec.cr
+++ b/spec/compiler/crystal/tools/doc/method_spec.cr
@@ -152,7 +152,7 @@ describe Doc::Method do
         end
         CRYSTAL
       generator = Doc::Generator.new program, [""]
-      method = generator.type(program.types["Foo"]).lookup_method("foo").not_nil!
+      method = generator.type(program.types["Foo"]).lookup_method("foo").should_not(be_nil)
       method.doc.should eq("Some docs")
       method.doc_copied_from.should be_nil
     end
@@ -164,7 +164,7 @@ describe Doc::Method do
         end
         CRYSTAL
       generator = Doc::Generator.new program, [""]
-      method = generator.type(program).lookup_class_method("foo").not_nil!
+      method = generator.type(program).lookup_class_method("foo").should_not(be_nil)
       method.doc.should be_nil
     end
 
@@ -176,7 +176,7 @@ describe Doc::Method do
         end
         CRYSTAL
       generator = Doc::Generator.new program, [""]
-      method = generator.type(program).lookup_class_method("foo").not_nil!
+      method = generator.type(program).lookup_class_method("foo").should_not(be_nil)
       method.doc.should eq("doc comment")
     end
 
@@ -195,7 +195,7 @@ describe Doc::Method do
         end
         CRYSTAL
       generator = Doc::Generator.new program, [""]
-      method = generator.type(program.types["Bar"]).lookup_method("foo").not_nil!
+      method = generator.type(program.types["Bar"]).lookup_method("foo").should_not(be_nil)
       method.doc.should eq("Some docs")
       method.doc_copied_from.should eq(generator.type(program.types["Foo"]))
     end
@@ -213,7 +213,7 @@ describe Doc::Method do
         end
         CRYSTAL
       generator = Doc::Generator.new program, [""]
-      method = generator.type(program.types["Foo"]).lookup_method("foo").not_nil!
+      method = generator.type(program.types["Foo"]).lookup_method("foo").should_not(be_nil)
       method.doc.should eq("Some docs")
       method.doc_copied_from.should be_nil
     end
@@ -237,7 +237,7 @@ describe Doc::Method do
         end
         CRYSTAL
       generator = Doc::Generator.new program, [""]
-      method = generator.type(program.types["Bar"]).lookup_method("foo").not_nil!
+      method = generator.type(program.types["Bar"]).lookup_method("foo").should_not(be_nil)
       method.doc.should eq("Some docs")
       method.doc_copied_from.should eq(generator.type(program.types["Foo"]))
     end
@@ -258,7 +258,7 @@ describe Doc::Method do
         end
         CRYSTAL
       generator = Doc::Generator.new program, [""]
-      method = generator.type(program.types["Bar"]).lookup_method("foo").not_nil!
+      method = generator.type(program.types["Bar"]).lookup_method("foo").should_not(be_nil)
       method.doc.should eq("Some docs")
       method.doc_copied_from.should be_nil
     end
@@ -283,7 +283,7 @@ describe Doc::Method do
         end
         CRYSTAL
       generator = Doc::Generator.new program, [""]
-      method = generator.type(program.types["Bar"]).lookup_method("foo").not_nil!
+      method = generator.type(program.types["Bar"]).lookup_method("foo").should_not(be_nil)
       method.doc.should eq("Before\n\nSome docs\n\nAfter")
       method.doc_copied_from.should be_nil
     end
@@ -311,7 +311,7 @@ describe Doc::Method do
         end
         CRYSTAL
       generator = Doc::Generator.new program, [""]
-      method = generator.type(program.types["Baz"]).lookup_method("foo").not_nil!
+      method = generator.type(program.types["Baz"]).lookup_method("foo").should_not(be_nil)
       method.doc.should eq("Some docs")
       method.doc_copied_from.should be_nil
     end

--- a/spec/compiler/crystal/tools/expand_spec.cr
+++ b/spec/compiler/crystal/tools/expand_spec.cr
@@ -46,7 +46,7 @@ private def assert_expand(code, expected_result, &)
   run_expand_tool code do |result|
     result.status.should eq("ok")
     result.message.should eq("#{expected_result.size} expansion#{expected_result.size >= 2 ? "s" : ""} found")
-    result.expansions.not_nil!.zip(expected_result) do |expansion, expected_result|
+    result.expansions.should_not(be_nil).zip(expected_result) do |expansion, expected_result|
       expansion_to_a(expansion).zip(expected_result) do |result, expected|
         result.should eq(expected)
       end
@@ -61,7 +61,7 @@ private def assert_expand_simple(code, expanded, original = code.delete('‸'))
 end
 
 private def assert_expand_simple(code, expanded, original = code.delete('‸'), &)
-  assert_expand(code, [[original, expanded]]) { |result| yield result.expansions.not_nil![0] }
+  assert_expand(code, [[original, expanded]]) { |result| yield result.expansions.should_not(be_nil)[0] }
 end
 
 private def assert_expand_fail(code, message = "no expansion found")
@@ -276,7 +276,7 @@ describe "expand" do
     CRYSTAL
 
     assert_expand code, [["bar", "foo\n:bar\n", ":foo\n:bar\n"]] do |result|
-      expansion = result.expansions.not_nil![0]
+      expansion = result.expansions.should_not(be_nil)[0]
 
       macros = expansion.expanded_macros
       macros.size.should eq(2)
@@ -318,7 +318,7 @@ describe "expand" do
     CRYSTAL
 
     assert_expand code, [["baz", "foo\nbar\n:baz\n", ":foo\nfoo\n:bar\n:baz\n", ":foo\n:foo\n:bar\n:baz\n"]] do |result|
-      expansion = result.expansions.not_nil![0]
+      expansion = result.expansions.should_not(be_nil)[0]
 
       macros = expansion.expanded_macros
       macros.size.should eq(3)

--- a/spec/compiler/crystal/tools/implementations_spec.cr
+++ b/spec/compiler/crystal/tools/implementations_spec.cr
@@ -31,8 +31,8 @@ private def assert_implementations(code)
   if cursor_location
     _, result = processed_implementation_visitor(code, cursor_location)
 
-    result_locations = result.implementations.not_nil!.map do |e|
-      Location.new(e.filename.not_nil!, e.line.not_nil!, e.column.not_nil!).to_s
+    result_locations = result.implementations.should_not(be_nil).map do |e|
+      Location.new(e.filename.should_not(be_nil), e.line.should_not(be_nil), e.column.should_not(be_nil)).to_s
     end.sort!
 
     result_locations.should eq(expected_locations.map(&.to_s))
@@ -483,7 +483,7 @@ describe "implementations" do
       Foo.new(42)
       CRYSTAL
 
-    result.implementations.not_nil!.map do |e|
+    result.implementations.should_not(be_nil).map do |e|
       Location.new(e.filename, e.line, e.column).to_s
     end.should eq ["<unknown>:0:0"]
   end

--- a/spec/compiler/lexer/location_spec.cr
+++ b/spec/compiler/lexer/location_spec.cr
@@ -142,7 +142,7 @@ describe "Lexer: location" do
   it "assigns correct loc location to node" do
     exps = Parser.parse(%[(#<loc:"foo.txt",2,3>1 + 2)]).as(Expressions)
     node = exps.expressions.first
-    location = node.location.not_nil!
+    location = node.location.should_not(be_nil)
     location.line_number.should eq(2)
     location.column_number.should eq(3)
     location.filename.should eq("foo.txt")

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -89,7 +89,7 @@ private def assert_end_location(source, line_number = 1, column_number = source.
     parser = Parser.new(string)
     node = parser.parse.as(Expressions).expressions[0]
     node_source(string, node).should eq(source)
-    end_loc = node.end_location.not_nil!
+    end_loc = node.end_location.should_not be_nil
     end_loc.line_number.should eq(line_number)
     end_loc.column_number.should eq(column_number)
   end
@@ -3151,7 +3151,7 @@ module Crystal
 
     it "gets corrects of ~" do
       node = Parser.parse("\n  ~1")
-      loc = node.location.not_nil!
+      loc = node.location.should_not be_nil
       loc.line_number.should eq(2)
       loc.column_number.should eq(3)
     end
@@ -3159,7 +3159,7 @@ module Crystal
     it "gets corrects end location for var" do
       parser = Parser.new("foo = 1\nfoo; 1")
       node = parser.parse.as(Expressions).expressions[1]
-      end_loc = node.end_location.not_nil!
+      end_loc = node.end_location.should_not be_nil
       end_loc.line_number.should eq(2)
       end_loc.column_number.should eq(3)
     end
@@ -3167,7 +3167,7 @@ module Crystal
     it "gets corrects end location for var + var" do
       parser = Parser.new("foo = 1\nfoo + nfoo; 1")
       node = parser.parse.as(Expressions).expressions[1].as(Call).obj.as(Var)
-      end_loc = node.end_location.not_nil!
+      end_loc = node.end_location.should_not be_nil
       end_loc.line_number.should eq(2)
       end_loc.column_number.should eq(3)
     end
@@ -3175,8 +3175,8 @@ module Crystal
     it "gets corrects end location for block with { ... }" do
       parser = Parser.new("foo { 1 + 2 }; 1")
       node = parser.parse.as(Expressions).expressions[0].as(Call)
-      block = node.block.not_nil!
-      end_loc = block.end_location.not_nil!
+      block = node.block.should_not be_nil
+      end_loc = block.end_location.should_not be_nil
       end_loc.line_number.should eq(1)
       end_loc.column_number.should eq(13)
       node.end_location.should eq(end_loc)
@@ -3185,8 +3185,8 @@ module Crystal
     it "gets corrects end location for block with do ... end" do
       parser = Parser.new("foo do\n  1 + 2\nend; 1")
       node = parser.parse.as(Expressions).expressions[0].as(Call)
-      block = node.block.not_nil!
-      end_loc = block.end_location.not_nil!
+      block = node.block.should_not be_nil
+      end_loc = block.end_location.should_not be_nil
       end_loc.line_number.should eq(3)
       end_loc.column_number.should eq(3)
       node.end_location.should eq(end_loc)
@@ -3201,13 +3201,13 @@ module Crystal
         1 + 'a'
         CRYSTAL
       node = parser.parse.as(Expressions).expressions[1]
-      loc = node.location.not_nil!
+      loc = node.location.should_not be_nil
       loc.line_number.should eq(5)
     end
 
     it "gets correct location with \r\n (#1558)" do
       nodes = Parser.parse("class Foo\r\nend\r\n\r\n1").as(Expressions)
-      loc = nodes.last.location.not_nil!
+      loc = nodes.last.location.should_not be_nil
       loc.line_number.should eq(4)
       loc.column_number.should eq(1)
     end
@@ -3215,7 +3215,7 @@ module Crystal
     it "sets location of enum method" do
       parser = Parser.new("enum Foo; A; def bar; end; end")
       node = parser.parse.as(EnumDef).members[1].as(Def)
-      loc = node.location.not_nil!
+      loc = node.location.should_not be_nil
       loc.line_number.should eq(1)
       loc.column_number.should eq(14)
     end
@@ -3223,7 +3223,7 @@ module Crystal
     it "gets correct location after macro with yield" do
       parser = Parser.new(%(\n  1 ? 2 : 3))
       node = parser.parse
-      loc = node.location.not_nil!
+      loc = node.location.should_not be_nil
       loc.line_number.should eq(2)
       loc.column_number.should eq(3)
     end
@@ -3231,7 +3231,7 @@ module Crystal
     it "gets correct location of empty exception handler inside def" do
       parser = Parser.new("def foo\nensure\nend")
       node = parser.parse.as(Def).body
-      loc = node.location.not_nil!
+      loc = node.location.should_not be_nil
       loc.line_number.should eq(2)
     end
 
@@ -3240,7 +3240,7 @@ module Crystal
       node = parser.parse.as(Expressions).expressions[1]
 
       node.name_location.should_not be_nil
-      name_location = node.name_location.not_nil!
+      name_location = node.name_location.should_not be_nil
 
       name_location.line_number.should eq(1)
       name_location.column_number.should eq(10)
@@ -3251,7 +3251,7 @@ module Crystal
       node = parser.parse.as(Expressions).expressions[1]
 
       node.name_location.should_not be_nil
-      name_location = node.name_location.not_nil!
+      name_location = node.name_location.should_not be_nil
 
       name_location.line_number.should eq(1)
       name_location.column_number.should eq(12)
@@ -3278,7 +3278,7 @@ module Crystal
     it "sets correct location of proc literal" do
       parser = Parser.new("->(\n  x : Int32,\n  y : String\n) { }")
       node = parser.parse.as(ProcLiteral)
-      loc = node.location.not_nil!
+      loc = node.location.should_not be_nil
       loc.line_number.should eq(1)
       loc.column_number.should eq(1)
     end
@@ -3286,62 +3286,62 @@ module Crystal
     it "sets correct location of `else` of if statement" do
       parser = Parser.new("if foo\nelse\nend")
       node = parser.parse.as(If)
-      node.location.not_nil!.line_number.should eq(1)
-      node.else_location.not_nil!.line_number.should eq(2)
-      node.end_location.not_nil!.line_number.should eq(3)
+      node.location.should_not(be_nil).line_number.should eq(1)
+      node.else_location.should_not(be_nil).line_number.should eq(2)
+      node.end_location.should_not(be_nil).line_number.should eq(3)
 
       parser = Parser.new("if foo\nend")
       node = parser.parse.as(If)
-      node.location.not_nil!.line_number.should eq(1)
+      node.location.should_not(be_nil).line_number.should eq(1)
       node.else_location.should be_nil
-      node.end_location.not_nil!.line_number.should eq(2)
+      node.end_location.should_not(be_nil).line_number.should eq(2)
     end
 
     it "sets correct location of `elsif` of if statement" do
       parser = Parser.new("if foo\nelsif bar\nend")
       node = parser.parse.as(If)
-      node.location.not_nil!.line_number.should eq(1)
-      node.else_location.not_nil!.line_number.should eq(2)
-      node.end_location.not_nil!.line_number.should eq(3)
+      node.location.should_not(be_nil).line_number.should eq(1)
+      node.else_location.should_not(be_nil).line_number.should eq(2)
+      node.end_location.should_not(be_nil).line_number.should eq(3)
     end
 
     it "sets correct location of `else` of unless statement" do
       parser = Parser.new("unless foo\nelse\nend")
       node = parser.parse.as(Unless)
-      node.location.not_nil!.line_number.should eq(1)
-      node.else_location.not_nil!.line_number.should eq(2)
-      node.end_location.not_nil!.line_number.should eq(3)
+      node.location.should_not(be_nil).line_number.should eq(1)
+      node.else_location.should_not(be_nil).line_number.should eq(2)
+      node.end_location.should_not(be_nil).line_number.should eq(3)
     end
 
     it "sets correct location and end location of `begin` block" do
       parser = Parser.new("begin\nfoo\nend")
       node = parser.parse.as(Expressions)
-      node.location.not_nil!.line_number.should eq(1)
-      node.end_location.not_nil!.line_number.should eq(3)
+      node.location.should_not(be_nil).line_number.should eq(1)
+      node.end_location.should_not(be_nil).line_number.should eq(3)
     end
 
     it "sets correct location and end location of parenthesized empty block" do
       parser = Parser.new("()")
       node = parser.parse.as(Expressions)
-      node.location.not_nil!.column_number.should eq(1)
-      node.end_location.not_nil!.column_number.should eq(2)
+      node.location.should_not(be_nil).column_number.should eq(1)
+      node.end_location.should_not(be_nil).column_number.should eq(2)
     end
 
     it "sets correct location and end location of parenthesized block" do
       parser = Parser.new("(foo; bar)")
       node = parser.parse.as(Expressions)
-      node.location.not_nil!.column_number.should eq(1)
-      node.end_location.not_nil!.column_number.should eq(10)
+      node.location.should_not(be_nil).column_number.should eq(1)
+      node.end_location.should_not(be_nil).column_number.should eq(10)
     end
 
     it "sets correct locations of keywords of exception handler" do
       parser = Parser.new("begin\nrescue\nelse\nensure\nend")
       node = parser.parse.as(ExceptionHandler)
-      node.location.not_nil!.line_number.should eq(1)
-      node.rescues.not_nil!.first.location.not_nil!.line_number.should eq(2)
-      node.else_location.not_nil!.line_number.should eq(3)
-      node.ensure_location.not_nil!.line_number.should eq(4)
-      node.end_location.not_nil!.line_number.should eq(5)
+      node.location.should_not(be_nil).line_number.should eq(1)
+      node.rescues.should_not(be_nil).first.location.should_not(be_nil).line_number.should eq(2)
+      node.else_location.should_not(be_nil).line_number.should eq(3)
+      node.ensure_location.should_not(be_nil).line_number.should eq(4)
+      node.end_location.should_not(be_nil).line_number.should eq(5)
     end
 
     it "sets correct locations of macro if / else" do
@@ -3711,7 +3711,7 @@ module Crystal
     it "sets correct location of trailing ensure" do
       parser = Parser.new("foo ensure bar")
       node = parser.parse.as(ExceptionHandler)
-      ensure_location = node.ensure_location.not_nil!
+      ensure_location = node.ensure_location.should_not(be_nil)
       ensure_location.line_number.should eq(1)
       ensure_location.column_number.should eq(5)
     end
@@ -3719,7 +3719,7 @@ module Crystal
     it "sets correct location of trailing rescue" do
       source = "foo rescue bar"
       parser = Parser.new(source)
-      node = parser.parse.as(ExceptionHandler).rescues.not_nil![0]
+      node = parser.parse.as(ExceptionHandler).rescues.should_not(be_nil)[0]
       node_source(source, node).should eq("rescue bar")
     end
 
@@ -3744,7 +3744,7 @@ module Crystal
 
     it "sets correct location of implicit tuple literal of multi-return" do
       source = "def foo; return 1, 2; end"
-      node = Parser.new(source).parse.as(Def).body.as(Return).exp.not_nil!
+      node = Parser.new(source).parse.as(Def).body.as(Return).exp.should_not be_nil
       node_source(source, node).should eq("1, 2")
     end
 
@@ -3761,7 +3761,7 @@ module Crystal
     it "sets correct location of var in proc pointer" do
       source = "foo : Foo; ->foo.bar"
       expressions = Parser.new(source).parse.as(Expressions).expressions
-      node = expressions[1].as(ProcPointer).obj.not_nil!
+      node = expressions[1].as(ProcPointer).obj.should_not be_nil
       node_source(source, node).should eq("foo")
     end
 
@@ -3774,7 +3774,7 @@ module Crystal
 
     it "sets correct location of receiver var in method def" do
       source = "def foo.bar; end"
-      node = Parser.new(source).parse.as(Def).receiver.not_nil!
+      node = Parser.new(source).parse.as(Def).receiver.should_not be_nil
       node_source(source, node).should eq("foo")
     end
 
@@ -3816,7 +3816,7 @@ module Crystal
       CRYSTAL
 
       exps = Parser.parse(code).as(Expressions)
-      exps.expressions[1].location.not_nil!.line_number.should eq(7)
+      exps.expressions[1].location.should_not(be_nil).line_number.should eq(7)
     end
 
     it "sets correct location for fun def" do
@@ -3878,25 +3878,25 @@ module Crystal
 
     it "sets correct location of argument in named tuple type" do
       source = "x : {foo: Bar}"
-      node = Parser.parse(source).as(TypeDeclaration).declared_type.as(Generic).named_args.not_nil!.first
+      node = Parser.parse(source).as(TypeDeclaration).declared_type.as(Generic).named_args.should_not(be_nil).first
       node_source(source, node).should eq("foo: Bar")
     end
 
     it "sets correct location of instance variable in proc pointer" do
       source = "->@foo.x"
-      node = Parser.parse(source).as(ProcPointer).obj.not_nil!
+      node = Parser.parse(source).as(ProcPointer).obj.should_not(be_nil)
       node_source(source, node).should eq("@foo")
     end
 
     it "sets correct location of instance variable in proc pointer" do
       source = "->@@foo.x"
-      node = Parser.parse(source).as(ProcPointer).obj.not_nil!
+      node = Parser.parse(source).as(ProcPointer).obj.should_not(be_nil)
       node_source(source, node).should eq("@@foo")
     end
 
     it "sets correct location of annotation on method parameter" do
       source = "def x(@[Foo] y) end"
-      node = Parser.parse(source).as(Def).args.first.parsed_annotations.not_nil!.first
+      node = Parser.parse(source).as(Def).args.first.parsed_annotations.should_not(be_nil).first
       node_source(source, node).should eq("@[Foo]")
     end
 

--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -19,7 +19,7 @@ describe "Block inference" do
       end
       CRYSTAL
     result = semantic input
-    input.last.as(Call).block.not_nil!.body.type.should eq(result.program.int32)
+    input.last.as(Call).block.should_not(be_nil).body.type.should eq(result.program.int32)
   end
 
   it "infer type of block parameter" do
@@ -34,7 +34,7 @@ describe "Block inference" do
       CRYSTAL
     result = semantic input
     mod = result.program
-    input.last.as(Call).block.not_nil!.args[0].type.should eq(mod.int32)
+    input.last.as(Call).block.should_not(be_nil).args[0].type.should eq(mod.int32)
   end
 
   it "infer type of local variable" do

--- a/spec/compiler/semantic/closure_spec.cr
+++ b/spec/compiler/semantic/closure_spec.cr
@@ -28,7 +28,7 @@ describe "Semantic: closure" do
     node = result.node.as(Expressions)
     call = node.expressions.last.as(Call)
     target_def = call.target_def
-    var = target_def.vars.not_nil!["x"]
+    var = target_def.vars.should_not(be_nil)["x"]
     var.closured?.should be_true
   end
 
@@ -46,8 +46,8 @@ describe "Semantic: closure" do
       CRYSTAL
     node = result.node.as(Expressions)
     call = node.expressions.last.as(Call)
-    block = call.block.not_nil!
-    var = block.vars.not_nil!["x"]
+    block = call.block.should_not(be_nil)
+    var = block.vars.should_not(be_nil)["x"]
     var.closured?.should be_true
   end
 
@@ -80,7 +80,7 @@ describe "Semantic: closure" do
       a
       CRYSTAL
     program = result.program
-    var = program.vars.not_nil!["a"]
+    var = program.vars.should_not(be_nil)["a"]
     var.closured?.should be_true
   end
 
@@ -114,8 +114,8 @@ describe "Semantic: closure" do
       CRYSTAL
     node = result.node.as(Expressions)
     call = node[1].as(Call)
-    block = call.block.not_nil!
-    var = block.vars.not_nil!["x"]
+    block = call.block.should_not(be_nil)
+    var = block.vars.should_not(be_nil)["x"]
     var.closured?.should be_false
   end
 
@@ -133,7 +133,7 @@ describe "Semantic: closure" do
     node = result.node.as(Expressions)
     call = node.expressions[-2].as(Call)
     target_def = call.target_def
-    var = target_def.vars.not_nil!["self"]
+    var = target_def.vars.should_not(be_nil)["self"]
     var.closured?.should be_false
     target_def.self_closured?.should be_true
   end

--- a/spec/compiler/semantic/doc_spec.cr
+++ b/spec/compiler/semantic/doc_spec.cr
@@ -10,7 +10,7 @@ describe "Semantic: doc" do
     program = result.program
     foo = program.types["Foo"]
     foo.doc.should eq("Hello")
-    foo.locations.not_nil!.size.should eq(1)
+    foo.locations.should_not(be_nil).size.should eq(1)
   end
 
   it "stores doc for abstract class" do
@@ -33,7 +33,7 @@ describe "Semantic: doc" do
     program = result.program
     foo = program.types["Foo"]
     foo.doc.should eq("Hello")
-    foo.locations.not_nil!.size.should eq(1)
+    foo.locations.should_not(be_nil).size.should eq(1)
   end
 
   it "stores doc for module" do
@@ -45,7 +45,7 @@ describe "Semantic: doc" do
     program = result.program
     foo = program.types["Foo"]
     foo.doc.should eq("Hello")
-    foo.locations.not_nil!.size.should eq(1)
+    foo.locations.should_not(be_nil).size.should eq(1)
   end
 
   it "stores doc for def" do
@@ -293,7 +293,7 @@ describe "Semantic: doc" do
     program = result.program
     foo = program.types["Foo"]
     foo.doc.should eq("Hello")
-    foo.locations.not_nil!.size.should eq(1)
+    foo.locations.should_not(be_nil).size.should eq(1)
   end
 
   it "stores doc for flags enum with base type" do
@@ -309,7 +309,7 @@ describe "Semantic: doc" do
     foo = program.types["Foo"]
     foo.annotation(ann).should_not be_nil
     foo.doc.should eq("Hello")
-    foo.locations.not_nil!.size.should eq(1)
+    foo.locations.should_not(be_nil).size.should eq(1)
   end
 
   it "stores doc for enum and doesn't mix with value" do
@@ -323,7 +323,7 @@ describe "Semantic: doc" do
     program = result.program
     foo = program.types["Foo"]
     foo.doc.should eq("Hello")
-    foo.locations.not_nil!.size.should eq(1)
+    foo.locations.should_not(be_nil).size.should eq(1)
   end
 
   it "stores doc for enum with @[Flags]" do
@@ -350,7 +350,7 @@ describe "Semantic: doc" do
     foo = program.types["Foo"]
     a = foo.types["A"]
     a.doc.should eq("Hello")
-    a.locations.not_nil!.size.should eq(1)
+    a.locations.should_not(be_nil).size.should eq(1)
   end
 
   it "stores location for implicit flag enum members" do
@@ -379,7 +379,7 @@ describe "Semantic: doc" do
     program = result.program
     a = program.types["CONST"]
     a.doc.should eq("Hello")
-    a.locations.not_nil!.size.should eq(1)
+    a.locations.should_not(be_nil).size.should eq(1)
   end
 
   it "stores doc for alias" do
@@ -390,7 +390,7 @@ describe "Semantic: doc" do
     program = result.program
     a = program.types["Alias"]
     a.doc.should eq("Hello")
-    a.locations.not_nil!.size.should eq(1)
+    a.locations.should_not(be_nil).size.should eq(1)
   end
 
   it "stores doc for nodes defined in macro call" do
@@ -447,7 +447,7 @@ describe "Semantic: doc" do
       def_foo
       CRYSTAL
     program = result.program
-    foo = program.macros.not_nil!["foo"].first
+    foo = program.macros.should_not(be_nil)["foo"].first
     foo.doc.should eq("Hello")
   end
 
@@ -465,7 +465,7 @@ describe "Semantic: doc" do
       program = result.program
       foo = program.types["Foo"]
       foo.doc.should eq("Hello")
-      foo.locations.not_nil!.size.should eq(2)
+      foo.locations.should_not(be_nil).size.should eq(2)
     end
 
     it "overwrites doc for {{module_type}} when reopening" do
@@ -495,7 +495,7 @@ describe "Semantic: doc" do
       CRYSTAL
     program = result.program
     foo = program.types["Foo"]
-    foo.locations.not_nil!.size.should eq(1)
+    foo.locations.should_not(be_nil).size.should eq(1)
   end
 
   it "attaches doc in double macro expansion (#8463)" do

--- a/spec/compiler/semantic/enum_spec.cr
+++ b/spec/compiler/semantic/enum_spec.cr
@@ -494,7 +494,7 @@ describe "Semantic: enum" do
       end
       CRYSTAL
 
-    method = result.program.types["Foo"].lookup_first_def("bar", block: false).not_nil!
+    method = result.program.types["Foo"].lookup_first_def("bar", block: false).should_not(be_nil)
     method.always_inline?.should be_true
   end
 

--- a/spec/compiler/semantic/exception_spec.cr
+++ b/spec/compiler/semantic/exception_spec.cr
@@ -293,7 +293,7 @@ describe "Semantic: exception" do
       baz
       CRYSTAL
     call = result.node.as(Expressions).expressions.last.as(Call)
-    call.target_defs.not_nil!.first.raises?.should be_true
+    call.target_defs.should_not(be_nil).first.raises?.should be_true
   end
 
   it "marks proc literal as raises" do

--- a/spec/compiler/semantic/lib_spec.cr
+++ b/spec/compiler/semantic/lib_spec.cr
@@ -478,7 +478,7 @@ describe "Semantic: lib" do
       LibSDL.init(0_u32)
       CRYSTAL
     sdl = result.program.types["LibSDL"].as(LibType)
-    attrs = sdl.link_annotations.not_nil!
+    attrs = sdl.link_annotations.should_not(be_nil)
     attrs.size.should eq(2)
     attrs[0].lib.should eq("SDL")
     attrs[1].lib.should eq("SDLMain")
@@ -538,7 +538,7 @@ describe "Semantic: lib" do
       LibSDL.init(0_u32)
       CRYSTAL
     sdl = result.program.types["LibSDL"].as(LibType)
-    attrs = sdl.link_annotations.not_nil!
+    attrs = sdl.link_annotations.should_not(be_nil)
     attrs.size.should eq(2)
     attrs[0].lib.should eq("SDL")
     attrs[1].lib.should eq("SDLMain")
@@ -558,7 +558,7 @@ describe "Semantic: lib" do
       LibSDL.init(0_u32)
       CRYSTAL
     sdl = result.program.types["LibSDL"].as(LibType)
-    attrs = sdl.link_annotations.not_nil!
+    attrs = sdl.link_annotations.should_not(be_nil)
     attrs.size.should eq(1)
     attrs[0].lib.should eq("SDL")
   end
@@ -575,7 +575,7 @@ describe "Semantic: lib" do
       LibSDL.init
       CRYSTAL
     sdl = result.program.types["LibSDL"].as(LibType)
-    attrs = sdl.link_annotations.not_nil!
+    attrs = sdl.link_annotations.should_not(be_nil)
     attrs.size.should eq(1)
     attrs[0].lib.should eq("SDL")
   end

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1799,8 +1799,8 @@ describe "Semantic: macro" do
       end
       CRYSTAL
 
-    method = result.program.types["Foo"].lookup_first_def("bar", false).not_nil!
-    method.location.not_nil!.expanded_location.not_nil!.line_number.should eq(9)
+    method = result.program.types["Foo"].lookup_first_def("bar", false).should_not(be_nil)
+    method.location.should_not(be_nil).expanded_location.should_not(be_nil).line_number.should eq(9)
   end
 
   it "assigns to underscore" do

--- a/spec/compiler/semantic/require_spec.cr
+++ b/spec/compiler/semantic/require_spec.cr
@@ -6,28 +6,28 @@ describe "Semantic: require" do
       error = assert_error %(require "file_that_doesnt_exist"),
         "can't find file 'file_that_doesnt_exist'"
 
-      error.message.not_nil!.should contain "If you're trying to require a shard:"
+      error.message.should_not(be_nil).should contain "If you're trying to require a shard:"
     end
 
     it "relative require" do
       error = assert_error %(require "./file_that_doesnt_exist"),
         "can't find file './file_that_doesnt_exist'"
 
-      error.message.not_nil!.should_not contain "If you're trying to require a shard:"
+      error.message.should_not(be_nil).should_not contain "If you're trying to require a shard:"
     end
 
     it "wildcard" do
       error = assert_error %(require "file_that_doesnt_exist/*"),
         "can't find file 'file_that_doesnt_exist/*'"
 
-      error.message.not_nil!.should contain "If you're trying to require a shard:"
+      error.message.should_not(be_nil).should contain "If you're trying to require a shard:"
     end
 
     it "relative wildcard" do
       error = assert_error %(require "./file_that_doesnt_exist/*"),
         "can't find file './file_that_doesnt_exist/*'"
 
-      error.message.not_nil!.should_not contain "If you're trying to require a shard:"
+      error.message.should_not(be_nil).should_not contain "If you're trying to require a shard:"
     end
   end
 end

--- a/spec/compiler/semantic/virtual_spec.cr
+++ b/spec/compiler/semantic/virtual_spec.cr
@@ -108,7 +108,7 @@ describe "Semantic: virtual" do
       CRYSTAL
     result = semantic nodes
     _, nodes = result.program, result.node.as(Expressions)
-    nodes.last.as(Call).target_defs.not_nil!.size.should eq(1)
+    nodes.last.as(Call).target_defs.should_not(be_nil).size.should eq(1)
   end
 
   it "dispatches virtual method with overload" do
@@ -131,7 +131,7 @@ describe "Semantic: virtual" do
       CRYSTAL
     result = semantic nodes
     _, nodes = result.program, result.node.as(Expressions)
-    nodes.last.as(Call).target_defs.not_nil!.size.should eq(2)
+    nodes.last.as(Call).target_defs.should_not(be_nil).size.should eq(2)
   end
 
   it "works with restriction alpha" do

--- a/spec/compiler/semantic/yield_with_scope_spec.cr
+++ b/spec/compiler/semantic/yield_with_scope_spec.cr
@@ -21,7 +21,7 @@ describe "Semantic: yield with scope" do
     result = semantic input
     mod, input = result.program, result.node.as(Expressions)
     call = input.last.as(Call)
-    assign = call.block.not_nil!.body.as(Assign)
+    assign = call.block.should_not(be_nil).body.as(Assign)
     assign.target.type.should eq(mod.int32)
   end
 
@@ -37,7 +37,7 @@ describe "Semantic: yield with scope" do
       CRYSTAL
     result = semantic input
     mod, input = result.program, result.node.as(Expressions)
-    input.last.as(Call).block.not_nil!.body.type.should eq(mod.int64)
+    input.last.as(Call).block.should_not(be_nil).body.type.should eq(mod.int64)
   end
 
   it "infer type of block body with yield scope and arguments" do
@@ -52,7 +52,7 @@ describe "Semantic: yield with scope" do
       CRYSTAL
     result = semantic input
     mod, input = result.program, result.node.as(Expressions)
-    input.last.as(Call).block.not_nil!.body.type.should eq(mod.float64)
+    input.last.as(Call).block.should_not(be_nil).body.type.should eq(mod.float64)
   end
 
   it "passes #229" do

--- a/spec/std/compress/gzip/gzip_spec.cr
+++ b/spec/std/compress/gzip/gzip_spec.cr
@@ -34,7 +34,7 @@ describe Compress::Gzip do
     io = new_sample_io
 
     Compress::Gzip::Reader.open(io) do |gzip|
-      header = gzip.header.not_nil!
+      header = gzip.header.should_not(be_nil)
       header.modification_time.should eq(SAMPLE_TIME)
       header.os.should eq(SAMPLE_OS)
       header.extra.should eq(SAMPLE_EXTRA)
@@ -61,7 +61,7 @@ describe Compress::Gzip do
   it "reads file with extra fields from file system" do
     File.open(datapath("test.gz")) do |file|
       Compress::Gzip::Reader.open(file) do |gzip|
-        header = gzip.header.not_nil!
+        header = gzip.header.should_not(be_nil)
         header.modification_time.to_utc.should eq(Time.utc(2012, 9, 4, 22, 6, 5))
         header.os.should eq(3_u8)
         header.extra.should eq(Bytes[1, 2, 3, 4, 5])
@@ -85,7 +85,7 @@ describe Compress::Gzip do
     end
     io.rewind
     Compress::Gzip::Reader.open(io) do |gzip|
-      header = gzip.header.not_nil!
+      header = gzip.header.should_not(be_nil)
       header.modification_time.to_utc.should eq(Time.utc(2012, 9, 4, 22, 6, 5))
       header.os.should eq(3_u8)
       header.extra.should eq(Bytes[1, 2, 3, 4, 5])

--- a/spec/std/compress/zip/zip_spec.cr
+++ b/spec/std/compress/zip/zip_spec.cr
@@ -13,7 +13,7 @@ describe Compress::Zip do
     io.rewind
 
     Compress::Zip::Reader.open(io) do |zip|
-      entry = zip.next_entry.not_nil!
+      entry = zip.next_entry.should_not(be_nil)
       entry.file?.should be_true
       entry.dir?.should be_false
       entry.filename.should eq("foo.txt")
@@ -24,7 +24,7 @@ describe Compress::Zip do
       entry.extra.should be_empty
       entry.io.gets_to_end.should eq("contents of foo")
 
-      entry = zip.next_entry.not_nil!
+      entry = zip.next_entry.should_not(be_nil)
       entry.filename.should eq("bar.txt")
       entry.io.gets_to_end.should eq("contents of bar")
 
@@ -47,7 +47,7 @@ describe Compress::Zip do
     io.rewind
 
     Compress::Zip::Reader.open(io) do |zip|
-      entry = zip.next_entry.not_nil!
+      entry = zip.next_entry.should_not(be_nil)
       entry.filename.should eq("foo.txt")
       entry.time.should eq(time)
       entry.extra.should eq(extra)
@@ -80,7 +80,7 @@ describe Compress::Zip do
     io.rewind
 
     Compress::Zip::Reader.open(io) do |zip|
-      entry = zip.next_entry.not_nil!
+      entry = zip.next_entry.should_not(be_nil)
       entry.filename.should eq("foo.txt")
       entry.compression_method.should eq(Compress::Zip::CompressionMethod::STORED)
       entry.crc32.should eq(crc32)
@@ -88,7 +88,7 @@ describe Compress::Zip do
       entry.uncompressed_size.should eq(text.bytesize)
       entry.io.gets_to_end.should eq(text)
 
-      entry = zip.next_entry.not_nil!
+      entry = zip.next_entry.should_not(be_nil)
       entry.filename.should eq("bar.txt")
       entry.io.gets_to_end.should eq(text)
     end
@@ -130,13 +130,13 @@ describe Compress::Zip do
     io.rewind
 
     Compress::Zip::Reader.open(io) do |zip|
-      entry = zip.next_entry.not_nil!
+      entry = zip.next_entry.should_not(be_nil)
       entry.filename.should eq("one/")
       entry.file?.should be_false
       entry.dir?.should be_true
       entry.io.gets_to_end.should eq("")
 
-      entry = zip.next_entry.not_nil!
+      entry = zip.next_entry.should_not(be_nil)
       entry.filename.should eq("two/")
       entry.dir?.should be_true
       entry.io.gets_to_end.should eq("")
@@ -153,7 +153,7 @@ describe Compress::Zip do
     io.rewind
 
     Compress::Zip::Reader.open(io) do |zip|
-      entry = zip.next_entry.not_nil!
+      entry = zip.next_entry.should_not(be_nil)
       entry.filename.should eq("foo.txt")
       entry.io.gets_to_end.should eq("contents of foo")
     end
@@ -169,7 +169,7 @@ describe Compress::Zip do
     io.rewind
 
     Compress::Zip::Reader.open(io) do |zip|
-      entry = zip.next_entry.not_nil!
+      entry = zip.next_entry.should_not(be_nil)
       entry.filename.should eq("foo.txt")
       entry.io.gets_to_end.should eq("contents of foo")
     end
@@ -186,7 +186,7 @@ describe Compress::Zip do
     io.rewind
 
     Compress::Zip::Reader.open(io) do |zip|
-      entry = zip.next_entry.not_nil!
+      entry = zip.next_entry.should_not(be_nil)
       entry.filename.should eq("foo.txt")
       entry.io.gets_to_end.should eq("contents of foo")
     end
@@ -205,7 +205,7 @@ describe Compress::Zip do
     io.rewind
 
     Compress::Zip::Reader.open(io) do |zip|
-      entry = zip.next_entry.not_nil!
+      entry = zip.next_entry.should_not(be_nil)
       entry.filename.should eq("foo.txt")
       entry.io.gets_to_end.should eq(File.read(filename))
     end

--- a/spec/std/crystal/event_loop/polling/arena_spec.cr
+++ b/spec/std/crystal/event_loop/polling/arena_spec.cr
@@ -122,7 +122,7 @@ describe Crystal::EventLoop::Polling::Arena do
       2.times do
         ret = arena.get?(index) do |ptr|
           ptr.should eq(pointer)
-          ptr.not_nil!.value.should eq(654321)
+          ptr.should_not(be_nil).value.should eq(654321)
           called += 1
         end
         ret.should be_true

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -444,7 +444,7 @@ describe "Dir" do
     it "root pattern" do
       {% if flag?(:windows) %}
         Dir["C:/"].should eq ["C:\\"]
-        Dir["/"].should eq [Path[Dir.current].anchor.not_nil!.to_s]
+        Dir["/"].should eq [Path[Dir.current].anchor.should_not(be_nil).to_s]
       {% else %}
         Dir["/"].should eq ["/"]
       {% end %}

--- a/spec/std/file/tempfile_spec.cr
+++ b/spec/std/file/tempfile_spec.cr
@@ -146,7 +146,7 @@ describe File do
         tempfile.path.should eq filepath
         tempfile.closed?.should be_true
 
-        filepath = filepath.not_nil!
+        filepath = filepath.should_not(be_nil)
         File.exists?(filepath).should be_true
       ensure
         File.delete(filepath) if filepath

--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -571,7 +571,7 @@ module HTTP
 
       it "sets future expiration_time with max-age" do
         cookie = parse_set_cookie("bla=1; max-age=1")
-        cookie.expiration_time.not_nil!.should be > Time.utc
+        cookie.expiration_time.should_not(be_nil).should be > Time.utc
       end
 
       it "sets future expiration_time with max-age and future cookie creation time" do

--- a/spec/std/http/cookies_spec.cr
+++ b/spec/std/http/cookies_spec.cr
@@ -149,7 +149,7 @@ module HTTP
       cookies << Cookie.new("not_the_key", "not_the_value")
       cookies << Cookie.new("a", "b")
       cookies.has_key?("the_key").should be_true
-      cookies.delete("the_key").not_nil!.value.should eq "the_value"
+      cookies.delete("the_key").should_not(be_nil).value.should eq "the_value"
       cookies.has_key?("the_key").should be_false
       cookies.size.should eq 2
     end

--- a/spec/std/http/http_spec.cr
+++ b/spec/std/http/http_spec.cr
@@ -36,13 +36,13 @@ describe HTTP do
 
     it "parses and is UTC (#2744)" do
       date = "Mon, 09 Sep 2011 23:36:00 GMT"
-      parsed_time = HTTP.parse_time(date).not_nil!
+      parsed_time = HTTP.parse_time(date).should_not(be_nil)
       parsed_time.utc?.should be_true
     end
 
     it "parses and is local (#2744)" do
       date = "Mon, 09 Sep 2011 23:36:00 -0300"
-      parsed_time = HTTP.parse_time(date).not_nil!
+      parsed_time = HTTP.parse_time(date).should_not(be_nil)
       parsed_time.offset.should eq -3 * 3600
       parsed_time.to_utc.to_s.should eq("2011-09-10 02:36:00 UTC")
     end

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -189,7 +189,7 @@ module HTTP
 
       it "headers are case insensitive" do
         request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).as(Request)
-        headers = request.headers.not_nil!
+        headers = request.headers.should_not(be_nil)
         headers["HOST"].should eq("host.example.org")
         headers["host"].should eq("host.example.org")
         headers["Host"].should eq("host.example.org")
@@ -200,7 +200,7 @@ module HTTP
         request.method.should eq("POST")
         request.path.should eq("/foo")
         request.headers.should eq(HTTP::Headers{"Content-Length" => "13"})
-        request.body.not_nil!.gets_to_end.should eq("thisisthebody")
+        request.body.should_not(be_nil).gets_to_end.should eq("thisisthebody")
       end
 
       it "handles malformed request" do

--- a/spec/std/http/server/handlers/static_file_handler_spec.cr
+++ b/spec/std/http/server/handlers/static_file_handler_spec.cr
@@ -63,7 +63,7 @@ describe HTTP::StaticFileHandler do
 
     it "returns 304 Not Modified for younger than Last-Modified" do
       initial_response = handle HTTP::Request.new("GET", "/test.txt")
-      last_modified = HTTP.parse_time(initial_response.headers["Last-Modified"]).not_nil!
+      last_modified = HTTP.parse_time(initial_response.headers["Last-Modified"]).should_not(be_nil)
 
       headers = HTTP::Headers.new
       headers["If-Modified-Since"] = HTTP.format_time(last_modified + 1.hour)
@@ -76,7 +76,7 @@ describe HTTP::StaticFileHandler do
 
     it "serves content for older than Last-Modified" do
       initial_response = handle HTTP::Request.new("GET", "/test.txt")
-      last_modified = HTTP.parse_time(initial_response.headers["Last-Modified"]).not_nil!
+      last_modified = HTTP.parse_time(initial_response.headers["Last-Modified"]).should_not(be_nil)
 
       headers = HTTP::Headers.new
       headers["If-Modified-Since"] = HTTP.format_time(last_modified - 1.hour)

--- a/spec/std/http/server/request_processor_spec.cr
+++ b/spec/std/http/server/request_processor_spec.cr
@@ -33,7 +33,7 @@ describe HTTP::Server::RequestProcessor do
     it "when body is consumed" do
       processor = HTTP::Server::RequestProcessor.new do |context|
         context.response.content_type = "text/plain"
-        context.response << context.request.body.not_nil!.gets(chomp: true)
+        context.response << context.request.body.should_not(be_nil).gets(chomp: true)
         context.response << "\r\n"
       end
 
@@ -199,7 +199,7 @@ describe HTTP::Server::RequestProcessor do
 
     it "continues when request body is entirely consumed" do
       processor = HTTP::Server::RequestProcessor.new do |context|
-        io = context.request.body.not_nil!
+        io = context.request.body.should_not(be_nil)
         io.gets_to_end
       end
 

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -111,7 +111,7 @@ describe HTTP::Server do
 
   it "handles Expect: 100-continue correctly when body is read" do
     server = HTTP::Server.new do |context|
-      context.response << context.request.body.not_nil!.gets_to_end
+      context.response << context.request.body.should_not(be_nil).gets_to_end
     end
 
     address = server.bind_unused_port

--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -384,7 +384,7 @@ describe HTTP::WebSocket do
           end
 
           ws.on_close do |code, message|
-            http_ref.not_nil!.close
+            http_ref.should_not(be_nil).close
             close_chan.send({code.to_i, message})
           end
         end
@@ -430,7 +430,7 @@ describe HTTP::WebSocket do
           end
 
           ws.on_close do
-            http_ref.not_nil!.close
+            http_ref.should_not(be_nil).close
           end
         end
 

--- a/spec/std/io/stapled_spec.cr
+++ b/spec/std/io/stapled_spec.cr
@@ -121,8 +121,8 @@ describe IO::Stapled do
         a.sync_close = false
         b.sync_close = false
       end
-      ext_a.not_nil!.closed?.should be_true
-      ext_b.not_nil!.closed?.should be_true
+      ext_a.should_not(be_nil).closed?.should be_true
+      ext_b.should_not(be_nil).closed?.should be_true
     end
   end
 end

--- a/spec/std/json/any_spec.cr
+++ b/spec/std/json/any_spec.cr
@@ -116,13 +116,13 @@ describe JSON::Any do
 
   describe "#[]?" do
     it "of array" do
-      JSON.parse("[1, 2, 3]")[1]?.not_nil!.raw.should eq(2)
+      JSON.parse("[1, 2, 3]")[1]?.should_not(be_nil).raw.should eq(2)
       JSON.parse("[1, 2, 3]")[3]?.should be_nil
       JSON.parse("[true, false]")[1]?.should be_false
     end
 
     it "of hash" do
-      JSON.parse(%({"foo": "bar"}))["foo"]?.not_nil!.raw.should eq("bar")
+      JSON.parse(%({"foo": "bar"}))["foo"]?.should_not(be_nil).raw.should eq("bar")
       JSON.parse(%({"foo": "bar"}))["fox"]?.should be_nil
       JSON.parse(%q<{"foo": false}>)["foo"]?.should be_false
     end

--- a/spec/std/oauth2/access_token_spec.cr
+++ b/spec/std/oauth2/access_token_spec.cr
@@ -65,7 +65,7 @@ class OAuth2::AccessToken
         "scope" : "baz",
         "unknown": [1, 2, 3]
         }))
-      token.extra.not_nil!["unknown"].should eq("[1,2,3]")
+      token.extra.should_not(be_nil)["unknown"].should eq("[1,2,3]")
     end
 
     it "builds from json without token_type, assumes Bearer (#4503)" do

--- a/spec/std/oauth2/client_spec.cr
+++ b/spec/std/oauth2/client_spec.cr
@@ -45,7 +45,7 @@ describe OAuth2::Client do
       describe "#get_access_token_using_authorization_code" do
         it "gets a valid token successfully" do
           handler = HTTP::Handler::HandlerProc.new do |context|
-            body = context.request.body.not_nil!.gets_to_end
+            body = context.request.body.should_not(be_nil).gets_to_end
             response = {access_token: "access_token", body: body}
             context.response.print response.to_json
           end
@@ -55,7 +55,7 @@ describe OAuth2::Client do
             client.http_client = http_client
 
             token = client.get_access_token_using_authorization_code(authorization_code: "SDFhw39fwfg23flSfpawbef")
-            token.extra.not_nil!["body"].should eq %("redirect_uri=&grant_type=authorization_code&code=SDFhw39fwfg23flSfpawbef")
+            token.extra.should_not(be_nil)["body"].should eq %("redirect_uri=&grant_type=authorization_code&code=SDFhw39fwfg23flSfpawbef")
             token.access_token.should eq "access_token"
           end
         end
@@ -93,7 +93,7 @@ describe OAuth2::Client do
 
       it "configures HTTP::Client" do
         server = HTTP::Server.new do |context|
-          body = context.request.body.not_nil!.gets_to_end
+          body = context.request.body.should_not(be_nil).gets_to_end
           response = {access_token: "access_token", body: body}
           context.response.print response.to_json
         end
@@ -105,14 +105,14 @@ describe OAuth2::Client do
           client.http_client.host.should eq "127.0.0.1"
 
           token = client.get_access_token_using_authorization_code(authorization_code: "SDFhw39fwfg23flSfpawbef")
-          token.extra.not_nil!["body"].should eq %("redirect_uri=&grant_type=authorization_code&code=SDFhw39fwfg23flSfpawbef")
+          token.extra.should_not(be_nil)["body"].should eq %("redirect_uri=&grant_type=authorization_code&code=SDFhw39fwfg23flSfpawbef")
           token.access_token.should eq "access_token"
         end
       end
 
       it "#get_access_token_using_resource_owner_credentials" do
         handler = HTTP::Handler::HandlerProc.new do |context|
-          body = context.request.body.not_nil!.gets_to_end
+          body = context.request.body.should_not(be_nil).gets_to_end
           response = {access_token: "access_token", body: body}
           context.response.print response.to_json
         end
@@ -122,14 +122,14 @@ describe OAuth2::Client do
           client.http_client = http_client
 
           token = client.get_access_token_using_resource_owner_credentials(username: "user123", password: "monkey", scope: "read_posts")
-          token.extra.not_nil!["body"].should eq %("grant_type=password&username=user123&password=monkey&scope=read_posts")
+          token.extra.should_not(be_nil)["body"].should eq %("grant_type=password&username=user123&password=monkey&scope=read_posts")
           token.access_token.should eq "access_token"
         end
       end
 
       it "#get_access_token_using_client_credentials" do
         handler = HTTP::Handler::HandlerProc.new do |context|
-          body = context.request.body.not_nil!.gets_to_end
+          body = context.request.body.should_not(be_nil).gets_to_end
           response = {access_token: "access_token", body: body}
           context.response.print response.to_json
         end
@@ -139,14 +139,14 @@ describe OAuth2::Client do
           client.http_client = http_client
 
           token = client.get_access_token_using_client_credentials(scope: "read_posts")
-          token.extra.not_nil!["body"].should eq %("grant_type=client_credentials&scope=read_posts")
+          token.extra.should_not(be_nil)["body"].should eq %("grant_type=client_credentials&scope=read_posts")
           token.access_token.should eq "access_token"
         end
       end
 
       it "#get_access_token_using_refresh_token" do
         handler = HTTP::Handler::HandlerProc.new do |context|
-          body = context.request.body.not_nil!.gets_to_end
+          body = context.request.body.should_not(be_nil).gets_to_end
           response = {access_token: "access_token", body: body}
           context.response.print response.to_json
         end
@@ -156,14 +156,14 @@ describe OAuth2::Client do
           client.http_client = http_client
 
           token = client.get_access_token_using_refresh_token(scope: "read_posts", refresh_token: "some_refresh_token")
-          token.extra.not_nil!["body"].should eq %("grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts")
+          token.extra.should_not(be_nil)["body"].should eq %("grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts")
           token.access_token.should eq "access_token"
         end
       end
 
       it "#make_token_request" do
         handler = HTTP::Handler::HandlerProc.new do |context|
-          body = context.request.body.not_nil!.gets_to_end
+          body = context.request.body.should_not(be_nil).gets_to_end
           dpop = context.request.headers.get?("DPoP")
           response = {access_token: "access_token", body: body, dpop: dpop}
           context.response.print response.to_json
@@ -183,8 +183,8 @@ describe OAuth2::Client do
           end
           token_response.status_code.should eq(200)
           token = OAuth2::AccessToken.from_json(token_response.body)
-          token.extra.not_nil!["body"].should eq %("redirect_uri=&grant_type=authorization_code&code=some_authorization_code&code_verifier=a_code_verifier&nonce=a_nonce")
-          token.extra.not_nil!["dpop"].should eq %(["a_DPoP_jwt_token"])
+          token.extra.should_not(be_nil)["body"].should eq %("redirect_uri=&grant_type=authorization_code&code=some_authorization_code&code_verifier=a_code_verifier&nonce=a_nonce")
+          token.extra.should_not(be_nil)["dpop"].should eq %(["a_DPoP_jwt_token"])
           token.access_token.should eq "access_token"
         end
       end
@@ -192,7 +192,7 @@ describe OAuth2::Client do
     describe "using Request Body to pass credentials" do
       it "#get_access_token_using_authorization_code" do
         handler = HTTP::Handler::HandlerProc.new do |context|
-          body = context.request.body.not_nil!.gets_to_end
+          body = context.request.body.should_not(be_nil).gets_to_end
           response = {access_token: "access_token", body: body}
           context.response.print response.to_json
         end
@@ -202,14 +202,14 @@ describe OAuth2::Client do
           client.http_client = http_client
 
           token = client.get_access_token_using_authorization_code(authorization_code: "SDFhw39fwfg23flSfpawbef")
-          token.extra.not_nil!["body"].should eq %("client_id=client_id&client_secret=client_secret&redirect_uri=&grant_type=authorization_code&code=SDFhw39fwfg23flSfpawbef")
+          token.extra.should_not(be_nil)["body"].should eq %("client_id=client_id&client_secret=client_secret&redirect_uri=&grant_type=authorization_code&code=SDFhw39fwfg23flSfpawbef")
           token.access_token.should eq "access_token"
         end
       end
 
       it "#get_access_token_using_resource_owner_credentials" do
         handler = HTTP::Handler::HandlerProc.new do |context|
-          body = context.request.body.not_nil!.gets_to_end
+          body = context.request.body.should_not(be_nil).gets_to_end
           response = {access_token: "access_token", body: body}
           context.response.print response.to_json
         end
@@ -219,14 +219,14 @@ describe OAuth2::Client do
           client.http_client = http_client
 
           token = client.get_access_token_using_resource_owner_credentials(username: "user123", password: "monkey", scope: "read_posts")
-          token.extra.not_nil!["body"].should eq %("client_id=client_id&client_secret=client_secret&grant_type=password&username=user123&password=monkey&scope=read_posts")
+          token.extra.should_not(be_nil)["body"].should eq %("client_id=client_id&client_secret=client_secret&grant_type=password&username=user123&password=monkey&scope=read_posts")
           token.access_token.should eq "access_token"
         end
       end
 
       it "#get_access_token_using_client_credentials" do
         handler = HTTP::Handler::HandlerProc.new do |context|
-          body = context.request.body.not_nil!.gets_to_end
+          body = context.request.body.should_not(be_nil).gets_to_end
           response = {access_token: "access_token", body: body}
           context.response.print response.to_json
         end
@@ -236,14 +236,14 @@ describe OAuth2::Client do
           client.http_client = http_client
 
           token = client.get_access_token_using_client_credentials(scope: "read_posts")
-          token.extra.not_nil!["body"].should eq %("client_id=client_id&client_secret=client_secret&grant_type=client_credentials&scope=read_posts")
+          token.extra.should_not(be_nil)["body"].should eq %("client_id=client_id&client_secret=client_secret&grant_type=client_credentials&scope=read_posts")
           token.access_token.should eq "access_token"
         end
       end
 
       it "#get_access_token_using_refresh_token" do
         handler = HTTP::Handler::HandlerProc.new do |context|
-          body = context.request.body.not_nil!.gets_to_end
+          body = context.request.body.should_not(be_nil).gets_to_end
           response = {access_token: "access_token", body: body}
           context.response.print response.to_json
         end
@@ -253,14 +253,14 @@ describe OAuth2::Client do
           client.http_client = http_client
 
           token = client.get_access_token_using_refresh_token(scope: "read_posts", refresh_token: "some_refresh_token")
-          token.extra.not_nil!["body"].should eq %("client_id=client_id&client_secret=client_secret&grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts")
+          token.extra.should_not(be_nil)["body"].should eq %("client_id=client_id&client_secret=client_secret&grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts")
           token.access_token.should eq "access_token"
         end
       end
 
       it "#make_token_request" do
         handler = HTTP::Handler::HandlerProc.new do |context|
-          body = context.request.body.not_nil!.gets_to_end
+          body = context.request.body.should_not(be_nil).gets_to_end
           dpop = context.request.headers.get?("DPoP")
           response = {access_token: "access_token", body: body, dpop: dpop}
           context.response.print response.to_json
@@ -279,8 +279,8 @@ describe OAuth2::Client do
           end
           token_response.status_code.should eq(200)
           token = OAuth2::AccessToken.from_json(token_response.body)
-          token.extra.not_nil!["body"].should eq %("client_id=client_id&client_secret=client_secret&grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts&nonce=a_nonce")
-          token.extra.not_nil!["dpop"].should eq %(["a_DPoP_jwt_token"])
+          token.extra.should_not(be_nil)["body"].should eq %("client_id=client_id&client_secret=client_secret&grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts&nonce=a_nonce")
+          token.extra.should_not(be_nil)["dpop"].should eq %(["a_DPoP_jwt_token"])
           token.access_token.should eq "access_token"
         end
       end

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -163,13 +163,13 @@ describe "Range" do
 
     it "Float" do
       inf = Float64::INFINITY
-      (0.0...100.0).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.not_nil!.should be_close(10.0, 0.0001)
-      (0.0...inf).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.not_nil!.should be_close(10.0, 0.0001)
-      (-inf..100.0).bsearch { |x| x >= 0 || Math.log(-x / 10) < 0 }.not_nil!.should be_close(-10.0, 0.0001)
-      (-inf..inf).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.not_nil!.should be_close(10.0, 0.0001)
+      (0.0...100.0).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.should_not(be_nil).should be_close(10.0, 0.0001)
+      (0.0...inf).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.should_not(be_nil).should be_close(10.0, 0.0001)
+      (-inf..100.0).bsearch { |x| x >= 0 || Math.log(-x / 10) < 0 }.should_not(be_nil).should be_close(-10.0, 0.0001)
+      (-inf..inf).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.should_not(be_nil).should be_close(10.0, 0.0001)
       (-inf..5).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.should be_nil
 
-      (-inf..10).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.not_nil!.should be_close(10.0, 0.0001)
+      (-inf..10).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.should_not(be_nil).should be_close(10.0, 0.0001)
       (inf...10).bsearch { |x| x > 0 && Math.log(x / 10) >= 0 }.should be_nil
 
       (-inf..inf).bsearch { false }.should be_nil
@@ -178,22 +178,22 @@ describe "Range" do
       (0..inf).bsearch { |x| x == inf }.should eq inf
       (0...inf).bsearch { |x| x == inf }.should be_nil
 
-      v = (0.0..1.0).bsearch { |x| x > 0 }.not_nil!
+      v = (0.0..1.0).bsearch { |x| x > 0 }.should_not(be_nil)
       v.should be_close(0, 0.0001)
       v.should be > 0
 
       (-1.0..0.0).bsearch { |x| x >= 0 }.should eq 0.0
       (-1.0...0.0).bsearch { |x| x >= 0 }.should be_nil
 
-      (0.0..inf).bsearch { |x| Math.log(x) >= 0 }.not_nil!.should be_close(1.0, 0.0001)
+      (0.0..inf).bsearch { |x| Math.log(x) >= 0 }.should_not(be_nil).should be_close(1.0, 0.0001)
 
-      (0.0..10).bsearch { |x| x >= 3.5 }.not_nil!.should be_close(3.5, 0.0001)
-      (0..10.0).bsearch { |x| x >= 3.5 }.not_nil!.should be_close(3.5, 0.0001)
+      (0.0..10).bsearch { |x| x >= 3.5 }.should_not(be_nil).should be_close(3.5, 0.0001)
+      (0..10.0).bsearch { |x| x >= 3.5 }.should_not(be_nil).should be_close(3.5, 0.0001)
 
-      (0_f32..5_f32).bsearch { |x| x >= 5_f32 }.not_nil!.should be_close(5_f32, 0.0001_f32)
+      (0_f32..5_f32).bsearch { |x| x >= 5_f32 }.should_not(be_nil).should be_close(5_f32, 0.0001_f32)
       (0_f32...5_f32).bsearch { |x| x >= 5_f32 }.should be_nil
-      (0_f32..5.0).bsearch { |x| x >= 5.0 }.not_nil!.should be_close(5.0, 0.0001)
-      (0..5.0_f32).bsearch { |x| x >= 5.0 }.not_nil!.should be_close(5.0, 0.0001)
+      (0_f32..5.0).bsearch { |x| x >= 5.0 }.should_not(be_nil).should be_close(5.0, 0.0001)
+      (0..5.0_f32).bsearch { |x| x >= 5.0 }.should_not(be_nil).should be_close(5.0, 0.0001)
 
       inf32 = Float32::INFINITY
       (0..inf32).bsearch { |x| x == inf32 }.should eq inf32

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2468,19 +2468,19 @@ describe "String" do
 
   it "#match_full" do
     pending! if {{ Regex::Engine.resolve.name == "Regex::PCRE" }}
-    "foo".match_full(/foo/).not_nil![0].should eq "foo"
+    "foo".match_full(/foo/).should_not(be_nil)[0].should eq "foo"
     "fooo".match_full(/foo/).should be_nil
     "ofoo".match_full(/foo/).should be_nil
-    "pattern".match_full(/(\A)?pattern(\z)?/).not_nil![0].should eq "pattern"
+    "pattern".match_full(/(\A)?pattern(\z)?/).should_not(be_nil)[0].should eq "pattern"
     "_pattern_".match_full(/(\A)?pattern(\z)?/).should be_nil
   end
 
   it "#match_full!" do
     pending! if {{ Regex::Engine.resolve.name == "Regex::PCRE" }}
-    "foo".match_full!(/foo/).not_nil![0].should eq "foo"
+    "foo".match_full!(/foo/).should_not(be_nil)[0].should eq "foo"
     expect_raises(Regex::Error) { "fooo".match_full!(/foo/) }
     expect_raises(Regex::Error) { "ofoo".match_full!(/foo/) }
-    "pattern".match_full!(/(\A)?pattern(\z)?/).not_nil![0].should eq "pattern"
+    "pattern".match_full!(/(\A)?pattern(\z)?/).should_not(be_nil)[0].should eq "pattern"
     expect_raises(Regex::Error) { "_pattern_".match_full!(/(\A)?pattern(\z)?/) }
   end
 

--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -157,7 +157,7 @@ class Time::Location
         it "loads from custom zipfile" do
           with_zoneinfo(ZONEINFO_ZIP) do
             location = Location.load("Asia/Jerusalem")
-            location.not_nil!.name.should eq "Asia/Jerusalem"
+            location.should_not(be_nil).name.should eq "Asia/Jerusalem"
           end
         end
 

--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -19,7 +19,7 @@ describe XML do
     doc.attributes.should be_empty
     doc.namespace.should be_nil
 
-    people = doc.root.not_nil!
+    people = doc.root.should_not(be_nil)
     people.name.should eq("people")
     people.type.should eq(XML::Node::Type::ELEMENT_NODE)
 
@@ -136,14 +136,14 @@ describe XML do
       XML
     )
 
-    people = doc.first_element_child.not_nil!
+    people = doc.first_element_child.should_not(be_nil)
     people.name.should eq("people")
 
-    person = people.first_element_child.not_nil!
+    person = people.first_element_child.should_not(be_nil)
     person.name.should eq("person")
     person["id"].should eq("1")
 
-    text = person.next.not_nil!
+    text = person.next.should_not(be_nil)
     text.content.should eq("\n  ")
 
     text.previous.should eq(person)
@@ -151,7 +151,7 @@ describe XML do
 
     person.next_sibling.should eq(text)
 
-    person2 = text.next.not_nil!
+    person2 = text.next.should_not(be_nil)
     person2.name.should eq("person")
     person2["id"].should eq("2")
 
@@ -164,7 +164,7 @@ describe XML do
       options = XML::ParserOptions::RECOVER | XML::ParserOptions::NONET
 
       xml = XML.parse(%(<people></foo>), options)
-      xml.root.not_nil!.name.should eq("people")
+      xml.root.should_not(be_nil).name.should eq("people")
       xml.errors.try(&.map(&.to_s)).should eq ["Opening and ending tag mismatch: people line 1 and foo"]
 
       xml = XML.parse(%(<foo></foo>))
@@ -199,7 +199,7 @@ describe XML do
             <openSearch:feed xmlns:foo="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/"></feed>
             XML
 
-          namespace = doc.root.not_nil!.namespace.should be_a XML::Namespace
+          namespace = doc.root.should_not(be_nil).namespace.should be_a XML::Namespace
           namespace.href.should eq "http://a9.com/-/spec/opensearchrss/1.0/"
           namespace.prefix.should eq "openSearch"
         end
@@ -212,7 +212,7 @@ describe XML do
             <feed xmlns:foo="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearchrss/1.0/"></feed>
             XML
 
-          namespace = doc.root.not_nil!.namespace.should be_a XML::Namespace
+          namespace = doc.root.should_not(be_nil).namespace.should be_a XML::Namespace
           namespace.href.should eq "http://a9.com/-/spec/opensearchrss/1.0/"
           namespace.prefix.should be_nil
         end
@@ -228,7 +228,7 @@ describe XML do
             </feed>
             XML
 
-          root = doc.root.not_nil!
+          root = doc.root.should_not(be_nil)
 
           namespace = root.children[1].namespace.should be_a XML::Namespace
           namespace.href.should eq "http://www.w3.org/2005/Atom"
@@ -248,7 +248,7 @@ describe XML do
           <feed></feed>
           XML
 
-        doc.root.not_nil!.namespace.should be_nil
+        doc.root.should_not(be_nil).namespace.should be_nil
       end
     end
 
@@ -259,7 +259,7 @@ describe XML do
           <feed xmlns:foo="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/"></feed>
           XML
 
-        doc.root.not_nil!.namespace.should be_nil
+        doc.root.should_not(be_nil).namespace.should be_nil
       end
     end
   end
@@ -273,7 +273,7 @@ describe XML do
         </feed>
         XML
 
-      namespaces = doc.root.not_nil!.first_element_child.not_nil!.namespace_definitions
+      namespaces = doc.root.should_not(be_nil).first_element_child.should_not(be_nil).namespace_definitions
 
       namespaces.size.should eq(1)
       namespaces[0].href.should eq("http://c")
@@ -288,7 +288,7 @@ describe XML do
         </feed>
         XML
 
-      doc.root.not_nil!.first_element_child.not_nil!.namespace_definitions.should be_empty
+      doc.root.should_not(be_nil).first_element_child.should_not(be_nil).namespace_definitions.should be_empty
     end
   end
 
@@ -300,7 +300,7 @@ describe XML do
         </feed>
         XML
 
-      namespaces = doc.root.not_nil!.namespace_scopes
+      namespaces = doc.root.should_not(be_nil).namespace_scopes
 
       namespaces.size.should eq(2)
       namespaces[0].href.should eq("http://www.w3.org/2005/Atom")
@@ -315,7 +315,7 @@ describe XML do
         <name>John</name>
         XML
 
-      namespaces = doc.root.not_nil!.namespace_scopes
+      namespaces = doc.root.should_not(be_nil).namespace_scopes
 
       namespaces.size.should eq(0)
     end
@@ -328,7 +328,7 @@ describe XML do
         </feed>
         XML
 
-      namespaces = doc.root.not_nil!.first_element_child.not_nil!.namespace_scopes
+      namespaces = doc.root.should_not(be_nil).first_element_child.should_not(be_nil).namespace_scopes
 
       namespaces.size.should eq(3)
       namespaces[0].href.should eq("http://c")
@@ -348,7 +348,7 @@ describe XML do
         </feed>
         XML
 
-      namespaces = doc.root.not_nil!.namespaces
+      namespaces = doc.root.should_not(be_nil).namespaces
       namespaces.should eq({
         "xmlns"            => "http://www.w3.org/2005/Atom",
         "xmlns:openSearch" => "http://a9.com/-/spec/opensearchrss/1.0/",
@@ -363,7 +363,7 @@ describe XML do
         </feed>
         XML
 
-      namespaces = doc.root.not_nil!.first_element_child.not_nil!.namespaces
+      namespaces = doc.root.should_not(be_nil).first_element_child.should_not(be_nil).namespaces
       namespaces.should eq({
         "xmlns:c"          => "http://c",
         "xmlns"            => "http://www.w3.org/2005/Atom",
@@ -379,7 +379,7 @@ describe XML do
         </feed>
         XML
 
-      namespaces = doc.root.not_nil!.first_element_child.not_nil!.namespaces
+      namespaces = doc.root.should_not(be_nil).first_element_child.should_not(be_nil).namespaces
       namespaces.should eq({} of String => String?)
     end
   end
@@ -388,7 +388,7 @@ describe XML do
     content = "." * 20_000
     string = %(<?xml version="1.0"?><root>#{content}</root>)
     parsed = XML.parse(IO::Memory.new(string))
-    parsed.root.not_nil!.children[0].text.should eq(content)
+    parsed.root.should_not(be_nil).children[0].text.should eq(content)
   end
 
   it "sets node text/content" do
@@ -397,7 +397,7 @@ describe XML do
       <name>John</name>
       XML
 
-    root = doc.root.not_nil!
+    root = doc.root.should_not(be_nil)
     root.text = "Peter"
     root.text.should eq("Peter")
 
@@ -411,7 +411,7 @@ describe XML do
       <name>John</name>
       XML
 
-    root = doc.root.not_nil!
+    root = doc.root.should_not(be_nil)
     expect_raises(Exception, "Cannot escape") do
       root.content = "\0"
     end
@@ -423,7 +423,7 @@ describe XML do
       <name>John</name>
       XML
 
-    root = doc.root.not_nil!
+    root = doc.root.should_not(be_nil)
     root.text = "<foo>"
     root.text.should eq("<foo>")
 
@@ -485,7 +485,7 @@ describe XML do
       <name>John</name>
       XML
     )
-    root = doc.root.not_nil!
+    root = doc.root.should_not(be_nil)
     root.name = "last-name"
     root.name.should eq("last-name")
   end
@@ -496,7 +496,7 @@ describe XML do
       <name>John</name>
       XML
     )
-    root = doc.root.not_nil!
+    root = doc.root.should_not(be_nil)
 
     expect_raises(XML::Error, "Invalid node name") do
       root.name = " foo bar"
@@ -554,7 +554,7 @@ describe XML do
         XML
     document = XML.parse(xml)
 
-    node = document.xpath_node("//lastname").not_nil!
+    node = document.xpath_node("//lastname").should_not(be_nil)
     node.unlink
 
     document.xpath_node("//lastname").should be_nil
@@ -574,7 +574,7 @@ describe XML do
 
   it "sets an attribute" do
     doc = XML.parse(%{<foo />})
-    root = doc.root.not_nil!
+    root = doc.root.should_not(be_nil)
 
     root["bar"] = "baz"
     root["bar"].should eq("baz")
@@ -583,7 +583,7 @@ describe XML do
 
   it "changes an attribute" do
     doc = XML.parse(%{<foo bar="baz"></foo>})
-    root = doc.root.not_nil!
+    root = doc.root.should_not(be_nil)
 
     root["bar"] = "baz"
     root["bar"].should eq("baz")
@@ -595,7 +595,7 @@ describe XML do
 
   it "deletes an attribute" do
     doc = XML.parse(%{<foo bar="baz"></foo>})
-    root = doc.root.not_nil!
+    root = doc.root.should_not(be_nil)
 
     res = root.delete("bar")
     root["bar"]?.should be_nil
@@ -608,7 +608,7 @@ describe XML do
 
   it "shows content when inspecting attribute" do
     doc = XML.parse(%{<foo bar="baz"></foo>})
-    attr = doc.root.not_nil!.attributes.first
+    attr = doc.root.should_not(be_nil).attributes.first
     attr.inspect.should contain(%(content="baz"))
   end
 

--- a/spec/std/xml/xpath_spec.cr
+++ b/spec/std/xml/xpath_spec.cr
@@ -89,7 +89,7 @@ module XML
       nodes = doc.xpath("//atom:feed", namespaces: {"atom" => "http://www.w3.org/2005/Atom"}).as(NodeSet)
       nodes.size.should eq(1)
       nodes[0].name.should eq("feed")
-      ns = nodes[0].namespace.not_nil!
+      ns = nodes[0].namespace.should_not(be_nil)
       ns.href.should eq("http://www.w3.org/2005/Atom")
       ns.prefix.should be_nil
     end
@@ -105,7 +105,7 @@ module XML
       nodes = doc.xpath("//openSearch:feed/openSearch:something").as(NodeSet)
       nodes.size.should eq(1)
       nodes[0].name.should eq("something")
-      ns = nodes[0].namespace.not_nil!
+      ns = nodes[0].namespace.should_not(be_nil)
       ns.href.should eq("http://a9.com/-/spec/opensearchrss/1.0/")
       ns.prefix.should eq("openSearch")
     end
@@ -116,10 +116,10 @@ module XML
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
         </feed>
         ))
-      nodes = doc.xpath("//xmlns:feed", namespaces: doc.root.not_nil!.namespaces).as(NodeSet)
+      nodes = doc.xpath("//xmlns:feed", namespaces: doc.root.should_not(be_nil).namespaces).as(NodeSet)
       nodes.size.should eq(1)
       nodes[0].name.should eq("feed")
-      ns = nodes[0].namespace.not_nil!
+      ns = nodes[0].namespace.should_not(be_nil)
       ns.href.should eq("http://www.w3.org/2005/Atom")
       ns.prefix.should be_nil
     end
@@ -130,10 +130,10 @@ module XML
         <openSearch:feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
         </openSearch:feed>
         ))
-      nodes = doc.xpath("//openSearch:feed", namespaces: doc.root.not_nil!.namespaces).as(NodeSet)
+      nodes = doc.xpath("//openSearch:feed", namespaces: doc.root.should_not(be_nil).namespaces).as(NodeSet)
       nodes.size.should eq(1)
       nodes[0].name.should eq("feed")
-      ns = nodes[0].namespace.not_nil!
+      ns = nodes[0].namespace.should_not(be_nil)
       ns.href.should eq("http://a9.com/-/spec/opensearchrss/1.0/")
       ns.prefix.should eq("openSearch")
     end
@@ -196,7 +196,7 @@ module XML
           <person id="2"/>
         </feed>
         ))
-      node = doc.xpath_node("//feed/person[@id=$value]", variables: {"value" => 2}).not_nil!
+      node = doc.xpath_node("//feed/person[@id=$value]", variables: {"value" => 2}).should_not(be_nil)
       node["id"].should eq("2")
     end
 

--- a/spec/std/yaml/any_spec.cr
+++ b/spec/std/yaml/any_spec.cr
@@ -374,7 +374,7 @@ describe YAML::Any do
 
   describe "#[]?" do
     it "of array" do
-      YAML.parse("- foo\n- bar\n")[1]?.not_nil!.raw.should eq("bar")
+      YAML.parse("- foo\n- bar\n")[1]?.should_not(be_nil).raw.should eq("bar")
       YAML.parse("- foo\n- bar\n")[3]?.should be_nil
 
       any = YAML::Any.new([YAML::Any.new("baz"), YAML::Any.new("bar")])
@@ -399,12 +399,12 @@ describe YAML::Any do
     end
 
     it "of hash" do
-      YAML.parse("foo: bar")["foo"]?.not_nil!.raw.should eq("bar")
+      YAML.parse("foo: bar")["foo"]?.should_not(be_nil).raw.should eq("bar")
       YAML.parse("foo: bar")["fox"]?.should be_nil
     end
 
     it "of hash with integer keys" do
-      YAML.parse("1: bar")[1]?.not_nil!.raw.should eq("bar")
+      YAML.parse("1: bar")[1]?.should_not(be_nil).raw.should eq("bar")
       YAML.parse("1: bar")[2]?.should be_nil
     end
 


### PR DESCRIPTION
In spec code, it's better to use `should_not(be_nil)` to clearly express a test expectation instead of a guaranteed invariant.