### PR TITLE
Add Module#prepend

### DIFF
--- a/spec/compiler/codegen/prepend_spec.cr
+++ b/spec/compiler/codegen/prepend_spec.cr
@@ -1,0 +1,138 @@
+require "../../spec_helper"
+
+describe "Code gen: prepend" do
+  it "prepended module method takes precedence over the class's own" do
+    run(<<-CRYSTAL).to_string.should eq("from prepended")
+      require "prelude"
+
+      module Prepended
+        def foo
+          "from prepended"
+        end
+      end
+
+      class Subclass
+        prepend Prepended
+
+        def foo
+          "from class"
+        end
+      end
+
+      Subclass.new.foo
+      CRYSTAL
+  end
+
+  it "super inside a prepended method calls the class's own method" do
+    run(<<-CRYSTAL).to_string.should eq("Prepended -> Subclass")
+      require "prelude"
+
+      module Prepended
+        def foo
+          "Prepended -> " + super
+        end
+      end
+
+      class Subclass
+        prepend Prepended
+
+        def foo
+          "Subclass"
+        end
+      end
+
+      Subclass.new.foo
+      CRYSTAL
+  end
+
+  it "follows Ruby's full chain: prepend -> class -> include -> superclass" do
+    # This is the example from issue #10504.
+    run(<<-CRYSTAL).to_string.should eq("Prepend\nSubclass\nIncluded\nBase\n")
+      require "prelude"
+
+      class Base
+        def foo
+          "Base"
+        end
+      end
+
+      module Included
+        def foo
+          "Included\\n" + super
+        end
+      end
+
+      module Prepend
+        def foo
+          "Prepend\\n" + super
+        end
+      end
+
+      class Subclass < Base
+        prepend Prepend
+        include Included
+
+        def foo
+          "Subclass\\n" + super
+        end
+      end
+
+      Subclass.new.foo + "\\n"
+      CRYSTAL
+  end
+
+  it "uses the last-prepended module first (multiple prepends)" do
+    run(<<-CRYSTAL).to_string.should eq("P2\nP1\nC\n")
+      require "prelude"
+
+      module P1
+        def foo
+          "P1\\n" + super
+        end
+      end
+
+      module P2
+        def foo
+          "P2\\n" + super
+        end
+      end
+
+      class C
+        prepend P1
+        prepend P2
+
+        def foo
+          "C"
+        end
+      end
+
+      C.new.foo + "\\n"
+      CRYSTAL
+  end
+
+  it "lets the prepended module observe an instance variable set in the class" do
+    run(<<-CRYSTAL).to_i.should eq(42)
+      require "prelude"
+
+      module Prepended
+        def value
+          super * 2
+        end
+      end
+
+      class C
+        prepend Prepended
+
+        def initialize
+          @x = 21
+        end
+
+        def value
+          @x
+        end
+      end
+
+      C.new.value
+      CRYSTAL
+  end
+end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -883,6 +883,9 @@ module Crystal
     it_parses "extend Foo", Extend.new("Foo".path)
     it_parses "extend Foo\nif true; end", [Extend.new("Foo".path), If.new(true.bool)]
     it_parses "extend self", Extend.new(Self.new)
+    it_parses "prepend Foo", Prepend.new("Foo".path)
+    it_parses "prepend Foo\nif true; end", [Prepend.new("Foo".path), If.new(true.bool)]
+    it_parses "class Foo prepend Bar end", ClassDef.new("Foo".path, [Prepend.new("Bar".path)] of ASTNode)
 
     it_parses "unless foo; 1; end", Unless.new("foo".call, 1.int32)
     it_parses "unless foo; 1; else; 2; end", Unless.new("foo".call, 1.int32, 2.int32)

