### PR TITLE
Avoid redundant gc memset

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2343,23 +2343,24 @@ module Crystal
     end
 
     def array_malloc(type, count)
-      generic_array_malloc(type, count) { crystal_malloc_fun }
+      generic_array_malloc(type, count, clear: false) { crystal_malloc_fun }
     end
 
     def array_malloc_atomic(type, count)
-      generic_array_malloc(type, count) { crystal_malloc_atomic_fun }
+      generic_array_malloc(type, count, clear: true) { crystal_malloc_atomic_fun }
     end
 
-    def generic_array_malloc(type, count, &)
+    def generic_array_malloc(type, count, *, clear : Bool, &)
       size = builder.mul type.size, count
 
       if malloc_fun = yield
         pointer = call malloc_fun, size
       else
         pointer = call c_malloc_fun, size_t(size)
+        clear = true
       end
 
-      memset pointer, int8(0), size_t(size)
+      memset pointer, int8(0), size_t(size) if clear
       pointer_cast pointer, type.pointer
     end
 

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2249,22 +2249,25 @@ module Crystal
 
     def allocate_aggregate(type)
       struct_type = llvm_struct_type(type)
+      clear = true
+
       if type.passed_by_value?
         type_ptr = alloca struct_type
       else
         if type.is_a?(InstanceVarContainer) && !type.struct? &&
            type.all_instance_vars.each_value.any? &.type.has_inner_pointers?
+          clear = !crystal_malloc_fun
           type_ptr = malloc struct_type
         else
           type_ptr = malloc_atomic struct_type
         end
       end
 
-      pre_initialize_aggregate(type, struct_type, type_ptr)
+      pre_initialize_aggregate(type, struct_type, type_ptr, clear: clear)
     end
 
-    def pre_initialize_aggregate(type, struct_type, ptr)
-      memset ptr, int8(0), size_t(struct_type.size)
+    def pre_initialize_aggregate(type, struct_type, ptr, *, clear : Bool = true)
+      memset ptr, int8(0), size_t(struct_type.size) if clear
       run_instance_vars_initializers(type, type, ptr)
 
       unless type.struct?


### PR DESCRIPTION
Hello.

Matz, the creator of Ruby, has been working on the Spinel project, which has recently attracted some attention. Spinel is a C transpiler, so its implementation approach is different from Crystal, which uses LLVM IR.

When comparing Spinel with Crystal, I think the interesting points may be:

1. Heavy use of type inference
2. Avoiding libgc

For (1), I think Spinel and Crystal have different goals. For (2), however, there may still be room for optimization in Crystal.

I asked AI to investigate the GC-related code, and it pointed out that there may be places where memory is cleared twice: first by a GC allocation that already returns zero-cleared memory, and then again by an additional `memset`.

---

Sorry for the long background. Since the code was entirely generated by AI, I wanted to also explain why I, as a human, became interested in investigating the GC code.

---

Based on this assumption, this PR avoids unnecessary clearing in the following two cases:

* object allocation for reference types that contain pointers
* `Pointer.malloc` for types that contain pointers

For paths where explicit clearing is still needed, such as `malloc_atomic`, stack allocation, and fallback C `malloc`, the existing `memset` is kept.

This is a draft PR. I would like to check whether the basic assumption behind this change is correct.
