### PR TITLE
Use `array_calloc_atomic` for pointer-free `Pointer.malloc`

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -11,6 +11,7 @@ module Crystal
   RAISE_NAME             = "__crystal_raise"
   RAISE_OVERFLOW_NAME    = "__crystal_raise_overflow"
   RAISE_CAST_FAILED_NAME = "__crystal_raise_cast_failed"
+  CALLOC_ATOMIC_NAME     = "__crystal_calloc_atomic64"
   MALLOC_NAME            = "__crystal_malloc64"
   MALLOC_ATOMIC_NAME     = "__crystal_malloc_atomic64"
   REALLOC_NAME           = "__crystal_realloc64"
@@ -270,6 +271,7 @@ module Crystal
 
     @malloc_fun : LLVMTypedFunction?
     @malloc_atomic_fun : LLVMTypedFunction?
+    @calloc_atomic_fun : LLVMTypedFunction?
     @realloc_fun : LLVMTypedFunction?
     @raise_overflow_fun : LLVMTypedFunction?
     @raise_cast_failed_fun : LLVMTypedFunction?
@@ -497,9 +499,8 @@ module Crystal
 
       def visit(node : FunDef)
         case node.name
-        when MALLOC_NAME, MALLOC_ATOMIC_NAME, REALLOC_NAME, RAISE_NAME,
-             @codegen.personality_name, GET_EXCEPTION_NAME, RAISE_OVERFLOW_NAME,
-             RAISE_CAST_FAILED_NAME, ONCE_INIT, ONCE
+        when MALLOC_NAME, MALLOC_ATOMIC_NAME, CALLOC_ATOMIC_NAME, REALLOC_NAME, RAISE_NAME,
+             @codegen.personality_name, GET_EXCEPTION_NAME, RAISE_OVERFLOW_NAME, RAISE_CAST_FAILED_NAME, ONCE_INIT, ONCE
           @codegen.accept node
         end
 
@@ -2327,6 +2328,16 @@ module Crystal
       generic_malloc(type) { crystal_malloc_atomic_fun }
     end
 
+    def calloc_atomic(type)
+      if crystal_calloc_atomic_fun
+        generic_malloc(type) { crystal_calloc_atomic_fun }
+      else
+        ptr = malloc_atomic(type)
+        memset ptr, int8(0), size_t(type.size)
+        ptr
+      end
+    end
+
     def generic_malloc(type, &)
       size = type.size
 
@@ -2347,6 +2358,17 @@ module Crystal
       generic_array_malloc(type, count) { crystal_malloc_atomic_fun }
     end
 
+    def array_calloc_atomic(type, count)
+      if crystal_calloc_atomic_fun
+        generic_array_malloc(type, count) { crystal_calloc_atomic_fun }
+      else
+        size = builder.mul type.size, count
+        ptr = array_malloc_atomic(type, count)
+        memset ptr, int8(0), size_t(size)
+        ptr
+      end
+    end
+
     def generic_array_malloc(type, count, &)
       size = builder.mul type.size, count
 
@@ -2356,7 +2378,6 @@ module Crystal
         pointer = call c_malloc_fun, size_t(size)
       end
 
-      memset pointer, int8(0), size_t(size)
       pointer_cast pointer, type.pointer
     end
 
@@ -2373,6 +2394,15 @@ module Crystal
       @malloc_atomic_fun ||= typed_fun?(@main_mod, MALLOC_ATOMIC_NAME)
       if malloc_fun = @malloc_atomic_fun
         check_main_fun MALLOC_ATOMIC_NAME, malloc_fun
+      else
+        nil
+      end
+    end
+
+    def crystal_calloc_atomic_fun
+      @calloc_atomic_fun ||= typed_fun?(@main_mod, CALLOC_ATOMIC_NAME)
+      if malloc_fun = @calloc_atomic_fun
+        check_main_fun CALLOC_ATOMIC_NAME, malloc_fun
       else
         nil
       end

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -847,9 +847,11 @@ class Crystal::CodeGenVisitor
     end
 
     if type.element_type.has_inner_pointers?
+      size = builder.mul llvm_type.size, call_args[1]
       last = array_malloc(llvm_type, call_args[1])
+      memset last, int8(0), size_t(size)
     else
-      last = array_malloc_atomic(llvm_type, call_args[1])
+      last = array_calloc_atomic(llvm_type, call_args[1])
     end
 
     if @debug.line_numbers?

--- a/src/gc.cr
+++ b/src/gc.cr
@@ -36,6 +36,20 @@ fun __crystal_malloc_atomic64(size : UInt64) : Void*
 end
 
 # :nodoc:
+fun __crystal_calloc_atomic64(size : UInt64) : Void*
+  {% if flag?(:bits32) %}
+    if size > UInt32::MAX
+      raise ArgumentError.new("Given size is bigger than UInt32::MAX")
+    end
+  {% end %}
+
+  size_t = LibC::SizeT.new(size)
+  ptr = GC.malloc_atomic(size_t)
+  ptr.clear(size_t) unless ptr.null?
+  ptr
+end
+
+# :nodoc:
 fun __crystal_realloc64(ptr : Void*, size : UInt64) : Void*
   {% if flag?(:bits32) %}
     if size > UInt32::MAX


### PR DESCRIPTION
This is a smaller variant of #14679.

- Add `__crystal_calloc_atomic64` as an internal entrypoint.
- Add `array_calloc_atomic` for zeroed atomic array allocation.
- Remove unconditional zeroing from `generic_array_malloc`.
- Keep `Pointer.malloc` zeroed in both scanned and atomic paths.

This pull request was created with assistance from Codex 5.5