--- a/spec/compiler/semantic/prepend_spec.cr
+++ b/spec/compiler/semantic/prepend_spec.cr
@@ -1,0 +1,76 @@
+require "../../spec_helper"
+
+describe "Semantic: prepend" do
+  it "registers the prepended module on the type and surfaces it through the macro `ancestors`" do
+    result = semantic(<<-CRYSTAL)
+      module Prepended
+      end
+
+      class Subclass
+        prepend Prepended
+
+        def foo
+          1
+        end
+      end
+      CRYSTAL
+
+    subclass = result.program.types["Subclass"].as(Crystal::ModuleType)
+    subclass.prepended_modules.try(&.map(&.to_s)).should eq(["Prepended"])
+    subclass.ancestors_with_prepended.map(&.to_s).first.should eq("Prepended")
+  end
+
+  it "method call on instance resolves to prepended module's def" do
+    assert_type(<<-CRYSTAL) { int32 }
+      module Prepended
+        def foo
+          1
+        end
+      end
+
+      class Subclass
+        prepend Prepended
+
+        def foo
+          'a'
+        end
+      end
+
+      Subclass.new.foo
+      CRYSTAL
+  end
+
+  it "errors with cyclic prepend" do
+    assert_error <<-CRYSTAL, "cyclic prepend detected"
+      module Foo
+      end
+
+      module Bar
+        prepend Foo
+      end
+
+      module Foo
+        prepend Bar
+      end
+      CRYSTAL
+  end
+
+  it "errors when prepending self" do
+    assert_error <<-CRYSTAL, "cyclic prepend detected"
+      module Foo
+        prepend self
+      end
+      CRYSTAL
+  end
+
+  it "rejects prepend of a non-module" do
+    assert_error <<-CRYSTAL, "is not a module, it's a class"
+      class Foo
+      end
+
+      class Bar
+        prepend Foo
+      end
+      CRYSTAL
+  end
+end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -994,6 +994,15 @@ module Crystal
       false
     end
 
+    def visit(node : Prepend)
+      node.hook_expansions.try &.each do |hook|
+        accept hook
+      end
+
+      @last = llvm_nil
+      false
+    end
+
     def visit(node : If)
       if node.truthy?
         accept node.cond

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -3246,6 +3246,10 @@ class Crystal::Repl::Compiler < Crystal::Visitor
     false
   end
 
+  def visit(node : Prepend)
+    false
+  end
+
   def visit(node : Unreachable)
     unreachable("Reached the unreachable", node: node)
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2350,11 +2350,11 @@ module Crystal
     end
 
     def self.ancestors(type)
-      ancestors = type.ancestors
+      ancestors = type.ancestors_with_prepended
       if ancestors.empty?
         empty_no_return_array
       else
-        ArrayLiteral.map(type.ancestors) { |ancestor| TypeNode.new(ancestor) }
+        ArrayLiteral.map(ancestors) { |ancestor| TypeNode.new(ancestor) }
       end
     end
 

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -664,19 +664,63 @@ class Crystal::Call
     # TODO: do this better
     lookup = enclosing_def.owner
 
+    scope_type = parent_visitor.scope
+    prepended = scope_type.prepended_modules
+
+    in_initialize = enclosing_def.name == "initialize"
+
+    # Detect `super` issued from inside a prepended module. The MRO at the
+    # current point is `..rest_prepended.., scope, ..scope.ancestors..`,
+    # and we must search scope's own defs without re-entering its
+    # `prepended_modules` (otherwise we'd recurse into ourselves).
+    if prepended
+      idx =
+        case lookup
+        when NonGenericModuleType
+          prepended.index(lookup)
+        when GenericModuleType
+          prepended.index { |m| m.is_a?(GenericModuleInstanceType) && m.generic_type == lookup }
+        else
+          nil
+        end
+
+      if idx
+        rest_prepended = prepended[(idx + 1)..]
+        rest_prepended.each do |mod|
+          if mod.lookup_first_def(enclosing_def.name, block)
+            return lookup_matches_in_type(mod, arg_types, named_args_types, scope, enclosing_def.name, !in_initialize, search_in_toplevel: false, with_autocast: with_autocast)
+          end
+        end
+
+        # Now search scope's own defs (without going back through
+        # prepended_modules) and then its regular ancestors.
+        if scope_type.has_def_without_parents?(enclosing_def.name)
+          return lookup_matches_in_type(scope_type, arg_types, named_args_types, scope, enclosing_def.name, false, search_in_toplevel: false, with_autocast: with_autocast)
+        end
+
+        scope_type.ancestors.each do |ancestor|
+          if ancestor.lookup_first_def(enclosing_def.name, block)
+            return lookup_matches_in_type(ancestor, arg_types, named_args_types, scope, enclosing_def.name, !in_initialize, search_in_toplevel: false, with_autocast: with_autocast)
+          end
+        end
+
+        return lookup_matches_in_type(scope_type.ancestors.last? || scope_type, arg_types, named_args_types, scope, enclosing_def.name, !in_initialize, search_in_toplevel: false, with_autocast: with_autocast)
+      end
+    end
+
     case lookup
     when VirtualType
       parents = lookup.base_type.ancestors
     when NonGenericModuleType
