### PR TITLE
Fix macro argument errors for path receiver calls

### DIFF
--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1306,6 +1306,28 @@ describe "Semantic: macro" do
       CRYSTAL
   end
 
+  it "reports wrong number of arguments for module macro call with path receiver (#5479)" do
+    assert_error(<<-CRYSTAL, "wrong number of arguments for macro 'foo' (given 2, expected 1)")
+      module Mod
+        macro foo(foo)
+        end
+      end
+
+      Mod.foo(String, String)
+      CRYSTAL
+  end
+
+  it "reports named argument errors for module macro call with path receiver" do
+    assert_error(<<-CRYSTAL, "no parameter named 'y'")
+      module Mod
+        macro foo(x = 1)
+        end
+      end
+
+      Mod.foo(y: String)
+      CRYSTAL
+  end
+
   it "uses bare *, doesn't let more args" do
     assert_error(<<-CRYSTAL, "no overload matches")
       def foo(x, *, y)

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -588,7 +588,9 @@ class Crystal::Call
   end
 
   private def raise_undefined_method(owner, def_name, obj)
-    check_macro_wrong_number_of_arguments(def_name)
+    # Report macro argument errors before falling back to undefined method.
+    # Use `owner` for path receivers such as `Mod.foo(...)`.
+    check_macro_wrong_number_of_arguments(owner, def_name)
 
     owner_trace = obj.try &.find_owner_trace(owner.program, owner)
     similar_name = owner.lookup_similar_def_name(def_name, self.args.size, block)
@@ -896,10 +898,23 @@ class Crystal::Call
     end
   end
 
-  def check_macro_wrong_number_of_arguments(def_name)
+  def check_macro_wrong_number_of_arguments(owner, def_name)
+    # `obj` is the receiver expression (`Mod` in `Mod.foo`, `obj` in `obj.foo`).
+    # `owner` is the resolved target where macros are looked up.
+
+    # Run this only for `foo` and `Mod.foo`.
+    # Skip `obj.foo` because that is a normal method call.
     return if (obj = self.obj) && !obj.is_a?(Path)
 
-    macros = in_macro_target &.lookup_macros(def_name)
+    # Choose the lookup scope based on the call style.
+    macros = if obj
+               # Example: `Mod.foo(...)` -> check macros defined on `Mod`.
+               owner.lookup_macros(def_name)
+             else
+               # Example: `foo(...)` -> check macros visible in the current macro scope.
+               in_macro_target &.lookup_macros(def_name)
+             end
+    # Continue only when macro lookup returned an actual macro list.
     return unless macros.is_a?(Array(Macro))
 
     if msg = single_def_error_message(macros, named_args)

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -588,8 +588,6 @@ class Crystal::Call
   end
 
   private def raise_undefined_method(owner, def_name, obj)
-    # Report macro argument errors before falling back to undefined method.
-    # Use `owner` for path receivers such as `Mod.foo(...)`.
     check_macro_wrong_number_of_arguments(owner, def_name)
 
     owner_trace = obj.try &.find_owner_trace(owner.program, owner)
@@ -899,22 +897,13 @@ class Crystal::Call
   end
 
   def check_macro_wrong_number_of_arguments(owner, def_name)
-    # `obj` is the receiver expression (`Mod` in `Mod.foo`, `obj` in `obj.foo`).
-    # `owner` is the resolved target where macros are looked up.
-
-    # Run this only for `foo` and `Mod.foo`.
-    # Skip `obj.foo` because that is a normal method call.
     return if (obj = self.obj) && !obj.is_a?(Path)
 
-    # Choose the lookup scope based on the call style.
     macros = if obj
-               # Example: `Mod.foo(...)` -> check macros defined on `Mod`.
                owner.lookup_macros(def_name)
              else
-               # Example: `foo(...)` -> check macros visible in the current macro scope.
                in_macro_target &.lookup_macros(def_name)
              end
-    # Continue only when macro lookup returned an actual macro list.
     return unless macros.is_a?(Array(Macro))
 
     if msg = single_def_error_message(macros, named_args)


### PR DESCRIPTION
This pull request aims to fix Issue https://github.com/crystal-lang/crystal/issues/5479.

When call resolution fails, it now checks the receiver’s owner as well as the current scope.
