### PR TITLE
PoC: dont use event loop to load debug info (elf, mach-o, pe, dwarf)

### DIFF
--- a/src/crystal/dwarf/info.cr
+++ b/src/crystal/dwarf/info.cr
@@ -15,7 +15,7 @@ module Crystal
       @offset : Int64
       @ref_offset : Int64
 
-      def initialize(@io : IO::FileDescriptor, @offset)
+      def initialize(@io : IO::Memory, @offset)
         @ref_offset = offset
 
         @unit_length = @io.read_bytes(UInt32)
@@ -26,7 +26,7 @@ module Crystal
           @dwarf64 = false
         end
 
-        @offset = @io.tell
+        @offset = @io.tell.to_i64
         @version = @io.read_bytes(UInt16)
 
         if @version < 2 || @version > 5
@@ -54,7 +54,7 @@ module Crystal
         end_offset = @offset + @unit_length
         attributes = [] of {AT, FORM, Value}
 
-        while @io.tell < end_offset
+        while @io.tell.to_i64 < end_offset
           code = DWARF.read_unsigned_leb128(@io)
           attributes.clear
 

--- a/src/crystal/dwarf/line_numbers.cr
+++ b/src/crystal/dwarf/line_numbers.cr
@@ -157,8 +157,8 @@ module Crystal
 
       @offset : Int64
 
-      def initialize(@io : IO::FileDescriptor, size, @base_address : LibC::SizeT = 0, @strings : Strings? = nil, @line_strings : Strings? = nil)
-        @offset = @io.tell
+      def initialize(@io : IO::Memory, size, @base_address : LibC::SizeT = 0, @strings : Strings? = nil, @line_strings : Strings? = nil)
+        @offset = @io.tell.to_i64
         @matrix = Array(Array(Row)).new
         decode_sequences(size)
 
@@ -177,7 +177,7 @@ module Crystal
       # Decodes the compressed matrix of addresses to line numbers.
       private def decode_sequences(size)
         while true
-          pos = @io.tell
+          pos = @io.tell.to_i64
           offset = pos - @offset
           break unless offset < size
 
@@ -237,7 +237,7 @@ module Crystal
             file_names = Array.new(count) { read_lnct(include_directories, file_format) }
           end
 