-      ancestors = parent_visitor.scope.ancestors
+      ancestors = scope_type.ancestors
       index_of_ancestor = ancestors.index!(lookup)
       parents = ancestors[index_of_ancestor + 1..-1]
     when GenericModuleType
-      ancestors = parent_visitor.scope.ancestors
+      ancestors = scope_type.ancestors
       index_of_ancestor = ancestors.index! { |ancestor| ancestor.is_a?(GenericModuleInstanceType) && ancestor.generic_type == lookup }
       parents = ancestors[index_of_ancestor + 1..-1]
     when GenericType
-      ancestors = parent_visitor.scope.ancestors
+      ancestors = scope_type.ancestors
       index_of_ancestor = ancestors.index { |ancestor| ancestor.is_a?(GenericClassInstanceType) && ancestor.generic_type == lookup }
       if index_of_ancestor
         parents = ancestors[index_of_ancestor + 1..-1]
@@ -686,8 +730,6 @@ class Crystal::Call
     else
       parents = lookup.ancestors
     end
-
-    in_initialize = enclosing_def.name == "initialize"
 
     if parents && parents.size > 0
       parents.each_with_index do |parent, i|

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -161,6 +161,11 @@ module Crystal
       node
     end
 
+    def transform(node : Prepend)
+      node.hook_expansions.try &.map! &.transform self
+      node
+    end
+
     def transform(node : Expressions)
       if exp = node.single_expression?
         return exp.transform(self)

--- a/src/compiler/crystal/semantic/fix_missing_types.cr
+++ b/src/compiler/crystal/semantic/fix_missing_types.cr
@@ -29,6 +29,11 @@ class Crystal::FixMissingTypes < Crystal::Visitor
     false
   end
 
+  def visit(node : Prepend)
+    node.hook_expansions.try &.each &.accept self
+    false
+  end
+
   def visit(node : Macro)
     false
   end

--- a/src/compiler/crystal/semantic/hooks.cr
+++ b/src/compiler/crystal/semantic/hooks.cr
@@ -108,6 +108,24 @@ module Crystal
     include HookExpansionsContainer
   end
 
+  class Prepend
+    # Hook expansions correspond to the `prepended` hook
+    #
+    # ```
+    # module Moo
+    #   macro prepended
+    #     puts 1
+    #   end
+    # end
+    #
+    # class Foo
+    #   # At this point the `prepended` hook is triggered
+    #   prepend Moo
+    # end
+    # ```
+    include HookExpansionsContainer
+  end
+
   class Def
     # Hook expansions correspond to the `method_added` hook
     #

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -69,6 +69,24 @@ module Crystal
 
   class Type
     def lookup_matches(signature, owner = self, path_lookup = self, matches_array = nil, analyze_all = false)
