### PR TITLE
Allow constants with type declarations

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1249,6 +1249,15 @@ describe Crystal::Formatter do
   assert_format "x  :   Int32  =   1", "x : Int32 = 1"
   assert_format "x : (Foo.class)?"
 
+  # Typed constant declarations (#13443)
+  assert_format "FOO : Int64 = 123"
+  assert_format "FOO  :  Int64  =  123", "FOO : Int64 = 123"
+  assert_format "FOO: Int64 = 123", "FOO : Int64 = 123"
+  assert_format "class A\nCONST : Int32 = 1\nend", "class A\n  CONST : Int32 = 1\nend"
+  assert_format "module M\nCONST : Int32 = 1\nend", "module M\n  CONST : Int32 = 1\nend"
+  assert_format "PAIR : Tuple(Int32, String) = {1, \"x\"}"
+  assert_format "TYPED : ::Int32 = -5"
+
   assert_format "def foo\n@x  :  Int32\nend", "def foo\n  @x : Int32\nend"
   assert_format "def foo\n@x   =  uninitialized   Int32\nend", "def foo\n  @x = uninitialized Int32\nend"
 

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1257,6 +1257,10 @@ describe Crystal::Formatter do
   assert_format "module M\nCONST : Int32 = 1\nend", "module M\n  CONST : Int32 = 1\nend"
   assert_format "PAIR : Tuple(Int32, String) = {1, \"x\"}"
   assert_format "TYPED : ::Int32 = -5"
+  assert_format "::FOO : Int64 = 123"
+  assert_format "::FOO  :  Int64  =  123", "::FOO : Int64 = 123"
+  assert_format "::FOO: Int64 = 123", "::FOO : Int64 = 123"
+  assert_format "::Foo::BAR : Int64 = 123"
 
   assert_format "def foo\n@x  :  Int32\nend", "def foo\n  @x : Int32\nend"
   assert_format "def foo\n@x   =  uninitialized   Int32\nend", "def foo\n  @x = uninitialized Int32\nend"

--- a/spec/compiler/parser/inspect_spec.cr
+++ b/spec/compiler/parser/inspect_spec.cr
@@ -248,6 +248,50 @@ describe "ASTNode#inspect" do
   expect_inspect %(foo : Int32 = 1), <<-CRYSTAL
       TypeDeclaration[Var["foo"], Path["Int32"], value: NumberLiteral["1", :i32]]
       CRYSTAL
+
+  # Typed constant declarations (#13443)
+  expect_inspect %(FOO : Int64 = 1), <<-CRYSTAL
+      TypeDeclaration[Path["FOO"], Path["Int64"], value: NumberLiteral["1", :i32]]
+      CRYSTAL
+  expect_inspect %(::FOO : Int64 = 1), <<-CRYSTAL
+      TypeDeclaration[
+        Path.global("FOO"),
+        Path["Int64"],
+        value: NumberLiteral["1", :i32]
+      ]
+      CRYSTAL
+  expect_inspect %(Foo::BAR : Int64 = 1), <<-CRYSTAL
+      TypeDeclaration[
+        Path["Foo", "BAR"],
+        Path["Int64"],
+        value: NumberLiteral["1", :i32]
+      ]
+      CRYSTAL
+  expect_inspect %(::Foo::BAR : Int64 = 1), <<-CRYSTAL
+      TypeDeclaration[
+        Path.global("Foo", "BAR"),
+        Path["Int64"],
+        value: NumberLiteral["1", :i32]
+      ]
+      CRYSTAL
+  expect_inspect %(FOO : String = "hey"), <<-CRYSTAL
+      TypeDeclaration[Path["FOO"], Path["String"], value: StringLiteral["hey"]]
+      CRYSTAL
+  expect_inspect %(FOO : ::Int32 = -5), <<-CRYSTAL
+      TypeDeclaration[
+        Path["FOO"],
+        Path.global("Int32"),
+        value: NumberLiteral["-5", :i32]
+      ]
+      CRYSTAL
+  expect_inspect %(PAIR : Tuple(Int32, String) = {1, "x"}), <<-CRYSTAL
+      TypeDeclaration[
+        Path["PAIR"],
+        Generic[Path["Tuple"], [Path["Int32"], Path["String"]]],
+        value: TupleLiteral[NumberLiteral["1", :i32], StringLiteral["x"]]
+      ]
+      CRYSTAL
+
   expect_inspect %(foo = uninitialized Int32), <<-CRYSTAL
       UninitializedVar[Var["foo"], Path["Int32"]]
       CRYSTAL

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1786,6 +1786,11 @@ module Crystal
     it_parses "@a : Foo = 1", TypeDeclaration.new("@a".instance_var, "Foo".path, 1.int32)
     it_parses "@@a : Foo = 1", TypeDeclaration.new("@@a".class_var, "Foo".path, 1.int32)
 
