### PR TITLE
Use Crysbot token in `update-devenv` workflow to trigger CI

### DIFF
--- a/.github/workflows/update-devenv.yml
+++ b/.github/workflows/update-devenv.yml
@@ -18,6 +18,7 @@ jobs:
   update-devenv:
     if: github.repository == 'crystal-lang/crystal'
     runs-on: ubuntu-latest
+    environment: github-write
 
     steps:
       - name: Download source
@@ -58,3 +59,4 @@ jobs:
           labels: "topic:infrastructure"
           branch: infra/update-devenv
           delete-branch: true
+          token: ${{ secrets.CRYSBOT_WRITE_PAT }}

--- a/.github/workflows/update-devenv.yml
+++ b/.github/workflows/update-devenv.yml
@@ -10,9 +10,7 @@ on:
       - '.github/workflows/update-devenv.yml'
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   update-devenv:


### PR DESCRIPTION
Commits and PRs created with the default `GITHUB_TOKEN` do not trigger workflow runs.

https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs