### PR TITLE
Add generic alias support

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1884,6 +1884,9 @@ module Crystal
 
     it_parses "alias Foo = Bar", Alias.new("Foo".path, "Bar".path)
     it_parses "alias Foo::Bar = Baz", Alias.new(Path.new("Foo", "Bar"), "Baz".path)
+    it_parses "alias Foo(T) = Bar(T)", Alias.new("Foo".path, Generic.new("Bar".path, ["T".path] of ASTNode), ["T"])
+    it_parses "alias Maybe(T) = T | Nil", Alias.new("Maybe".path, Crystal::Union.new(["T".path, "Nil".path] of ASTNode), ["T"])
+    it_parses "alias Pair(K, V) = Tuple(K, V)", Alias.new("Pair".path, Generic.new("Tuple".path, ["K".path, "V".path] of ASTNode), ["K", "V"])
     assert_syntax_error "alias Foo?"
 
     it_parses "def foo\n1\nend\nif 1\nend", [Def.new("foo", body: 1.int32), If.new(1.int32)] of ASTNode

--- a/spec/compiler/semantic/alias_spec.cr
+++ b/spec/compiler/semantic/alias_spec.cr
@@ -8,6 +8,95 @@ describe "Semantic: alias" do
       CRYSTAL
   end
 
+  describe "generic alias" do
+    it "resolves a generic alias used as a metaclass expression" do
+      assert_type(<<-CRYSTAL) { union_of(int32, nil_type).metaclass }
+        alias Maybe(T) = T | Nil
+        Maybe(Int32)
+        CRYSTAL
+    end
+
+    it "resolves a multi-parameter generic alias substituting both type vars" do
+      assert_type(<<-CRYSTAL) { generic_class("TwoTypes", types["String"], types["Int32"]) }
+        class TwoTypes(K, V)
+          def initialize(@k : K, @v : V); end
+        end
+
+        alias StringKeyed(V) = TwoTypes(String, V)
+
+        StringKeyed(Int32).new("a", 1)
+        CRYSTAL
+    end
+
+    it "errors with the wrong number of type arguments" do
+      assert_error <<-CRYSTAL, "wrong number of type vars"
+        alias Pair(K, V) = Tuple(K, V)
+        x : Pair(Int32) = uninitialized Pair(Int32)
+        CRYSTAL
+    end
+
+    it "uses a generic alias as a method argument restriction" do
+      assert_type(<<-CRYSTAL) { int32 }
+        class MyBox(T)
+          def initialize(@value : T); end
+          def value; @value; end
+        end
+
+        alias StringKeyed(V) = MyBox(V)
+
+        def take(x : StringKeyed(Int32))
+          x.value
+        end
+
+        take(MyBox(Int32).new(42))
+        CRYSTAL
+    end
+
+    it "uses a generic alias inside a `forall T` restriction" do
+      assert_type(<<-CRYSTAL) { int32 }
+        alias Boxed(T) = T
+
+        def unbox(x : Boxed(T)) forall T
+          x
+        end
+
+        unbox(1)
+        CRYSTAL
+    end
+
+    it "unifies a generic alias body via forall" do
+      assert_type(<<-CRYSTAL) { tuple_of([int32, char]) }
+        class Pair(K, V)
+          def initialize(@k : K, @v : V); end
+          def to_tuple
+            {@k, @v}
+          end
+        end
+
+        alias KV(K, V) = Pair(K, V)
+
+        def take(x : KV(K, V)) forall K, V
+          x.to_tuple
+        end
+
+        take(Pair(Int32, Char).new(1, 'a'))
+        CRYSTAL
+    end
+
+    it "preserves recursive (non-generic) aliases" do
+      result = assert_type(<<-CRYSTAL) { int32 }
+        class Foo(T)
+        end
+
+        alias Alias = Int32 | Foo(Alias)
+        1
+        CRYSTAL
+      mod = result.program
+      a = mod.types["Alias"].as(AliasType)
+      a.aliased_type.should_not be_nil
+    end
+  end
+
   it "declares alias inside type" do
     assert_type(<<-CRYSTAL) { types["Int32"].metaclass }
       alias Foo::Bar = Int32

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -250,6 +250,29 @@ module Crystal
       end
 
       instance_type = node.name.type.instance_type