+    it_parses "FOO : Int64 = 1", TypeDeclaration.new("FOO".path, "Int64".path, 1.int32)
+    it_parses "FOO : Foo::Bar = 1", TypeDeclaration.new("FOO".path, Path.new(["Foo", "Bar"]), 1.int32)
+    it_parses "Foo::BAR : Int64 = 1", TypeDeclaration.new(Path.new(["Foo", "BAR"]), "Int64".path, 1.int32)
+    assert_syntax_error "FOO : Int64", "expected '=' for constant type declaration"
+
     it_parses "Foo?", Generic.new("Union".path(global: true), ["Foo".path, "Nil".path(global: true)] of ASTNode)
     it_parses "a : Foo*", TypeDeclaration.new("a".var, Generic.new("Pointer".path(global: true), ["Foo".path] of ASTNode, suffix: Generic::Suffix::Asterisk))
     it_parses "a : Foo[12]", TypeDeclaration.new("a".var, Generic.new("StaticArray".path(global: true), ["Foo".path, 12.int32] of ASTNode, suffix: Generic::Suffix::Bracket))

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1789,6 +1789,7 @@ module Crystal
     it_parses "FOO : Int64 = 1", TypeDeclaration.new("FOO".path, "Int64".path, 1.int32)
     it_parses "FOO : Foo::Bar = 1", TypeDeclaration.new("FOO".path, Path.new(["Foo", "Bar"]), 1.int32)
     it_parses "Foo::BAR : Int64 = 1", TypeDeclaration.new(Path.new(["Foo", "BAR"]), "Int64".path, 1.int32)
+    assert_syntax_warning "FOO: Int64 = 1", "space required before colon in type declaration (run `crystal tool format` to fix this)"
     assert_syntax_error "FOO : Int64", "expected '=' for constant type declaration"
 
     it "computes name_size for a TypeDeclaration whose var is a Path (#13443)" do

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1791,6 +1791,11 @@ module Crystal
     it_parses "Foo::BAR : Int64 = 1", TypeDeclaration.new(Path.new(["Foo", "BAR"]), "Int64".path, 1.int32)
     assert_syntax_error "FOO : Int64", "expected '=' for constant type declaration"
 
+    it "computes name_size for a TypeDeclaration whose var is a Path (#13443)" do
+      Parser.parse("FOO : Int64 = 1").as(TypeDeclaration).name_size.should eq("FOO".size)
+      Parser.parse("Foo::BAR : Int64 = 1").as(TypeDeclaration).name_size.should eq("Foo::BAR".size)
+    end
+
     it_parses "Foo?", Generic.new("Union".path(global: true), ["Foo".path, "Nil".path(global: true)] of ASTNode)
     it_parses "a : Foo*", TypeDeclaration.new("a".var, Generic.new("Pointer".path(global: true), ["Foo".path] of ASTNode, suffix: Generic::Suffix::Asterisk))
     it_parses "a : Foo[12]", TypeDeclaration.new("a".var, Generic.new("StaticArray".path(global: true), ["Foo".path, 12.int32] of ASTNode, suffix: Generic::Suffix::Bracket))

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1789,12 +1789,17 @@ module Crystal
     it_parses "FOO : Int64 = 1", TypeDeclaration.new("FOO".path, "Int64".path, 1.int32)
     it_parses "FOO : Foo::Bar = 1", TypeDeclaration.new("FOO".path, Path.new(["Foo", "Bar"]), 1.int32)
     it_parses "Foo::BAR : Int64 = 1", TypeDeclaration.new(Path.new(["Foo", "BAR"]), "Int64".path, 1.int32)