-          if @io.tell - @offset < offset + total_length
+          if @io.tell.to_i64 - @offset < offset + total_length
             sequence = Sequence.new(
               offset,
               unit_length,
@@ -417,7 +417,7 @@ module Crystal
             when LNE::EndSequence
               registers.end_sequence = true
               register_to_matrix(sequence, registers)
-              if (@io.tell - @offset - sequence.offset) < sequence.total_length
+              if (@io.tell.to_i64 - @offset - sequence.offset) < sequence.total_length
                 registers = Register.new(sequence.default_is_stmt)
               else
                 break

--- a/src/crystal/dwarf/strings.cr
+++ b/src/crystal/dwarf/strings.cr
@@ -1,10 +1,10 @@
 module Crystal
   module DWARF
     struct Strings
-      def initialize(@io : IO::FileDescriptor, @offset : UInt32 | UInt64, size)
+      def initialize(@io : IO::Memory, @offset : UInt32 | UInt64, size)
         # Read a good chunk of bytes to decode strings faster
         # (avoid seeking/reading the IO too many times)
-        @buffer = Bytes.new(Math.min(Math.max(16384, size), io.info.size - offset))
+        @buffer = Bytes.new(Math.min(Math.max(16384, size), io.size - offset))
         pos = @io.pos
         @io.read_fully(@buffer)
         @io.pos = pos

--- a/src/crystal/elf.cr
+++ b/src/crystal/elf.cr
@@ -1,3 +1,5 @@
+require "crystal/system/memory_map"
+
 module Crystal
   # :nodoc:
   #
@@ -147,12 +149,27 @@ module Crystal
     property! shstrndx : UInt16
 
     def self.open(path, &)
-      File.open(path, "r") do |file|
-        yield new(file)
+      fd = System::File.system_open(path, LibC::O_RDONLY, ::File::DEFAULT_CREATE_PERMISSIONS)
+      return unless fd.is_a?(System::FileDescriptor::Handle)
+
+      begin
+        info = System::FileDescriptor.system_info(fd)
+        return unless info.is_a?(File::Info)
+
+        memory_map = System.memory_map(fd, offset: 0, size: info.size)
+        return unless memory_map.is_a?(System::MemoryMap)
+
+        begin
+          yield new(IO::Memory.new(memory_map.to_slice))
+        ensure
+          memory_map.unmap
+        end
+      ensure
+        System::File.system_close(fd)
       end
     end
 
-    def initialize(@io : IO::FileDescriptor)
+    def initialize(@io : IO::Memory)
       read_magic
       read_ident
       read_header

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -284,23 +284,12 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
   end
 
   def open(path : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : {System::FileDescriptor::Handle, Bool} | WinError
-    access, disposition, attributes = System::File.posix_to_open_opts(flags, permissions, !!blocking)
-
-    handle = LibC.CreateFileW(
-      System.to_wstr(path),
-      access,
-      LibC::DEFAULT_SHARE_MODE, # UNIX semantics
-      nil,
-      disposition,
-      attributes,
-      LibC::HANDLE.null
-    )
-
-    if handle == LibC::INVALID_HANDLE_VALUE
-      WinError.value
-    else
+    case handle = System::File.system_open(path, flags, permissions, !!blocking)
+    when System::FileDescriptor::Handle
       create_completion_port(handle) unless blocking
       {handle.address, !!blocking}
+    when WinError
+      handle
     end
   end
 

--- a/src/crystal/mach_o.cr
+++ b/src/crystal/mach_o.cr
@@ -1,3 +1,5 @@
+require "crystal/system/memory_map"
+
 module Crystal
   # :nodoc:
   #
@@ -91,12 +93,27 @@ module Crystal
     @symbols : Array(Nlist64)?
 
     def self.open(path, &)
-      File.open(path, "r") do |file|
-        yield new(file)
+      fd = System::File.system_open(path, LibC::O_RDONLY, ::File::DEFAULT_CREATE_PERMISSIONS)
+      return unless fd.is_a?(System::FileDescriptor::Handle)
+
+      begin
+        info = System::FileDescriptor.system_info(fd)
+        return unless info.is_a?(File::Info)
+
+        memory_map = System.memory_map(fd, offset: 0, size: info.size)
+        return unless memory_map.is_a?(System::MemoryMap)
+
+        begin
+          yield new(IO::Memory.new(memory_map.to_slice))
+        ensure
+          memory_map.unmap
+        end
+      ensure
+        System::File.system_close(fd)
       end
     end
 
-    def initialize(@io : IO::FileDescriptor)
+    def initialize(@io : IO::Memory)
       @magic = read_magic
       @cputype = CpuType.new(@io.read_bytes(Int32, endianness))
       @cpusubtype = @io.read_bytes(Int32, endianness)
@@ -105,7 +122,7 @@ module Crystal
       @sizeofcmds = @io.read_bytes(UInt32, endianness)
       @flags = Flags.new(@io.read_bytes(UInt32, endianness))
       @io.skip(4) if abi64? # reserved
-      @ldoff = @io.tell
+      @ldoff = @io.tell.to_i64
       @segments = [] of Segment64
       @sections = [] of Section64
     end

--- a/src/crystal/pe.cr
+++ b/src/crystal/pe.cr
@@ -1,3 +1,5 @@
+require "crystal/system/memory_map"
+
 module Crystal
   # :nodoc:
   #
@@ -25,13 +27,28 @@ module Crystal
     # offsets within that section
     getter coff_symbols = Hash(Int32, Array(COFFSymbol)).new
 
-    def self.open(path : String | ::Path, &)
-      File.open(path, "r") do |file|
-        yield new(file)
+    def self.open(path, &)
+      fd = System::File.system_open(path, LibC::O_RDONLY, ::File::DEFAULT_CREATE_PERMISSIONS)
+      return unless fd.is_a?(System::FileDescriptor::Handle)
+
+      begin
+        info = System::FileDescriptor.system_info(fd)
+        return unless info.is_a?(File::Info)
+
+        memory_map = System.memory_map(fd, offset: 0, size: info.size)
+        return unless memory_map.is_a?(System::MemoryMap)
+
+        begin
+          yield new(IO::Memory.new(memory_map.to_slice))
+        ensure
+          memory_map.unmap
+        end
+      ensure
+        System::File.system_close(fd)
       end
     end
 
-    def initialize(@io : IO::FileDescriptor)
+    def initialize(@io : IO::Memory)
       dos_header = uninitialized LibC::IMAGE_DOS_HEADER
       io.read_fully(pointerof(dos_header).to_slice(1).to_unsafe_bytes)
       raise Error.new("Invalid DOS header") unless dos_header.e_magic == 0x5A4D # MZ

--- a/src/crystal/system/memory_map.cr
+++ b/src/crystal/system/memory_map.cr
@@ -1,0 +1,31 @@
+module Crystal::System
+  struct MemoryMap
+    @pointer : UInt8*
+    getter size : LibC::SizeT
+    getter? read_only : Bool
+
+    # def unmap : Nil | Errno | WinError
+
+    def to_slice : Bytes
+      Bytes.new(@pointer, @size.to_i32, read_only: @read_only)
+    end
+
+    def to_slice(offset : Int, count : Int) : Bytes
+      Bytes.new(@pointer + offset, (@size - count).to_i32, read_only: @read_only)
+    end
+
+    def to_unsafe : UInt8*
+      @pointer
+    end
+  end
+
+  # def self.memory_map(handle : FileDescriptor::Handle, offset : Int, size : Int, read_only = true) : MemoryMap | Errno | WinError
+end
+
+{% if flag?(:unix) %}
+  require "./unix/memory_map"
+{% elsif flag?(:win32) %}
+  require "./win32/memory_map"
+{% else %}
+  {% raise "No Crystal::System::MemoryMap implementation available" %}
+{% end %}

--- a/src/crystal/system/unix/dir.cr
+++ b/src/crystal/system/unix/dir.cr
@@ -41,13 +41,13 @@ module Crystal::System::Dir
     LibC.rewinddir(dir)
   end
 
-  def self.info(dir, path) : ::File::Info
+  def self.info(dir, path) : ::File::Info | Errno
     fd = {% if flag?(:netbsd) %}
            dir.value.dd_fd
          {% else %}
            LibC.dirfd(dir)
          {% end %}
-    Crystal::System::FileDescriptor.system_info(fd)
+    FileDescriptor.system_info(fd)
   end
 
   def self.close(dir, path) : Nil

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -14,6 +14,25 @@ module Crystal::System::File
     end
   end
 
+  def self.system_open(path : String, mode : Int, perm : ::File::Permissions, blocking : Bool = true) : FileDescriptor::Handle | Errno
+    fd = LibC.open(path.check_no_null_byte, mode | LibC::O_CLOEXEC, perm)
+    return Errno.value if fd == -1
+
+    FileDescriptor.set_blocking(fd, false) unless blocking
+    fd
+  end
+
+  def self.system_close(fd : FileDescriptor::Handle) : Nil | Errno
+    return if LibC.close(fd) == 0
+
+    case errno = Errno.value
+    when Errno::EINTR, Errno::EINPROGRESS
+      # ignore
+    else
+      errno
+    end
+  end
+
   protected def system_init(mode : String, blocking : Bool) : Nil
   end
 

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -44,15 +44,17 @@ module Crystal::System::FileDescriptor
 
   protected def system_blocking_init(blocking : Bool?)
     if blocking.nil?
-      blocking = EventLoop.default_file_blocking? ||
-                 case system_info.type
-                 when .pipe?, .socket?, .character_device?
-                   false
-                 else
-                   true
-                 end
+      blocking = EventLoop.default_file_blocking? || !FileDescriptor.special_type?(fd)
     end
     self.system_blocking = blocking
+  end
+
+  protected def self.special_type?(fd)
+    if type = system_info(fd).as?(::File::Info).try(&.type)
+      type.pipe? || type.socket? || type.character_device?
+    else
+      false
+    end
   end
 
   private def system_close_on_exec?
@@ -79,18 +81,16 @@ module Crystal::System::FileDescriptor
     FileDescriptor.fcntl(fd, cmd, arg)
   end
 
-  def self.system_info(fd)
+  def self.system_info(fd) : ::File::Info | Errno
     stat = uninitialized LibC::Stat
-    ret = File.fstat(fd, pointerof(stat))
-
-    if ret != 0
-      raise IO::Error.from_errno("Unable to get info")
+    if File.fstat(fd, pointerof(stat)) == 0
+      ::File::Info.new(stat)
+    else
+      Errno.value
     end
-
-    ::File::Info.new(stat)
   end
 
-  private def system_info
+  private def system_info : ::File::Info | Errno
     FileDescriptor.system_info(fd)
   end
 

--- a/src/crystal/system/unix/memory_map.cr
+++ b/src/crystal/system/unix/memory_map.cr
@@ -1,0 +1,25 @@
+require "c/sys/mman"
+
+module Crystal::System
+  struct MemoryMap
+    def initialize(@pointer, @size, @read_only)
+    end
+
+    def unmap : Nil | Errno
+      unless LibC.munmap(@pointer, @size) == 0
+        Errno.value
+      end
+    end
+  end
+
+  def self.memory_map(handle : FileDescriptor::Handle, offset : Int, size : Int, read_only = true) : MemoryMap | Errno
+    size_t = LibC::SizeT.new(size)
+    protect = LibC::PROT_READ
+    protect |= LibC::PROT_WRITE unless read_only
+
+    pointer = LibC.mmap(nil, size_t, protect, LibC::MAP_PRIVATE, handle, offset)
+    return Errno.value if pointer == LibC::MAP_FAILED
+
+    MemoryMap.new(pointer.as(UInt8*), size_t, read_only)
+  end
+end

--- a/src/crystal/system/unix/urandom.cr
+++ b/src/crystal/system/unix/urandom.cr
@@ -15,7 +15,8 @@ module Crystal::System::Random
 
       # safety check: urandom can't be a regular disk file or anything, it must
       # be a character device; if not it's a system security issue
-      return unless FileDescriptor.system_info(fd).type.character_device?
+      return unless info = FileDescriptor.system_info(fd).as?(::File::Info)
+      return unless info.type.character_device?
 
       @@urandom = fd
     end

--- a/src/crystal/system/wasi/dir.cr
+++ b/src/crystal/system/wasi/dir.cr
@@ -64,8 +64,8 @@ module Crystal::System::Dir
     dir.end_pos = dir.pos = dir.buf.size.to_u32
   end
 
-  def self.info(dir, path) : ::File::Info
-    Crystal::System::FileDescriptor.system_info dir.fd
+  def self.info(dir, path) : ::File::Info | WasiError
+    FileDescriptor.system_info(dir.fd)
   end
 
   def self.close(dir, path) : Nil

--- a/src/crystal/system/win32/dir.cr
+++ b/src/crystal/system/win32/dir.cr
@@ -66,7 +66,7 @@ module Crystal::System::Dir
     close(dir)
   end
 
-  def self.info(dir : DirHandle, path) : ::File::Info
+  def self.info(dir : DirHandle, path) : ::File::Info | WinError
     if dir.file_handle == LibC::INVALID_HANDLE_VALUE
       handle = LibC.CreateFileW(
         System.to_wstr(path),
@@ -79,13 +79,13 @@ module Crystal::System::Dir
       )
 
       if handle == LibC::INVALID_HANDLE_VALUE
-        raise ::File::Error.from_winerror("Unable to get directory info", file: path)
+        return WinError.value
       end
 
       dir.file_handle = handle
     end
 
-    Crystal::System::FileDescriptor.system_info dir.file_handle, LibC::FILE_TYPE_DISK
+    FileDescriptor.system_info(dir.file_handle, LibC::FILE_TYPE_DISK)
   end
 
   def self.close(dir : DirHandle, path : String) : Nil

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -15,16 +15,7 @@ module Crystal::System::File
   getter? system_append = false
 
   def self.open(filename : String, mode : String, perm : Int32 | ::File::Permissions, blocking : Bool?) : {FileDescriptor::Handle, Bool}
-    perm = ::File::Permissions.new(perm) if perm.is_a? Int32
-    # Only the owner writable bit is used, since windows only supports
-    # the read only attribute.
-    if perm.owner_write?
-      perm = LibC::S_IREAD | LibC::S_IWRITE
-    else
-      perm = LibC::S_IREAD
-    end
-
-    case result = EventLoop.current.open(filename, open_flag(mode), ::File::Permissions.new(perm), blocking != false)
+    case result = EventLoop.current.open(filename, open_flag(mode), posix_perms(perm), blocking != false)
     in Tuple(FileDescriptor::Handle, Bool)
       result
     in WinError
@@ -32,7 +23,39 @@ module Crystal::System::File
     end
   end
 
-  def self.posix_to_open_opts(flags : Int32, perm : ::File::Permissions, blocking : Bool)
+  def self.system_open(path : String, mode : Int, perm : ::File::Permissions, blocking : Bool = true) : FileDescriptor::Handle | WinError
+    access, disposition, attributes = posix_to_open_opts(mode, posix_perms(perm), blocking)
+    handle = LibC.CreateFileW(
+      System.to_wstr(path),
+      access,
+      LibC::DEFAULT_SHARE_MODE, # UNIX semantics
+      nil,
+      disposition,
+      attributes,
+      LibC::HANDLE.null
+    )
+    handle == LibC::INVALID_HANDLE_VALUE ? WinError.value : handle
+  end
+
+  def self.system_close(fd : FileDescriptor::Handle) : Nil | WinError
+    if LibC.CloseHandle(handle) == 0
+      WinError.value
+    end
+  end
+
+  def self.posix_perms(perm)
+    perm = ::File::Permissions.new(perm) if perm.is_a? Int32
+
+    # Only the owner writable bit is used, since windows only supports
+    # the read only attribute.
+    if perm.owner_write?
+      ::File::Permissions.new(LibC::S_IREAD | LibC::S_IWRITE)
+    else
+      ::File::Permissions.new(LibC::S_IREAD)
+    end
+  end
+
+  def self.posix_to_open_opts(flags : Int32, perm : Int32, blocking : Bool)
     access = if flags.bits_set? LibC::O_WRONLY
                LibC::FILE_GENERIC_WRITE
              elsif flags.bits_set? LibC::O_RDWR

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -162,29 +162,27 @@ module Crystal::System::FileDescriptor
     LibC::HANDLE.new(fd)
   end
 
-  def self.system_info(handle, file_type = nil)
+  def self.system_info(handle, file_type = nil) : ::File::Info | WinError
     unless file_type
       file_type = LibC.GetFileType(handle)
-
       if file_type == LibC::FILE_TYPE_UNKNOWN
         error = WinError.value
-        raise IO::Error.from_os_error("Unable to get info", error, target: self) unless error == WinError::ERROR_SUCCESS
+        return error unless error == WinError::ERROR_SUCCESS
       end
     end
 
     if file_type == LibC::FILE_TYPE_DISK
       if LibC.GetFileInformationByHandle(handle, out file_info) == 0
-        raise IO::Error.from_winerror("Unable to get info")
+        return WinError.value
       end
-
       ::File::Info.new(file_info, file_type)
     else
       ::File::Info.new(file_type)
     end
   end
 
-  private def system_info
-    FileDescriptor.system_info windows_handle
+  private def system_info : ::File::Info | WinError
+    FileDescriptor.system_info(windows_handle)
   end
 
   def system_seek(offset, whence : IO::Seek) : Nil

--- a/src/crystal/system/win32/memory_map.cr
+++ b/src/crystal/system/win32/memory_map.cr
@@ -1,0 +1,55 @@
+require "c/memoryapi"
+
+module Crystal::System
+  struct Crystal::System::MemoryMap
+    @map_handle : LibC::HANDLE
+
+    def initialize(@map_handle, @pointer, @size, @read_only)
+    end
+
+    def unmap : Nil | WinError
+      if LibC.UnmapViewOfFile(@pointer) == 0
+        error = WinError.new
+      end
+
+      if LibC.CloseHandle(@map_handle) == 0
+        error ||= WinError.new
+      end
+
+      error
+    end
+  end
+
+  def self.memory_map(handle : FileDescriptor::Handle, offset : Int, size : Int, read_only = true) : MemoryMap | WinError
+    size_t = LibC::SizeT.new(size)
+
+    map_handle = LibC.CreateFileMappingA(
+      handle,
+      nil,
+      read_only ? LibC::PAGE_READONLY : LibC::PAGE_READWRITE,
+      LibC::DWORD.new!(size >> 32),
+      LibC::DWORD.new!(size),
+      nil
+    )
+    if map_handle == LibC::INVALID_HANDLE_VALUE
+      return WinError.value
+    end
+
+    map_access = LibC::FILE_MAP_READ
+    map_access |= LibC::FILE_MAP_WRITE unless read_only
+
+    pointer = LibC.MapViewOfFile(
+      map_handle,
+      map_access,
+      LibC::DWORD.new!(offset >> 32),
+      LibC::DWORD.new!(offset),
+      size_t
+    )
+    if pointer.null?
+      LibC.CloseHandle(map_handle)
+      return WinError.value
+    end
+
+    MemoryMap.new(pointer.as(UInt8*), size_t, read_only)
+  end
+end

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -166,7 +166,9 @@ class Dir
 
   # This method is faster than `.info` and avoids race conditions if a `Dir` is already open on POSIX systems, but not necessarily on windows.
   def info : File::Info
-    Crystal::System::Dir.info(@dir, path)
+    result = Crystal::System::Dir.info(@dir, path).as?(File::Info)
+    raise ::File::Error.from_os_error("Unable to get directory info", result, file: path) unless result.is_a?(File::Info)
+    result
   end
 
   # Closes the directory stream.

--- a/src/exception/call_stack/elf.cr
+++ b/src/exception/call_stack/elf.cr
@@ -18,11 +18,6 @@ struct Exception::CallStack
     end
   end
 
-  def self.load_debug_info : Nil
-    # FIXME: Crystal::ELF depends on the event loop (it shouldn't)
-    previous_def if Crystal::EventLoop.current?
-  end
-
   protected def self.load_debug_info_impl : Nil
     program = Process.executable_path
     return unless program && File::Info.readable? program

--- a/src/exception/call_stack/mach_o.cr
+++ b/src/exception/call_stack/mach_o.cr
@@ -15,11 +15,6 @@ struct Exception::CallStack
 
   @@image_slide : LibC::Long?
 
-  def self.load_debug_info : Nil
-    # FIXME: Crystal::Mach-O depends on the event loop (it shouldn't)
-    previous_def if Crystal::EventLoop.current?
-  end
-
   protected def self.load_debug_info_impl : Nil
     locate_dsym_bundle do |image|
       read_dwarf_sections(image)

--- a/src/exception/call_stack/pe.cr
+++ b/src/exception/call_stack/pe.cr
@@ -9,11 +9,6 @@ struct Exception::CallStack
 
   @@coff_symbols : Hash(Int32, Array(Crystal::PE::COFFSymbol))?
 
-  def self.load_debug_info : Nil
-    # FIXME: Crystal::PE depends on the event loop (it shouldn't)
-    previous_def if Crystal::EventLoop.current?
-  end
-
   protected def self.load_debug_info_impl : Nil
     program = Process.executable_path
     return unless program && File::Info.readable? program

--- a/src/file.cr
+++ b/src/file.cr
@@ -771,6 +771,13 @@ class File < IO::FileDescriptor
     io << '>'
   end
 
+  # :inherit:
+  def info : File::Info
+    result = @fd_lock.reference { system_info }
+    raise File::Error.from_os_error("Unable to get file info", result, file: path) unless result.is_a?(File::Info)
+    result
+  end
+
   # Changes the owner of the specified file.
   #
   # ```

--- a/src/io.cr
+++ b/src/io.cr
@@ -1140,6 +1140,18 @@ abstract class IO
     raise Error.new "Unable to seek"
   end
 
+  # Same as `seek` but yields to the block after seeking and eventually seeks
+  # back to the original position when the block returns.
+  def seek(offset, whence : Seek = Seek::Set, &)
+    original_pos = tell
+    begin
+      seek(offset, whence)
+      yield
+    ensure
+      seek(original_pos)
+    end
+  end
+
   # Returns the current position (in bytes) in this `IO`.
   #
   # The `IO` class raises on this method, but some subclasses, notable

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -186,18 +186,6 @@ class IO::FileDescriptor < IO
     self
   end
 
-  # Same as `seek` but yields to the block after seeking and eventually seeks
-  # back to the original position when the block returns.
-  def seek(offset, whence : Seek = Seek::Set, &)
-    original_pos = tell
-    begin
-      seek(offset, whence)
-      yield
-    ensure
-      seek(original_pos)
-    end
-  end
-
   # Returns the current position (in bytes) in this `IO`.
   #
   # ```

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -157,7 +157,9 @@ class IO::FileDescriptor < IO
   #
   # Use `File.info` if the file is not open and a path to the file is available.
   def info : File::Info
-    @fd_lock.reference { system_info }
+    result = @fd_lock.reference { system_info }
+    raise IO::Error.from_os_error("Unable to get file info", result) unless result.is_a?(File::Info)
+    result
   end
 
   # Seeks to a given *offset* (in bytes) according to the *whence* argument.

--- a/src/lib_c/x86_64-windows-msvc/c/memoryapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/memoryapi.cr
@@ -12,4 +12,10 @@ lib LibC
   fun VirtualFree(lpAddress : Void*, dwSize : SizeT, dwFreeType : DWORD) : BOOL
   fun VirtualProtect(lpAddress : Void*, dwSize : SizeT, flNewProtect : DWORD, lpfOldProtect : DWORD*) : BOOL
   fun VirtualQuery(lpAddress : Void*, lpBuffer : MEMORY_BASIC_INFORMATION*, dwLength : SizeT) : SizeT
+
+  FILE_MAP_WRITE = 2
+  FILE_MAP_READ  = 4
+
+  fun CreateFileMappingA(hFile : HANDLE, lpFileMappingAttributes : SECURITY_ATTRIBUTES, flProtect : DWORD, dwMaximumSizeHigh : DWORD, dwMaximumSizeLow : DWORD, lpName : LPSTR) : HANDLE
+  fun MapViewOfFile(hFileMappingObject : HANDLE, dwDesiredAccess : DWORD, dwFileOffsetHigh : DWORD, dwFileOffsetLow : DWORD, dwNumberOfBytesToMap : SizeT) : Void*
 end

--- a/src/lib_c/x86_64-windows-msvc/c/winnt.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winnt.cr
@@ -43,6 +43,7 @@ lib LibC
   IO_REPARSE_TAG_AF_UNIX = 0x80000023_u32
 
   # Memory protection constants
+  PAGE_READONLY  =  0x02
   PAGE_READWRITE =  0x04
   PAGE_GUARD     = 0x100
 


### PR DESCRIPTION
Follow up to #16877.

We currently use the EventLoop to parse ELF, Mach-O, PE files and DWARF sections, but we can avoid the event loop by manually opening the program's executable file, mapping it into memory, then use `IO::Memory` to parse the contents.


The caveat is that if your file is larger than 2GB, then we can't slice it into an IO::Memory (math overflow) and debug info won't be loaded. I expect this to be unlikely.

This PoC introduces changes:

- `IO#seek(&)` (moved from `IO::FileDescriptor`)

- `Crystal::System::File.system_open` and `.system_close` to abstract open / close file across targets. They reuse the "errorable" pattern that I already started to use in the EventLoop and allows to defer raising (or silence, or skip, or abort) to the call site.

- `Crystal::System::FileDescriptor.system_info` has been refactored to become an errorable. It allows the call site to raise (or not) and allows `File#info` to raise a `File::Error` with a `path` instead of an abstract `IO::Error` (bonus).

- `Crystal::System::MemoryMap` to abstract mapping files into memory across systems.

- `Crystal::ELF`, `Crystal::MachO` and `Crystal::PE` now system_open, system_info, memory_map the file, then pass an IO::Memory around. There are little changes in the actual types. The `T.open` method is duplicated (that calls for a refactor, see below).

_**WIP**: most commits must be extracted into distinct PRs._

Future work could be:

1. Pass the `System::MemoryMap` around and slice each section independently, instead of using a single large `IO::Memory`. That would lift the 2GB limitation.

2. Consolidate the `Crystal::ELF`, `Crystal::MachO` and `Crystal::PE` types into a single `Crystal::System` type so we only care about the target's 32/64 bits and big/little endianness (especially for next step). Same for `Crystal::DWARF`.

3. Map structs directly to memory (don't parse & copy). That would drop the dependency on IO. It might improve performance (not much), but that would certainly simplify (a lot).