+
+      # Handle generic aliases (`alias Foo(T) = ...`): resolve by
+      # substituting the supplied type arguments into the alias body. The
+      # Generic node's type follows the usual rule: when used inside a
+      # type-args position (restrictions, type declarations) it is the
+      # instance type; outside (value position) it is the metaclass.
+      if instance_type.is_a?(AliasType) && instance_type.type_vars
+        alias_tv_names = instance_type.type_vars.not_nil!
+        if alias_tv_names.size != node.type_vars.size
+          node.wrong_number_of "type vars", instance_type, node.type_vars.size, alias_tv_names.size
+        end
+        resolved_args = node.type_vars.map do |tv|
+          if tv.is_a?(NumberLiteral)
+            tv.as(TypeVar)
+          else
+            tv.type.virtual_type.as(TypeVar)
+          end
+        end
+        resolved = instance_type.instantiate(resolved_args)
+        node.type = check_type_in_type_args(resolved.virtual_type)
+        return false
+      end
+
       unless instance_type.is_a?(GenericType)
         node.raise "#{instance_type} is not a generic type, it's a #{instance_type.type_desc}"
       end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -256,8 +256,7 @@ module Crystal
       # Generic node's type follows the usual rule: when used inside a
       # type-args position (restrictions, type declarations) it is the
       # instance type; outside (value position) it is the metaclass.
-      if instance_type.is_a?(AliasType) && instance_type.type_vars
-        alias_tv_names = instance_type.type_vars.not_nil!
+      if instance_type.is_a?(AliasType) && (alias_tv_names = instance_type.type_vars)
         if alias_tv_names.size != node.type_vars.size
           node.wrong_number_of "type vars", instance_type, node.type_vars.size, alias_tv_names.size
         end

--- a/src/compiler/crystal/semantic/recursive_struct_checker.cr
+++ b/src/compiler/crystal/semantic/recursive_struct_checker.cr
@@ -39,7 +39,7 @@ class Crystal::RecursiveStructChecker
       check_recursive_instance_var_container(target, type, checked, path)
     end
 
-    if type.is_a?(AliasType) && !type.simple?
+    if type.is_a?(AliasType) && !type.simple? && !type.type_vars
       target = type
       checked = Set(Type).new
       path = [] of Var | Type

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -1,5 +1,29 @@
 require "../syntax/ast"
+require "../syntax/transformer"
 require "../types"
+
+module Crystal
+  # Walks an AST node replacing single-name `Path`s that match a registered
+  # type-parameter name with the supplied substitution node. Used to expand
+  # a generic alias's body during overload matching.
+  class AliasGenericArgSubstituter < Transformer
+    def initialize(@substitutions : Hash(String, ASTNode))
+    end
+
+    def substitute(node : ASTNode) : ASTNode
+      node.transform(self)
+    end
+
+    def transform(node : Path) : ASTNode
+      if !node.global? && node.names.size == 1
+        if replacement = @substitutions[node.names.first]?
+          return replacement.clone.at(node.location)
+        end
+      end
+      node
+    end
+  end
+end
 
 # Here is the logic for deciding two things:
 #
@@ -935,8 +959,18 @@ module Crystal
     end
 
     def restrict(other : Generic, context)
-      # Special case: consider `Union(X, Y, ...)` the same as `X | Y | ...`
       generic_type = get_generic_type(other, context)
+
+      # Generic alias (`alias Foo(T) = ...`): expand the alias body with
+      # the supplied type arguments and re-enter `restrict` on the
+      # expanded restriction. This makes generic aliases transparent for
+      # overload matching including `forall T` unification.
+      if generic_type.is_a?(AliasType) && (alias_type_vars = generic_type.type_vars)
+        substituted = expand_generic_alias_restriction(generic_type, alias_type_vars, other)
+        return restrict(substituted, context)
+      end
+
+      # Special case: consider `Union(X, Y, ...)` the same as `X | Y | ...`
       if generic_type.is_a?(GenericUnionType)
         types = [] of Type
 
@@ -1150,6 +1184,17 @@ module Crystal
 
     def restrict(other : Generic, context)
       generic_type = get_generic_type(other, context)
+
+      # Generic alias: rewrite the restriction by substituting the alias's
+      # type-parameter names with the arguments at the use site, then
+      # re-enter `restrict` with the expanded restriction. This lets the
+      # existing matching machinery (including `forall` unification) handle
+      # generic aliases the same way as a hand-written restriction would.
+      if generic_type.is_a?(AliasType) && (alias_type_vars = generic_type.type_vars)
+        substituted = expand_generic_alias_restriction(generic_type, alias_type_vars, other)
+        return restrict(substituted, context)
+      end
+
       generic_type = generic_type.remove_alias if generic_type.is_a? AliasType
       return super unless generic_type == self.generic_type
 
