### PR TITLE
Fix auto-indentation in the REPL when typing classes.

### DIFF
--- a/src/compiler/crystal/interpreter/repl_reader.cr
+++ b/src/compiler/crystal/interpreter/repl_reader.cr
@@ -15,7 +15,7 @@ class Crystal::ReplReader < Reply::Reader
     "expecting identifier 'end', not 'EOF'",
     "expecting token 'CONST', not 'EOF'",
     "expecting any of these tokens: IDENT, CONST, `, <<, <, <=, ==, ===, !=, =~, !~, >>, >, >=, +, -, *, /, //, !, ~, %, &, |, ^, **, [], []?, []=, <=>, &+, &-, &*, &** (not 'EOF')",
-    "expecting any of these tokens: ;, NEWLINE (not 'EOF')",
+    "expecting any of these tokens: ;, NEWLINE, SPACE (not 'EOF')",
     "expecting token ')', not 'EOF'",
     "expecting token ']', not 'EOF'",
     "expecting token '}', not 'EOF'",


### PR DESCRIPTION
When typing `class Foo\n`, the REPL should decide whether to continue editing or submit. To do this, it tries to parse the input and decides based on the error raised. However, the error message for an incomplete class has changed. This PR updates the message expected.