+      is_new = owner.metaclass? && signature.name == "new"
+
+      # Prepended modules sit *before* this type in the method-resolution
+      # order. Search them first so their defs win over the type's own.
+      my_prepended =
+        if is_new
+          instance_type.prepended_modules.try &.map(&.metaclass.as(Type))
+        else
+          prepended_modules
+        end
+      if my_prepended
+        my_prepended.each do |mod|
+          matches = mod.lookup_matches(signature, owner, mod, matches_array, analyze_all: analyze_all)
+          return matches if matches.cover_all?
+          matches_array = matches.matches
+        end
+      end
+
       matches = lookup_matches_without_parents(signature, owner, path_lookup, matches_array, analyze_all: analyze_all)
       return matches if matches.cover_all?
 
@@ -76,7 +94,6 @@ module Crystal
 
       cover = matches.cover
 
-      is_new = owner.metaclass? && signature.name == "new"
       if is_new
         # For a `new` method we need to do this in case a `new` is defined
         # in a module type

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -157,6 +157,13 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     false
   end
 
+  def visit(node : Prepend)
+    check_outside_exp node, "prepend"
+    node.hook_expansions.try &.each &.accept self
+    node.set_type(@program.nil)
+    false
+  end
+
   def visit(node : Alias)
     check_outside_exp node, "declare alias"
     node.set_type(@program.nil)
@@ -257,7 +264,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
   def nesting_exp?(node)
     case node
     when Expressions, LibDef, CStructOrUnionDef, ClassDef, ModuleDef, FunDef, Def, Macro,
-         Alias, Include, Extend, EnumDef, VisibilityModifier, MacroFor, MacroIf, MacroExpression,
+         Alias, Include, Extend, Prepend, EnumDef, VisibilityModifier, MacroFor, MacroIf, MacroExpression,
          FileNode, TypeDeclaration, Require, AnnotationDef
       false
     else

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -549,6 +549,12 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     false
   end
 
+  def visit(node : Prepend)
+    check_outside_exp node, "prepend"
+    prepend_in current_type, node, :prepended
+    false
+  end
+
   def visit(node : LibDef)
     check_outside_exp node, "declare lib"
 
@@ -1146,6 +1152,34 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       # This will make the location show on that node instead of the `raise` call.
       ex.inner = Crystal::MacroRaiseException.for_node node, ex.message
 
+      raise ex
+    rescue ex : TypeException
+      node.raise "at '#{kind}' hook", ex
+    end
+  end
+
+  def prepend_in(current_type, node, kind : HookKind)
+    node_name = node.name
+
+    type = lookup_type(node_name)
+    case type
+    when GenericModuleType
+      node.raise "generic type arguments must be specified when prepending #{type}"
+    when .module?
+      # OK
+    else
+      node_name.raise "#{type} is not a module, it's a #{type.type_desc}"
+    end
+
+    if node_name.is_a?(Path)
+      @program.check_deprecated_type(type, node_name)
+    end
+
+    begin
+      current_type.as(ModuleType).prepend type
+      run_hooks hook_type(type), current_type, kind, node
+    rescue ex : MacroRaiseException
+      ex.inner = Crystal::MacroRaiseException.for_node node, ex.message
       raise ex
     rescue ex : TypeException
       node.raise "at '#{kind}' hook", ex

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -2593,6 +2593,36 @@ module Crystal
     end
   end
 
+  # `prepend Foo` — mixes a module into the inheriting class such that the
+  # module's methods take precedence over the class's own. The prepended
+  # module sits *before* the class itself in the method lookup chain.
+  class Prepend < ASTNode
+    property name : ASTNode
+
+    def initialize(@name)
+    end
+
+    def accept_children(visitor)
+      @name.accept visitor
+    end
+
+    def clone_without_location
+      Prepend.new(@name)
+    end
+
+    def end_location
+      @end_location || @name.end_location
+    end
+
+    def_equals_and_hash name
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Prepend[", "]") do
+        name.pretty_print(pp)
+      end
+    end
+  end
+
   class LibDef < ASTNode
     property name : Path
     property doc : String?

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -797,6 +797,10 @@ module Crystal
           end
         when 'r'
           case next_char
