### PR TITLE
[Backport release/1.20] Simplify `Sync::Mutex#synchronize` proc type constraints

### DIFF
--- a/src/sync/exclusive.cr
+++ b/src/sync/exclusive.cr
@@ -65,7 +65,7 @@ module Sync
     #
     # WARNING: The value musn't be retained and accessed after the block has
     # returned.
-    def lock(& : T -> U) : U forall U
+    def lock(& : T -> _)
       lock.synchronize { yield @value }
     end
 

--- a/src/sync/mutex.cr
+++ b/src/sync/mutex.cr
@@ -25,7 +25,7 @@ module Sync
     # Acquires the exclusive lock for the duration of the block. The lock will
     # be released automatically before returning, or if the block raises an
     # exception.
-    def synchronize(& : -> U) : U forall U
+    def synchronize(& : -> _)
       lock
       begin
         yield

--- a/src/sync/rw_lock.cr
+++ b/src/sync/rw_lock.cr
@@ -36,7 +36,7 @@ module Sync
     # WARNING: the shared lock is technically reentrant but any attempt to
     # relock read can result in a deadlock if another fiber is trying to lock
     # write!
-    def read(& : -> U) : U forall U
+    def read(& : -> _)
       lock_read
       begin
         yield
@@ -77,7 +77,7 @@ module Sync
     # Only one fiber can acquire the exclusive (write) lock at the same time.
     # The block will never run concurrently to a shared (read) lock or another
     # exclusive (write) lock.
-    def write(& : -> U) : U forall U
+    def write(& : -> _)
       lock_write
       begin
         yield

--- a/src/sync/shared.cr
+++ b/src/sync/shared.cr
@@ -67,7 +67,7 @@ module Sync
     #
     # WARNING: The value musn't be retained and accessed after the block has
     # returned.
-    def shared(& : T -> U) : U forall U
+    def shared(& : T -> _)
       lock.read { yield @value }
     end
 
@@ -79,7 +79,7 @@ module Sync
     #
     # WARNING: The value musn't be retained and accessed after the block has
     # returned.
-    def lock(& : T -> U) : U forall U
+    def lock(& : T -> _)
       lock.write { yield @value }
     end
 


### PR DESCRIPTION
Backport of https://github.com/crystal-lang/crystal/pull/16904 to `release/1.20`

Fixes a regression where the proc type constraint of `Sync::Mutex#synchronize(& : -> U) forall U` causes semantic to fail in some edge cases: the block's returned type is different from what the semantics expects `U` to be.

Fixes the other `forall` expressions in the `Sync` namespace as they can exhibit the same issue.

Workaround for https://github.com/crystal-lang/crystal/issues/16903