+    it_parses "::FOO : Int64 = 1", TypeDeclaration.new("FOO".path(global: true), "Int64".path, 1.int32)
+    it_parses "::Foo::BAR : Int64 = 1", TypeDeclaration.new(Path.new(["Foo", "BAR"], global: true), "Int64".path, 1.int32)
     assert_syntax_warning "FOO: Int64 = 1", "space required before colon in type declaration (run `crystal tool format` to fix this)"
+    assert_syntax_warning "::FOO: Int64 = 1", "space required before colon in type declaration (run `crystal tool format` to fix this)"
     assert_syntax_error "FOO : Int64", "expected '=' for constant type declaration"
+    assert_syntax_error "::FOO : Int64", "expected '=' for constant type declaration"
 
     it "computes name_size for a TypeDeclaration whose var is a Path (#13443)" do
       Parser.parse("FOO : Int64 = 1").as(TypeDeclaration).name_size.should eq("FOO".size)
       Parser.parse("Foo::BAR : Int64 = 1").as(TypeDeclaration).name_size.should eq("Foo::BAR".size)
+      Parser.parse("::FOO : Int64 = 1").as(TypeDeclaration).name_size.should eq("::FOO".size)
     end
 
     it_parses "Foo?", Generic.new("Union".path(global: true), ["Foo".path, "Nil".path(global: true)] of ASTNode)

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -224,6 +224,14 @@ describe "ASTNode#to_s" do
   expect_to_s %q("#{(1 + 2)}")
   expect_to_s %({(1 + 2) => (3 + 4)})
   expect_to_s %([(1 + 2)] of Int32)
+
+  # Typed constant declarations (#13443)
+  expect_to_s "FOO : Int64 = 123"
+  expect_to_s "FOO : String = \"hey\""
+  expect_to_s %(class Bar\n  CONST : Int32 = 1\nend)
+  expect_to_s %(module Mod\n  NESTED : Float64 = 3.14\nend)
+  expect_to_s "PAIR : Tuple(Int32, String) = {1, \"x\"}"
+  expect_to_s "TYPED : ::Int32 = -5"
   expect_to_s %(foo(1, (2 + 3), bar: (4 + 5)))
   expect_to_s %(if (1 + 2\n3)\n  4\nend)
   expect_to_s "%x(whoami)", "`whoami`"

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -232,6 +232,8 @@ describe "ASTNode#to_s" do
   expect_to_s %(module Mod\n  NESTED : Float64 = 3.14\nend)
   expect_to_s "PAIR : Tuple(Int32, String) = {1, \"x\"}"
   expect_to_s "TYPED : ::Int32 = -5"
+  expect_to_s "::FOO : Int64 = 123"
+  expect_to_s "::Foo::BAR : Int64 = 123"
   expect_to_s %(foo(1, (2 + 3), bar: (4 + 5)))
   expect_to_s %(if (1 + 2\n3)\n  4\nend)
   expect_to_s "%x(whoami)", "`whoami`"

--- a/spec/compiler/semantic/const_spec.cr
+++ b/spec/compiler/semantic/const_spec.cr
@@ -33,6 +33,25 @@ describe "Semantic: const" do
       CRYSTAL
   end
 
