### PR TITLE
Improve wording in warning about doc generator without LibXML2

### DIFF
--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -124,7 +124,7 @@ class Crystal::Command
     end
 
     if Crystal::Doc::MarkdDocRenderer::SANITIZER.nil?
-      STDERR.puts "Crystal built without LibXML2 support, documentation sanitization disabled"
+      STDERR.puts "Crystal built without LibXML2 support, HTML sanitization will be skipped"
     end
 
     unless project_info.name? && project_info.version?


### PR DESCRIPTION
When you run `crystal docs`, the following warning may appear.

```console
Crystal built without LibXML2 support, documentation sanitization disabled
```

This is actually just a WARNING or INFO.
However, this message can be misleading. It may look like `crystal docs` is not working correctly.

In January 2026, I saw this message and thought `crystal docs` was broken. @Blacksmoke16 explained it to me on Discord. Later, I saw blacksmoke16 explain the [same misunderstanding to another person on the Forum](https://forum.crystal-lang.org/t/missing-docs-in-crystal-compiler/8927), so I started to think this may not be only my personal issue.

The current message says “documentation sanitization”, but I think “HTML sanitization” is more accurate. 
Also, “documentation ... disabled” may sound like documentation generation itself is disabled, especially for non-native English speakers.

So I thought changing “documentation” to “HTML”, and using “skipped” instead of “disabled”, might make the message less confusing.

This is just one suggestion. Since I am not a native English speaker, I cannot fully understand the exact nuance in English, so my proposal may be limited. This proposal was also written with the help of ChatGPT. Before ChatGPT, I would have used Google Translate or DeepL anyway. If there is a better idea, please feel free to use it.

Thank you.