### PR TITLE
Fix summary wrapping condition in OptionParser

### DIFF
--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -940,6 +940,30 @@ describe "OptionParser with summary_width and summary_indent" do
     output.should eq(expected_output)
   end
 
+  it "formats summary_width boundary cases" do
+    parser = OptionParser.new
+    parser.summary_width = 20
+    parser.summary_indent = " " * 4
+
+    parser.on("-c", "--complex-option", "desc") { }
+    parser.on("-d", "--extended-option", "desc") { }
+    parser.on("-e", "--val-option VAL", "desc") { }
+    parser.on("-f", "--value-opt VALUE", "desc") { }
+
+    output = parser.to_s
+
+    expected_output = <<-USAGE
+        -c, --complex-option desc
+        -d, --extended-option
+                             desc
+        -e, --val-option VAL desc
+        -f, --value-opt VALUE
+                             desc
+    USAGE
+
+    output.should eq(expected_output)
+  end
+
   it "handles extreme summary_width values (e.g., 0)" do
     parser = OptionParser.new
     parser.summary_width = 0

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -331,7 +331,7 @@ class OptionParser
     description_indent = "#{summary_indent}#{" " * summary_width} "
     description = description.gsub("\n", "\n#{description_indent}")
 
-    if flag.size >= summary_width
+    if flag.size > summary_width
       @flags << "#{summary_indent}#{flag}\n#{description_indent}#{description}"
     else
       @flags << "#{summary_indent}#{flag}#{" " * (summary_width - flag.size)} #{description}"


### PR DESCRIPTION
This is in preparation for https://github.com/crystal-lang/crystal/pull/16914
This pull request slightly relaxes the conditions under which option descriptions wrap to the next line.

```cr
require "option_parser"  # Crystal
# require "optparse"     # Ruby


parser = OptionParser.new
parser.summary_width = 20
parser.on("-c", "--complex-option", "This is a detailed description") {}
puts parser
```

Before

```console
    -c, --complex-option
                         This is a detailed description
```

After

```console
    -c, --complex-option This is a detailed description
```

The behavior of Ruby's OptionParser is the same.

```console
Usage: ruby_option_parser_width_boundary.rb [options]
    -c, --complex-option This is a detailed description
```