+  it "types a typed constant on a global path target" do
+    assert_type(<<-CRYSTAL) { int64 }
+      ::FOO : Int64 = 123
+
+      ::FOO
+      CRYSTAL
+  end
+
+  it "types a typed constant on a global qualified path target" do
+    assert_type(<<-CRYSTAL) { int64 }
+      module Foo
+      end
+
+      ::Foo::BAR : Int64 = 123
+
+      ::Foo::BAR
+      CRYSTAL
+  end
+
   it "rejects non storable types" do
     assert_error <<-CRYSTAL, "can't use Int as the type of a constant yet"
       FOO : Int = 1

--- a/spec/compiler/semantic/const_spec.cr
+++ b/spec/compiler/semantic/const_spec.cr
@@ -33,6 +33,13 @@ describe "Semantic: const" do
       CRYSTAL
   end
 
+  it "rejects non storable types" do
+    assert_error <<-CRYSTAL, "can't use Int as the type of a constant yet"
+      FOO : Int = 1
+      FOO
+      CRYSTAL
+  end
+
   it "errors when typed constant initializer doesn't match declared type" do
     assert_error <<-CRYSTAL, "type must be Int64"
       FOO : Int64 = "hello"

--- a/spec/compiler/semantic/const_spec.cr
+++ b/spec/compiler/semantic/const_spec.cr
@@ -11,6 +11,35 @@ describe "Semantic: const" do
     assert_type("CONST = 1; CONST") { int32 }
   end
 
+  it "types a constant with explicit type declaration" do
+    assert_type("FOO : Int64 = 123; FOO") { int64 }
+  end
+
+  it "autocasts the initializer of a typed constant" do
+    assert_type(<<-CRYSTAL) { int64 }
+      FOO : Int64 = 123
+      FOO
+      CRYSTAL
+  end
+
+  it "types a typed constant on a path target" do
+    assert_type(<<-CRYSTAL) { int64 }
+      module Foo
+      end
+
+      Foo::BAR : Int64 = 123
+
+      Foo::BAR
+      CRYSTAL
+  end
+
+  it "errors when typed constant initializer doesn't match declared type" do
+    assert_error <<-CRYSTAL, "type must be Int64"
+      FOO : Int64 = "hello"
+      FOO
+      CRYSTAL
+  end
+
   it "types a nested constant" do
     assert_type("class Foo; A = 1; end; Foo::A") { int32 }
   end