+          when 'e'
+            if char_sequence?('p', 'e', 'n', 'd')
+              return check_ident_or_keyword(:prepend, start)
+            end
           when 'i'
             if char_sequence?('v', 'a', 't', 'e')
               return check_ident_or_keyword(:private, start)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1144,6 +1144,12 @@ module Crystal
                 parse_extend
               end
             end
+          when .prepend?
+            check_type_declaration do
+              check_not_inside_def("can't prepend") do
+                parse_prepend
+              end
+            end
           when .class?
             check_type_declaration do
               check_not_inside_def("can't define class") do
@@ -3109,6 +3115,10 @@ module Crystal
       parse_include_or_extend Extend
     end
 
+    def parse_prepend
+      parse_include_or_extend Prepend
+    end
+
     def parse_include_or_extend(klass)
       location = @token.location
 
@@ -4221,7 +4231,7 @@ module Crystal
         # so they are invalid internal name.
         when .begin?, Keyword::NIL, .true?, .false?, .yield?, .with?, .abstract?,
              .def?, .macro?, .require?, .case?, .select?, .if?, .unless?, .include?,
-             .extend?, .class?, .struct?, .module?, .enum?, .while?, .until?, .return?,
+             .extend?, .prepend?, .class?, .struct?, .module?, .enum?, .while?, .until?, .return?,
              .next?, .break?, .lib?, .fun?, .alias?, .pointerof?, .sizeof?, .offsetof?,
              .instance_sizeof?, .typeof?, .private?, .protected?, .asm?, .out?,
              .self?, Keyword::IN, .end?, .alignof?, .instance_alignof?
@@ -4233,7 +4243,7 @@ module Crystal
         case keyword
         when "begin", "nil", "true", "false", "yield", "with", "abstract",
              "def", "macro", "require", "case", "select", "if", "unless", "include",
-             "extend", "class", "struct", "module", "enum", "while", "until", "return",
+             "extend", "prepend", "class", "struct", "module", "enum", "while", "until", "return",
              "next", "break", "lib", "fun", "alias", "pointerof", "sizeof", "offsetof",
              "instance_sizeof", "typeof", "private", "protected", "asm", "out",
              "self", "in", "end", "alignof", "instance_alignof"

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1345,6 +1345,12 @@ module Crystal
       false
     end
 
+    def visit(node : Prepend)
+      @str << "prepend "
+      node.name.accept self
+      false
+    end
+
     def visit(node : And)
       to_s_binary node, "&&"
     end

--- a/src/compiler/crystal/syntax/token.cr
+++ b/src/compiler/crystal/syntax/token.cr
@@ -41,6 +41,7 @@ module Crystal
     OFFSETOF
     OUT
     POINTEROF
+    PREPEND
     PRIVATE
     PROTECTED
     REQUIRE

--- a/src/compiler/crystal/syntax/transformer.cr
+++ b/src/compiler/crystal/syntax/transformer.cr
@@ -384,6 +384,11 @@ module Crystal
       node
     end
 
+    def transform(node : Prepend)
+      node.name = node.name.transform(self)
+      node
+    end
+
     def transform(node : RangeLiteral)
       node.from = node.from.transform(self)
       node.to = node.to.transform(self)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -3475,6 +3475,13 @@ module Crystal
       false
     end
 
+    def visit(node : Prepend)
+      write_keyword :prepend, " "
+      accept node.name
+
+      false
+    end
+
     def visit(node : LibDef)
       @inside_lib += 1
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -381,6 +381,12 @@ module Crystal
       nil
     end
 
+    # See `ModuleType#prepended_modules`. Returns `nil` for types that
+    # cannot have prepended modules.
+    def prepended_modules
+      nil
+    end
+
     def ancestors
       ancestors = [] of Type
       collect_ancestors(ancestors)
@@ -392,6 +398,22 @@ module Crystal
         ancestors << parent
         parent.collect_ancestors(ancestors)
       end