@@ -1829,4 +1874,22 @@ private def get_generic_type(node, context)
   else
     name.type
   end
+end
+
+# Expands a `Foo(T1, T2, ...)` restriction whose `Foo` is a generic alias
+# (`alias Foo(A, B) = ...`) into the alias's body with the alias's type
+# parameter names substituted by the supplied argument AST nodes.
+# The returned node can then be fed back into `restrict` and unified the
+# same way as a hand-written restriction.
+private def expand_generic_alias_restriction(alias_type, alias_type_vars, generic_node)
+  if alias_type_vars.size != generic_node.type_vars.size
+    generic_node.wrong_number_of "type vars", alias_type, generic_node.type_vars.size, alias_type_vars.size
+  end
+
+  substitutions = {} of String => Crystal::ASTNode
+  alias_type_vars.each_with_index do |name, i|
+    substitutions[name] = generic_node.type_vars[i]
+  end
+
+  Crystal::AliasGenericArgSubstituter.new(substitutions).substitute(alias_type.value.clone)
 end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -15,10 +15,8 @@ module Crystal
     end
 
     def transform(node : Path) : ASTNode
-      if !node.global? && node.names.size == 1
-        if replacement = @substitutions[node.names.first]?
-          return replacement.clone.at(node.location)
-        end
+      if (name = node.single_name?) && (replacement = @substitutions[name]?)
+        return replacement.clone.at(node.location)
       end
       node
     end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -1889,5 +1889,7 @@ private def expand_generic_alias_restriction(alias_type, alias_type_vars, generi
     substitutions[name] = generic_node.type_vars[i]
   end
 
-  Crystal::AliasGenericArgSubstituter.new(substitutions).substitute(alias_type.value.clone)
+  Crystal::AliasGenericArgSubstituter
+    .new(substitutions)
+    .substitute(alias_type.value.clone)
 end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -369,7 +369,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       end
     end
 
-    alias_type = AliasType.new(@program, scope, name, node.value)
+    alias_type = AliasType.new(@program, scope, name, node.value, node.type_vars)
     process_annotations(annotations) do |annotation_type, ann|
       alias_type.add_annotation(annotation_type, ann)
     end

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -224,6 +224,18 @@ class Crystal::Type
             node.wrong_number_of "type vars", instance_type, node.type_vars.size, instance_type.type_vars.size
           end
         end
+      when AliasType
+        # A generic alias: validate arity, then instantiate below.
+        alias_type_vars = instance_type.type_vars
+        unless alias_type_vars
+          node.raise "#{instance_type} is not a generic alias, it's a #{instance_type.type_desc}"
+        end
+        if node.named_args
+          node.raise "can only use named arguments with NamedTuple"
+        end
+        if alias_type_vars.size != node.type_vars.size
+          node.wrong_number_of "type vars", instance_type, node.type_vars.size, alias_type_vars.size
+        end
       else
         node.raise "#{instance_type} is not a generic type, it's a #{instance_type.type_desc}"
       end
@@ -299,6 +311,8 @@ class Crystal::Type
           # union types only when the type is instantiated.
           # TODO: check that everything is a type
           MixedUnionType.new(@root.program, type_vars.map(&.as(Type)))
+        elsif instance_type.is_a?(AliasType)
+          instance_type.instantiate(type_vars)
         else
           instance_type.as(GenericType).instantiate(type_vars)
         end

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -2801,10 +2801,13 @@ module Crystal
   class Alias < ASTNode
     property name : Path
     property value : ASTNode
+    # Names of the type parameters for a generic alias, e.g. `alias Foo(T) = ...`.
+    # `nil` for a plain `alias Foo = ...`.
+    property type_vars : Array(String)?
     property doc : String?
     property visibility = Visibility::Public
 
-    def initialize(@name : Path, @value : ASTNode)
+    def initialize(@name : Path, @value : ASTNode, @type_vars : Array(String)? = nil)
     end
 
     def accept_children(visitor)
@@ -2812,10 +2815,10 @@ module Crystal
     end
 
     def clone_without_location
-      Alias.new(@name.clone, @value.clone)
+      Alias.new(@name.clone, @value.clone, @type_vars.dup)
     end
 
-    def_equals_and_hash @name, @value
+    def_equals_and_hash @name, @value, @type_vars
 
     def pretty_print(pp) : Nil
       pp_type(pp, "Alias[", "]") do

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -5992,6 +5992,12 @@ module Crystal
       name = parse_path
 
       skip_space
+      type_vars, splat_index = parse_type_vars
+      if splat_index
+        raise "splat type parameters are not supported in alias definitions"
+      end
+      skip_space
+
       check :OP_EQ
       next_token_skip_space_or_newline
 
@@ -5999,7 +6005,7 @@ module Crystal
       end_location = value.end_location
       skip_space
 
-      alias_node = Alias.new(name, value).at_end(end_location)
+      alias_node = Alias.new(name, value, type_vars).at_end(end_location)
       alias_node.doc = doc
       alias_node
     end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1702,6 +1702,14 @@ module Crystal
     def visit(node : Alias)
       @str << "alias "
       node.name.accept self
+      if type_vars = node.type_vars
+        @str << '('
+        type_vars.each_with_index do |tv, i|
+          @str << ", " if i > 0
+          @str << tv
+        end
+        @str << ')'
+      end
       @str << " = "
       node.value.accept self
       false

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4079,6 +4079,23 @@ module Crystal
       end
 
       skip_space
+
+      if node.is_a?(Alias) && (type_vars = node.type_vars)
+        write_token :OP_LPAREN
+        skip_space_or_newline
+        type_vars.each_with_index do |tv, i|
+          if i > 0
+            write_token :OP_COMMA
+            skip_space_or_newline
+            write " "
+          end
+          write tv
+          next_token_skip_space_or_newline
+        end
+        write_token :OP_RPAREN
+        skip_space
+      end
+
       write_token " ", :OP_EQ, " "
       skip_space_or_newline
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2851,7 +2851,6 @@ module Crystal
       resolved
     end
 
-
     def includes_type?(other)
       remove_indirection.includes_type?(other)
     end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2749,7 +2749,20 @@ module Crystal
     property! aliased_type : Type
     getter? simple
 
-    def initialize(program, namespace, name, @value : ASTNode)
+    # The body AST for this alias (right-hand side of `alias Foo = ...`).
+    getter value : ASTNode
+
+    # Type-parameter names for a generic alias (e.g. `alias Pair(K, V) = ...`).
+    # `nil` for a regular non-generic alias.
+    getter type_vars : Array(String)?
+
+    # Cache of instantiated generic-alias bodies keyed by the array of
+    # supplied type arguments (`[Int32, String]`). The value is the type the
+    # body resolves to with those substitutions applied. Only used when
+    # `type_vars` is non-nil.
+    private getter(generic_instances) { {} of Array(TypeVar) => Type }
+
+    def initialize(program, namespace, name, @value : ASTNode, @type_vars : Array(String)? = nil)
       super(program, namespace, name)
       @simple = true
     end
@@ -2798,18 +2811,53 @@ module Crystal
 
     def process_value
       return if @value_processed
+      # A generic alias's body cannot be resolved without knowing the
+      # actual type arguments; it is resolved on demand via `#instantiate`.
+      return if @type_vars
       @value_processed = true
       @aliased_type = namespace.lookup_type(@value,
         allow_typeof: false,
         find_root_generic_type_parameters: false)
     end
 
+    # Resolves the alias body with the given type arguments substituted for
+    # this alias's type parameters. Results are cached per argument tuple
+    # so each `alias Foo(T) = Bar(T)` instantiation site builds at most one
+    # resolved type.
+    def instantiate(type_args : Array(TypeVar)) : Type
+      tv_names = @type_vars
+      unless tv_names
+        raise TypeException.new "can't instantiate non-generic alias #{self}"
+      end
+      if type_args.size != tv_names.size
+        raise TypeException.new "wrong number of type vars for #{self} (given #{type_args.size}, expected #{tv_names.size})"
+      end
+
+      if cached = generic_instances[type_args]?
+        return cached
+      end
+
+      free_vars = {} of String => TypeVar
+      tv_names.each_with_index do |name, i|
+        free_vars[name] = type_args[i]
+      end
+
+      resolved = namespace.lookup_type(@value,
+        allow_typeof: false,
+        free_vars: free_vars,
+        find_root_generic_type_parameters: false)
+
+      generic_instances[type_args] = resolved
+      resolved
+    end
+
+
     def includes_type?(other)
       remove_indirection.includes_type?(other)
     end
 
     def type_desc
-      "alias"
+      @type_vars ? "generic alias" : "alias"
     end
   end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2814,6 +2814,7 @@ module Crystal
       # A generic alias's body cannot be resolved without knowing the
       # actual type arguments; it is resolved on demand via `#instantiate`.
       return if @type_vars
+
       @value_processed = true
       @aliased_type = namespace.lookup_type(@value,
         allow_typeof: false,


### PR DESCRIPTION
## Summary
Resolves #2803. `alias` now accepts type parameters, so platform-, container-, and option-style aliases can be defined parametrically instead of being copy-pasted:

```crystal
alias Maybe(T) = T | Nil
alias StringKeyed(V) = Hash(String, V)
alias Pair(K, V) = Tuple(K, V)

x : Maybe(Int32) = 1                # resolves to Int32 | Nil
y = StringKeyed(Int32).new          # resolves to Hash(String, Int32)
```

Generic aliases work everywhere a regular type can appear: type declarations, restrictions, generic instantiations, and — importantly — inside `forall T` restrictions.

## What's preserved
The existing recursive-alias support is **untouched**. The classic JSON-style recursive alias still works exactly as before:

```crystal
alias Json = Int32 | String | Hash(String, Json) | Array(Json)
```

A regression test for `Alias = Int32 | Foo(Alias)` is in the new spec block.

## What's new

| Use site | Behaviour |
|---|---|
| `Bar(Int32)` as a metaclass expression | resolves to the body with `T = Int32` |
| `: Bar(Int32)` as a restriction / type declaration | matches the substituted type |
| `def f(x : Bar(T)) forall T` | unifies `T` from the argument |
| Wrong arity (`Pair(Int32)` for a 2-param alias) | clear "wrong number of type vars" error |
| Splat in alias type params (`alias Foo(*T) = ...`) | rejected at parse time — no defined semantics yet |

## Implementation

- **AST** (`Alias`): adds `type_vars : Array(String)?`.
- **Parser**: `parse_alias` calls `parse_type_vars` after the name. Splat params raise.
- **`AliasType`**: holds `type_vars` and a `generic_instances` cache. `process_value` early-returns for generic aliases (the body is unresolvable without arguments); `instantiate(type_args)` builds `free_vars` from the type parameters, runs the body through `lookup_type`, and caches the result per argument tuple.
- **Type lookup** (`type_lookup.cr#lookup(Generic)`) and **MainVisitor#visit(Generic)**: when a `Generic` node's name resolves to an `AliasType` with `type_vars`, validate arity and call `instantiate`. `MainVisitor` uses `check_type_in_type_args` so the resulting node carries the instance type inside restrictions and the metaclass outside.
- **Overload matcher** (`restrictions.cr`): a new `expand_generic_alias_restriction` helper clones the alias body and substitutes each `Path("T")` with the matching argument AST node, then re-enters `restrict`. Wired into both `Type#restrict(Generic)` and `GenericInstanceType#restrict(Generic)`. This is what makes `forall T` work — the matcher sees the expanded restriction and unifies as it always would.
- **`recursive_struct_checker`**: skips generic aliases (they don't have a single resolved `aliased_type`).
- **`to_s` / `formatter`**: emit `Foo(T, U)` when type params are present.

## Test plan
- [x] Parser specs for `alias Foo(T) = Bar(T)`, `alias Maybe(T) = T | Nil`, `alias Pair(K, V) = Tuple(K, V)`
- [x] Semantic specs in `alias_spec.cr`:
  - Metaclass expression `Maybe(Int32)` → `(Int32 | Nil).class`
  - Multi-parameter substitution `StringKeyed(Int32)` → `TwoTypes(String, Int32)`
  - Wrong arity error
  - Generic alias as a method-argument restriction
  - Generic alias inside `forall T` restriction (`Boxed(T) = T`, `unbox(1)` resolves T = Int32)
  - Generic alias body with multiple unified type vars (`KV(K, V) = Pair(K, V)`)
  - Recursive non-generic alias preserved (regression test for `Alias = Int32 | Foo(Alias)`)

## Out of scope
- Splat parameters in generic aliases (`alias Foo(*T) = ...`) — rejected at parse, semantics unclear