--- a/spec/std/crystal/syntax_highlighter/colorize_spec.cr
+++ b/spec/std/crystal/syntax_highlighter/colorize_spec.cr
@@ -127,6 +127,9 @@ describe Crystal::SyntaxHighlighter::Colorize do
 
     it_highlights "Set{1, 2, 3}", %(\e[36mSet\e[39m{\e[35m1\e[39m, \e[35m2\e[39m, \e[35m3\e[39m})
 
+    # Typed constant declarations (#13443)
+    it_highlights "FOO : Int64 = 123", %(\e[36mFOO\e[39m : \e[36mInt64\e[39m \e[91m=\e[39m \e[35m123\e[39m)
+
     it_highlights "foo(/Name: /)", %(foo(\e[93m/Name: /\e[39m))
     it_highlights "foo[/Name: /]", %(foo[\e[93m/Name: /\e[39m])
     it_highlights "Foo{/Name: /}", %(\e[36mFoo\e[39m{\e[93m/Name: /\e[39m})

--- a/spec/std/crystal/syntax_highlighter/html_spec.cr
+++ b/spec/std/crystal/syntax_highlighter/html_spec.cr
@@ -122,6 +122,9 @@ describe Crystal::SyntaxHighlighter::HTML do
 
     it_highlights "Set{1, 2, 3}", %(<span class="t">Set</span>{<span class="n">1</span>, <span class="n">2</span>, <span class="n">3</span>})
 
+    # Typed constant declarations (#13443)
+    it_highlights "FOO : Int64 = 123", %(<span class="t">FOO</span> : <span class="t">Int64</span> <span class="o">=</span> <span class="n">123</span>)
+
     it_highlights "foo(/Name: /)", %(foo(<span class="s">/Name: /</span>))
     it_highlights "foo[/Name: /]", %(foo[<span class="s">/Name: /</span>])
     it_highlights "Foo{/Name: /}", %(<span class="t">Foo</span>{<span class="s">/Name: /</span>})

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -204,7 +204,7 @@ module Crystal
           # inferred type conforms to T.
           if declared_type_node = type.declared_type
             declared_type = type_visitor.lookup_type(declared_type_node)
-            MainVisitor.check_automatic_cast(@program, type.value, declared_type)
+            check_automatic_cast(type.value, declared_type)
             value_type = type.value.type
             unless value_type.implements?(declared_type)
               declared_type_node.raise "constant #{type} type must be #{declared_type}, not #{value_type}"

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -199,6 +199,18 @@ module Crystal
           type_visitor.inside_constant = true
           type.value.accept type_visitor
 
+          # When the constant was declared with `FOO : T = value`, resolve T
+          # and either autocast a number/symbol literal or assert the value's
+          # inferred type conforms to T.
+          if declared_type_node = type.declared_type
+            declared_type = type_visitor.lookup_type(declared_type_node)
+            MainVisitor.check_automatic_cast(@program, type.value, declared_type)
+            value_type = type.value.type
+            unless value_type.implements?(declared_type)
+              declared_type_node.raise "constant #{type} type must be #{declared_type}, not #{value_type}"
+            end
+          end
+
           type.fake_def = const_def
           type.visitor = self
           type.used = true
@@ -450,6 +462,11 @@ module Crystal
         var.var = class_var
         class_var.thread_local = true if thread_local
 
+        node.type = @program.nil
+      when Path
+        # Typed constant declarations (`FOO : Int64 = 123`) are fully handled
+        # by TopLevelVisitor + visit(Path) on the constant lookup; here we
+        # just give the node a type so binding continues to work.
         node.type = @program.nil
       else
         raise "Bug: unexpected var type: #{var.class}"

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -464,9 +464,6 @@ module Crystal
 
         node.type = @program.nil
       when Path
-        # Typed constant declarations (`FOO : Int64 = 123`) are fully handled
-        # by TopLevelVisitor + visit(Path) on the constant lookup; here we
-        # just give the node a type so binding continues to work.
         node.type = @program.nil
       else
         raise "Bug: unexpected var type: #{var.class}"

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -879,6 +879,8 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   end
 
   def type_assign(target : Path, value, node, declared_type : ASTNode? = nil)
+    node.raise "constant type declaration requires a value" unless value
+
     # We are inside the assign, so we go outside it to check if we are inside an outer expression
     @exp_nest -= 1
     check_outside_exp node, "declare constant"
@@ -1036,9 +1038,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     when Var
       @vars[var.name] = MetaVar.new(var.name)
     when Path
-      value = node.value
-      node.raise "constant type declaration requires a value" unless value
-      type_assign(var, value, node, node.declared_type)
+      type_assign(var, node.value, node, node.declared_type)
       return false
     end
 

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -1037,7 +1037,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       @vars[var.name] = MetaVar.new(var.name)
     elsif var.is_a?(Path)
       value = node.value
-      node.raise "constant type declaration requires an initializer" unless value
+      node.raise "constant type declaration requires a value" unless value
       type_assign(var, value, node, declared_type: node.declared_type)
       return false
     end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -1032,13 +1032,13 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   end
 
   def visit(node : TypeDeclaration)
-    var = node.var
-    if var.is_a?(Var)
+    case var = node.var
+    when Var
       @vars[var.name] = MetaVar.new(var.name)
-    elsif var.is_a?(Path)
+    when Path
       value = node.value
       node.raise "constant type declaration requires a value" unless value
-      type_assign(var, value, node, declared_type: node.declared_type)
+      type_assign(var, value, node, node.declared_type)
       return false
     end
 

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -878,7 +878,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     false
   end
 
-  def type_assign(target : Path, value, node)
+  def type_assign(target : Path, value, node, declared_type : ASTNode? = nil)
     # We are inside the assign, so we go outside it to check if we are inside an outer expression
     @exp_nest -= 1
     check_outside_exp node, "declare constant"
@@ -894,6 +894,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     end
 
     const = Const.new(@program, scope, name, value)
+    const.declared_type = declared_type
     const.private = true if target.visibility.private?
 
     process_annotations(annotations) do |annotation_type, ann|
@@ -1031,8 +1032,14 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   end
 
   def visit(node : TypeDeclaration)
-    if (var = node.var).is_a?(Var)
+    var = node.var
+    if var.is_a?(Var)
       @vars[var.name] = MetaVar.new(var.name)
+    elsif var.is_a?(Path)
+      value = node.value
+      node.raise "constant type declaration requires an initializer" unless value
+      type_assign(var, value, node, declared_type: node.declared_type)
+      return false
     end
 
     # Because the value could be using macro expansions
@@ -1225,7 +1232,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     end
   end
 
-  def check_ditto(node : Def | Assign | FunDef | Const | Macro, location : Location?) : Nil
+  def check_ditto(node : Def | Assign | FunDef | Const | Macro | TypeDeclaration, location : Location?) : Nil
     return if !@program.wants_doc?
 
     if stripped_doc = node.doc.try &.strip

--- a/src/compiler/crystal/semantic/type_declaration_visitor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_visitor.cr
@@ -170,6 +170,9 @@ class Crystal::TypeDeclarationVisitor < Crystal::SemanticVisitor
       declare_instance_var(node, var)
     when ClassVar
       declare_class_var(node, var, false)
+    when Path
+      # Typed-constant declarations (`FOO : Int64 = 123`) are processed by
+      # `TopLevelVisitor#visit(TypeDeclaration)`; nothing to do here.
     else
       raise "Unexpected TypeDeclaration var type: #{var.class}"
     end

--- a/src/compiler/crystal/semantic/type_declaration_visitor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_visitor.cr
@@ -171,8 +171,7 @@ class Crystal::TypeDeclarationVisitor < Crystal::SemanticVisitor
     when ClassVar
       declare_class_var(node, var, false)
     when Path
-      # Typed-constant declarations (`FOO : Int64 = 123`) are processed by
-      # `TopLevelVisitor#visit(TypeDeclaration)`; nothing to do here.
+      # nothing to do
     else
       raise "Unexpected TypeDeclaration var type: #{var.class}"
     end

--- a/src/compiler/crystal/semantic/type_declaration_visitor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_visitor.cr
@@ -171,7 +171,8 @@ class Crystal::TypeDeclarationVisitor < Crystal::SemanticVisitor
     when ClassVar
       declare_class_var(node, var, false)
     when Path
-      # nothing to do
+      var_type = lookup_type(node.declared_type)
+      check_declare_var_type(node, var_type, "a constant")
     else
       raise "Unexpected TypeDeclaration var type: #{var.class}"
     end

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -2194,10 +2194,7 @@ module Crystal
       when Global
         var.name.size
       when Path
-        # `FOO : Type = value` or `Foo::BAR : Type = value` (#13443).
-        size = var.names.sum(&.size) + (var.names.size - 1) * 2
-        size += 2 if var.global?
-        size
+        var.name_size
       else
         raise "can't happen"
       end

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -2193,6 +2193,11 @@ module Crystal
         var.name.size
       when Global
         var.name.size
+      when Path
+        # `FOO : Type = value` or `Foo::BAR : Type = value` (#13443).
+        size = var.names.sum(&.size) + (var.names.size - 1) * 2
+        size += 2 if var.global?
+        size
       else
         raise "can't happen"
       end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1229,7 +1229,7 @@ module Crystal
           set_visibility parse_var_or_call
         end
       when .const?
-        parse_generic_or_custom_literal
+        parse_const_or_type_declaration
       when .instance_var?
         if @in_macro_expression && @token.value == "@type"
           @is_macro_def = true
@@ -1311,6 +1311,29 @@ module Crystal
       type = parse_generic(expression: true)
       skip_space
       parse_custom_literal type
+    end
+
+    # Parses a constant path that might be the target of a typed-constant
+    # declaration (e.g. `FOO : Int64 = 1` or `Foo::BAR : Int64 = 1`). When the
+    # path is followed by `: Type = value` we produce a `TypeDeclaration`;
+    # otherwise we fall back to the normal path/custom-literal parsing.
+    def parse_const_or_type_declaration
+      type = parse_generic(expression: true)
+      skip_space
+
+      if @no_type_declaration == 0 && @token.type.op_colon? && type.is_a?(Path)
+        next_token_skip_space_or_newline
+        var_type = parse_bare_proc_type
+        skip_space
+        unless @token.type.op_eq?
+          raise "expected '=' for constant type declaration"
+        end
+        next_token_skip_space_or_newline
+        value = parse_op_assign_no_control
+        TypeDeclaration.new(type, var_type, value).at(type).at_end(value)
+      else
+        parse_custom_literal type
+      end
     end
 
     def parse_custom_literal(type)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1229,7 +1229,7 @@ module Crystal
           set_visibility parse_var_or_call
         end
       when .const?
-        parse_const_or_type_declaration
+        parse_const
       when .instance_var?
         if @in_macro_expression && @token.value == "@type"
           @is_macro_def = true
@@ -1307,17 +1307,7 @@ module Crystal
       end
     end
 
-    def parse_generic_or_custom_literal
-      type = parse_generic(expression: true)
-      skip_space
-      parse_custom_literal type
-    end
-
-    # Parses a constant path that might be the target of a typed-constant
-    # declaration (e.g. `FOO : Int64 = 1` or `Foo::BAR : Int64 = 1`). When the
-    # path is followed by `: Type = value` we produce a `TypeDeclaration`;
-    # otherwise we fall back to the normal path/custom-literal parsing.
-    def parse_const_or_type_declaration
+    def parse_const
       type = parse_generic(expression: true)
       space_after_name = @token.type.space?
       skip_space

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1319,9 +1319,13 @@ module Crystal
     # otherwise we fall back to the normal path/custom-literal parsing.
     def parse_const_or_type_declaration
       type = parse_generic(expression: true)
+      space_after_name = @token.type.space?
       skip_space
 
       if @no_type_declaration == 0 && @token.type.op_colon? && type.is_a?(Path)
+        unless space_after_name
+          warnings.add_warning_at(@token.location, "space required before colon in type declaration (run `crystal tool format` to fix this)")
+        end
         next_token_skip_space_or_newline
         var_type = parse_bare_proc_type
         skip_space

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1261,13 +1261,15 @@ module Crystal
       end
     end
 
-    def parse_type_declaration(var)
+    def parse_type_declaration(var, is_const = false)
       next_token_skip_space_or_newline
       var_type = parse_bare_proc_type
       skip_space
       if @token.type.op_eq?
         next_token_skip_space_or_newline
         value = parse_op_assign_no_control
+      elsif is_const
+        raise "expected '=' for constant type declaration"
       end
       TypeDeclaration.new(var, var_type, value).at(var).at_end(value || var_type)
     end
@@ -1316,15 +1318,7 @@ module Crystal
         unless space_after_name
           warnings.add_warning_at(@token.location, "space required before colon in type declaration (run `crystal tool format` to fix this)")
         end
-        next_token_skip_space_or_newline
-        var_type = parse_bare_proc_type
-        skip_space
-        unless @token.type.op_eq?
-          raise "expected '=' for constant type declaration"
-        end
-        next_token_skip_space_or_newline
-        value = parse_op_assign_no_control
-        TypeDeclaration.new(type, var_type, value).at(type).at_end(value)
+        parse_type_declaration(type, is_const: true)
       else
         parse_custom_literal type
       end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1309,8 +1309,8 @@ module Crystal
       end
     end
 
-    def parse_const
-      type = parse_generic(expression: true)
+    def parse_const(global = false, location = @token.location)
+      type = parse_generic global, location, expression: true
       space_after_name = @token.type.space?
       skip_space
 
@@ -5059,9 +5059,7 @@ module Crystal
       when .ident?
         set_visibility parse_var_or_call global: true, location: location
       when .const?
-        ident = parse_generic global: true, location: location, expression: true
-        skip_space
-        parse_custom_literal ident
+        parse_const global: true, location: location
       else
         unexpected_token
       end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3320,6 +3320,12 @@ module Crystal
   # saved under a type types like any other type.
   class Const < NamedType
     property value : ASTNode
+
+    # Type restriction declared with `FOO : Int64 = 123` syntax. The value's
+    # inferred type must conform to this and number/symbol literals autocast
+    # to it.
+    property declared_type : ASTNode?
+
     property fake_def : Def?
     property? used = false
     property? visited = false


### PR DESCRIPTION
## Summary
Resolves #13443. Allows constant declarations to carry an explicit type, e.g.

```crystal
FOO : Int64        = 123
FOO : LibC::SizeT  = 123      # autocasts to platform's size_t
Foo::BAR : Int64   = 123      # qualified path also works
```

A number/symbol-literal initializer autocasts to the declared type, mirroring how `@x : Int64 = 123` and `@@x : Int64 = 123` already work for instance and class variables. A non-conforming initializer is rejected, and a typed constant must always have an initializer.

## Why this matters
Without this, the only way to pin a constant to a platform-specific or non-default integer type is `FOO = LibC::SizeT.new(123)`, which (a) reads awkwardly and (b) prevents the compiler from inferring `FOO` as a compile-time constant — it emits a runtime `~FOO:init` initializer ([godbolt](https://godbolt.org/z/M6z8nsYxv)). The new syntax keeps the value a literal, so constant folding still kicks in.

## Behaviour

| Input | Result |
|-------|--------|
| `FOO : Int64 = 123` | typed `Int64` |
| `FOO : LibC::SizeT = 123` | autocasts to platform `SizeT` |
| `Foo::BAR : Int64 = 123` | qualified path |
| `FOO : Int64 = "hello"` | error: `constant FOO type must be Int64, not String` |
| `FOO : Int64` (no initializer) | error: `expected '=' for constant type declaration` |

The issue explicitly leaves uninitialized typed-constants out of scope; that stays disallowed.

## Implementation
- **Parser** (`syntax/parser.cr`): new `parse_const_or_type_declaration`. After `parse_generic` produces the path, if a `:` follows we parse `Type [= value]` and emit a `TypeDeclaration` whose `var` is the `Path`. Without an `=` we raise immediately, so the no-initializer case never reaches semantic.
- **AST**: no new node — `TypeDeclaration#var` is already typed as `ASTNode`, so it can already hold a `Path`. `Crystal::Macros::TypeDeclaration#var` therefore naturally returns the `Path` for the macro API (as called out in the issue).
- **`Const`** (`types.cr`): adds `property declared_type : ASTNode?`.
- **`TopLevelVisitor`** (`semantic/top_level_visitor.cr`): `visit(TypeDeclaration)` recognises a `Path` var and routes through `type_assign(target : Path, ..., declared_type:)`, which stores the declaration on the new `Const`. `check_ditto`'s accepted union picks up `TypeDeclaration` so existing doc handling still applies.
- **`TypeDeclarationVisitor`** / **`MainVisitor#visit(TypeDeclaration)`**: harmless no-op branches for `Path` so other passes don't choke on the new shape.
- **`MainVisitor#visit(Path)`**: when resolving a `Const` that has a `declared_type`, we look it up via `lookup_type`, run `MainVisitor.check_automatic_cast` (the same helper class-var initialisers use), and then assert the inferred value type `implements?` the declared one.