+    end
+
+    # Like `ancestors` but also includes modules brought in via `prepend`.
+    # The prepended modules sit at the head, in walk order (most recently
+    # prepended first), followed by the type itself implicitly and then
+    # the regular `ancestors`. The type itself is *not* present in the
+    # returned list (matching `ancestors`).
+    def ancestors_with_prepended
+      result = [] of Type
+      prepended_modules.try &.each do |mod|
+        result << mod
+        mod.prepended_modules.try { |inner| inner.each { |im| result << im } }
+        mod.collect_ancestors(result)
+      end
+      collect_ancestors(result)
+      result
     end
 
     # Returns this type's superclass, or `nil` if it doesn't have one
@@ -406,12 +428,29 @@ module Crystal
     end
 
     def lookup_defs(name : String, all_defs : Array(Def), lookup_ancestors_for_new : Bool? = false)
+      is_new = name == "new"
+      is_new_or_initialize = is_new || name == "initialize"
+
+      # Prepended modules sit *before* this type in the method-resolution
+      # order, so consult them first and short-circuit `new`/`initialize`
+      # discovery just like the rest of the chain.
+      my_prepended =
+        if is_new
+          instance_type.prepended_modules.try &.map(&.metaclass.as(Type))
+        else
+          prepended_modules
+        end
+      my_prepended.try &.each do |mod|
+        old_size = all_defs.size
+        mod.lookup_defs(name, all_defs, lookup_ancestors_for_new)
+        break if is_new_or_initialize && all_defs.size > old_size
+      end
+      return if is_new_or_initialize && !all_defs.empty?
+
       self.defs.try &.[name]?.try &.each do |item|
         all_defs << item.def unless all_defs.find(&.same?(item.def))
       end
 
-      is_new = name == "new"
-      is_new_or_initialize = is_new || name == "initialize"
       return if is_new_or_initialize && !all_defs.empty?
 
       if !is_new_or_initialize || (lookup_ancestors_for_new || self.lookup_new_in_ancestors?)
@@ -856,6 +895,7 @@ module Crystal
     Inherited
     Included
     Extended
+    Prepended
     MethodAdded
   end
 
@@ -908,6 +948,11 @@ module Crystal
     getter hooks : Array(Hook)?
     getter(parents) { [] of Type }
 
+    # Modules brought in via `prepend`. They sit *before* this type itself in
+    # the ancestor chain, so their defs take precedence over this type's own
+    # defs (Ruby's `Module#prepend` semantics).
+    getter(prepended_modules) { [] of Type }
+
     def add_def(a_def)
       a_def.owner = self
 
@@ -949,6 +994,8 @@ module Crystal
         return add_hook :included, a_macro
       when "extended"
         return add_hook :extended, a_macro
+      when "prepended"
+        return add_hook :prepended, a_macro
       when "method_added"
         return add_hook :method_added, a_macro, args_size: 1
       when "method_missing"
@@ -1002,6 +1049,34 @@ module Crystal
 
       unless parents.includes?(mod)
         parents.insert 0, mod
+        mod.add_including_type(self)
+      end
+    end
+
+    # See `prepended_modules`.
+    def prepend(mod)
+      generic_module = mod.is_a?(GenericModuleInstanceType) ? mod.generic_type : mod
+
+      if generic_module == self
+        raise TypeException.new "cyclic prepend detected"
+      end
+
+      # Walk both the regular ancestor chain *and* the prepended chain so a
+      # cycle through `prepend` (e.g. `A.prepend(B)` followed by
+      # `B.prepend(A)`) is caught.
+      generic_module.ancestors_with_prepended.each do |ancestor|
+        if ancestor == self || (ancestor.is_a?(GenericModuleInstanceType) && ancestor.generic_type == self)
+          raise TypeException.new "cyclic prepend detected"
+        end
+      end
+
+      modules = prepended_modules
+      unless modules.includes?(mod)
+        # Insert at the front so that the most-recently prepended module sits
+        # closest to the type itself in the lookup order: walking
+        # `prepended_modules` left-to-right gives the order they should be
+        # consulted *before* `self.defs`.
+        modules.unshift mod
         mod.add_including_type(self)
       end
     end


