### PR TITLE
Reapply "Refactor `Formatter` code for simplification" (#16885) [fixup #16744]

### DIFF
--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1215,37 +1215,21 @@ module Crystal
           break
         end
 
-        accept type
-
-        last = last?(i, node.types)
-        if last
-          skip_space
-        else
+        unless i == 0
           skip_space_or_newline
-        end
+          write_token " ", :op_bar, " "
+          skip_space
 
-        while true
-          case @token.type
-          when .op_bar?
-            write " | "
-            next_token_skip_space
-            if @token.type.newline?
-              write_line
-              write_indent(column)
-              next_token_skip_space_or_newline
-            end
-          when .op_rparen?
-            if @paren_count > 0
-              @paren_count -= 1
-              write ")"
-              next_token_skip_space
-            else
-              break
-            end
-          else
-            break
+          if @token.type.newline?
+            write_line
+            write_indent(column)
+            next_token_skip_space_or_newline
           end
         end
+
+        accept type
+
+        skip_space
       end
 
       write_token :OP_RPAREN if node.parens?


### PR DESCRIPTION
This reverts commit f331cb18deb7e4463cb3796cb944e7434698c3e2.

The original refactor in https://github.com/crystal-lang/crystal/pull/16745 broke an unexpected use case and was subsequently reverted in https://github.com/crystal-lang/crystal/pull/16885.
With https://github.com/crystal-lang/crystal/pull/16744 merged, we can reapply the patch because this use case now takes a different path.

This is actually necessary to fix a regression introduced in https://github.com/crystal-lang/crystal/pull/16744, resulting from a merge conflict with https://github.com/crystal-lang/crystal/pull/16885.