### PR TITLE
[Backport release/1.20] Fix: `Range#sample` eventually loses randomness

### DIFF
--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -455,6 +455,25 @@ describe "Range" do
       (1..3).sample(0).empty?.should be_true
     end
 
+    describe "doesn't lose randomness when delegating to Enumerable#sample (#16480)" do
+      it do
+        results = Array(Int32).new(100) { (0..9.0).sample }
+        results[-10..].uniq!.size.should_not eq(1)
+      end
+
+      it do
+        results = Array(Array(Int32)).new
+        100.times { results << (0..9).sample(10) }
+        results[-10..].uniq!.size.should_not eq(1)
+      end
+
+      it do
+        results = Array(Array(Char)).new
+        100.times { results << ('0'..'9').sample(10) }
+        results[-10..].uniq!.size.should_not eq(1)
+      end
+    end
+
     context "for an integer range" do
       it "samples an inclusive range without n" do
         value = (1..3).sample

--- a/src/range.cr
+++ b/src/range.cr
@@ -361,7 +361,7 @@ struct Range(B, E)
 
       Range.new(b, e, @exclusive).sample(rng)
     {% else %}
-      super
+      super(rng)
     {% end %}
   end
 
@@ -398,7 +398,7 @@ struct Range(B, E)
       # faster to just traverse the entire range than hitting
       # a lot of duplicates because or random.
       if n >= available // 4
-        return super
+        return super(n, rng)
       end
 
       possible = Math.min(n, available)
@@ -431,7 +431,7 @@ struct Range(B, E)
       when 1
         [sample(rng)]
       else
-        super
+        super(n, rng)
       end
     {% end %}
   end


### PR DESCRIPTION
Backport of https://github.com/crystal-lang/crystal/pull/16853 to `release/1.20`

`Range#sample` defaults to the thread-local RNG and then also calls `Random.split_on_stack` in `Enumerable#sample` which exhausts randomness.