### PR TITLE
Fix interpreter multidispatch cache collision

### DIFF
--- a/spec/compiler/interpreter/multidispatch_spec.cr
+++ b/spec/compiler/interpreter/multidispatch_spec.cr
@@ -435,5 +435,45 @@ describe Crystal::Repl::Interpreter do
         foo("b" || nil)
       CRYSTAL
     end
+
+    it "doesn't reuse a cached dispatch chain when a later call site sees a wider target_defs set (#16810)" do
+      # Two call sites against the same union type. The second site
+      # instantiates `G(C)`, which adds an extra `target_def` to the
+      # multidispatch. With the old cache key (`obj_type` + `signature`
+      # only) both sites would share a dispatch chain built for the
+      # first one, and the new type would fall through into the
+      # `unreachable` else branch.
+      interpret(<<-CRYSTAL).should eq(42 * 1000 + 42)
+        module M1; end
+        module M2; end
+
+        class G(T)
+          include M1
+          def my_check
+            42
+          end
+        end
+
+        alias V = Int32 | M1 | M2 | Nil
+
+        class C
+          include M2
+        end
+
+        class Object
+          def my_check
+            0
+          end
+        end
+
+        v1 = G(M2 | C).new.as(V)
+        res1 = v1.my_check
+
+        v2 = G(C).new.as(V)
+        res2 = v2.my_check
+
+        res1 &* 1000 &+ res2
+      CRYSTAL
+    end
   end
 end

--- a/src/compiler/crystal/interpreter/context.cr
+++ b/src/compiler/crystal/interpreter/context.cr
@@ -4,7 +4,14 @@ require "./repl"
 # program. For example, it includes the memory region to store constants
 # and class variables, what are all the know symbols, and a few more things.
 class Crystal::Repl::Context
-  record MultidispatchKey, obj_type : Type, call_signature : CallSignature
+  # The cache key for synthetic dispatch methods. `target_def_ids` must be
+  # part of the key because two call sites with the same `obj_type` and
+  # signature can resolve to different `target_defs` when intervening code
+  # instantiates new types that fall under the union — without it, the
+  # second site reuses the first's dispatch chain and any newly resolved
+  # type falls through the `else` branch into "Reached the unreachable"
+  # (#16810).
+  record MultidispatchKey, obj_type : Type, call_signature : CallSignature, target_def_ids : Array(UInt64)
 
   getter program : Program
 

--- a/src/compiler/crystal/interpreter/multidispatch.cr
+++ b/src/compiler/crystal/interpreter/multidispatch.cr
@@ -59,7 +59,7 @@ module Crystal::Repl::Multidispatch
       block: node.block,
     )
 
-    cache_key = Context::MultidispatchKey.new(obj_type, signature)
+    cache_key = Context::MultidispatchKey.new(obj_type, signature, target_defs.map(&.object_id).sort!)
     cached_def = context.multidispatchs[cache_key]?
     return cached_def if cached_def
 


### PR DESCRIPTION
## Summary
Resolves #16810. The interpreter caches synthetic multidispatch methods by `(obj_type, call_signature)`. Two call sites that look identical by that key can resolve to *different* `target_defs` if intervening code instantiates a new concrete type that lands inside the union — the second site then reuses the first's dispatch chain, the new type matches none of its branches, and execution falls through into `raise "unreachable"`.

```crystal
# (Excerpt from #16810; the original reproducer crashes today.)

v1 = G(M2 | C).new.as(V)   # call site 1 — chain built for 4 target_defs
res1 = v1.my_check

v2 = G(C).new.as(V)        # call site 2 — semantic now resolves 5 target_defs
res2 = v2.my_check         # cached chain misses G(C), hits "Reached the unreachable"
```

## Fix
Add the sorted `target_def` object IDs to `Context::MultidispatchKey`. When the resolved set differs at the second site, the key differs and a fresh dispatch chain is built. This is exactly the patch suggested in the issue body, with a comment explaining why the extra component is needed.

```diff
-record MultidispatchKey, obj_type : Type, call_signature : CallSignature
+record MultidispatchKey, obj_type : Type, call_signature : CallSignature, target_def_ids : Array(UInt64)
```

```diff
-cache_key = Context::MultidispatchKey.new(obj_type, signature)
+cache_key = Context::MultidispatchKey.new(obj_type, signature, target_defs.map(&.object_id).sort!)
```

## Test plan
- [x] New regression spec in `spec/compiler/interpreter/multidispatch_spec.cr` running the issue's exact reproducer; the assertion encodes both results into one integer (`res1 * 1000 + res2 = 42042`) so a future regression that hits the "unreachable" else branch fails the test instead of silently returning `0` from one of the two sites.