### PR DESCRIPTION
## Summary
Resolves #10504. Adds Ruby-style `Module#prepend` to Crystal: a module mixed in with `prepend` sits *before* the class in the method-resolution order, so its methods wrap the class's own and can call `super` to delegate to them.

```crystal
class Base
  def foo; puts "Base"; end
end

module Included
  def foo; puts "Included"; super; end
end

module Prepend
  def foo; puts "Prepend"; super; end
end

class Subclass < Base
  prepend Prepend
  include Included
  def foo; puts "Subclass"; super; end
end

Subclass.new.foo
# Prepend
# Subclass
# Included
# Base
```

Matches the example from the issue body exactly.

## Behaviour
- `prepend Mod` inside a class/module/struct body inserts `Mod` at the head of an internal `prepended_modules` list. The most-recently prepended module wins.
- Method dispatch walks `prepended_modules` *before* `self.defs`, then `parents` as today.
- `super` from a prepended method walks the rest of the prepended chain, then the scope itself, then the regular ancestor chain — preserving Ruby's MRO semantics.
- `super` from the class itself remains unchanged (it never re-enters the prepended modules).
- Cyclic prepends are caught (`module A; prepend B; end; module B; prepend A; end` → error).
- A new `prepended` macro hook fires when `prepend Mod` is processed, mirroring the existing `included`/`extended` hooks.
- Macro `TypeNode#ancestors` now returns the full MRO with prepended modules at the head (matching Ruby's `Module#ancestors`).
- `prepend` is reserved as a keyword (`def prepend` and `arr.prepend` style identifiers in user code are no longer allowed at the call site — `arr.prepend` as a method call still works since it's not at statement position).

## Implementation notes

- **`Crystal::Prepend < ASTNode`** mirrors `Include`/`Extend`. Visitor / transformer / formatter / `to_s` overloads added for the new node.
- **`ModuleType#prepended_modules`** — new array, paralleling `parents`. `ModuleType#prepend(mod)` mirrors `#include(mod)` with cyclic-detection that walks both regular ancestors and prepended ancestors.
- **`Type#ancestors`** is unchanged — does *not* include prepended modules. This keeps `super` from a non-prepended method's resolution trivial. A new `Type#ancestors_with_prepended` exposes the full MRO; that's what the macro layer uses.
- **`lookup_matches` (method_lookup.cr)** consults `prepended_modules` before falling through to `lookup_matches_without_parents` and then to `parents`.
- **`lookup_super_matches` (call.cr)** detects when the enclosing method's owner is a prepended module and walks: remaining prepended modules → scope's own defs (using `search_in_parents: false` so it doesn't re-enter the prepended chain) → scope's regular ancestors.
- **Hook plumbing**: `HookKind::Prepended`, `add_macro` recognises `macro prepended`, `top_level_visitor#prepend_in` mirrors `include_in`.

## Test plan
- [x] New parser specs for `prepend Foo`, `prepend Foo\nif true; end`, and `class Foo prepend Bar end`
- [x] New `spec/compiler/codegen/prepend_spec.cr`: precedence, single & chained `super`, the issue's full Ruby example, multiple-prepend ordering, and instance-var access through `super`
- [x] New `spec/compiler/semantic/prepend_spec.cr`: ancestors registration, type-resolution precedence, cyclic-prepend error, `prepend self` error, prepend-of-class error

## Deferred / not in scope
- After-the-fact `Module.prepend(other)` (post-definition) is not supported — Crystal classes/modules are reopenable but type structure is finalized at class body level.
- Prepend into a generic-module instance hasn't been exercised — the cyclic check handles it but the lookup paths haven't been smoke-tested.
- The `prepend` keyword reservation is a small breaking change for any code defining `def prepend` at the top level. If that's a concern, this can be relaxed (e.g. by making `prepend` only a keyword in class/module body context), but for parity with `include` it's reserved everywhere.