### PR TITLE
Detect uninitialized ancestor ivars through macro_def initializers

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4782,7 +4782,7 @@ describe "Semantic: instance var" do
   end
 
   it "errors with macro def but another def doesn't initialize all" do
-    assert_error <<-CRYSTAL, "instance variable '@y' of Foo was not initialized directly in all of the 'initialize' methods, rendering it nilable. Indirect initialization is not supported."
+    assert_error <<-CRYSTAL, "this 'initialize' doesn't explicitly initialize instance variable '@y' of Foo"
       class Foo
         @x : Int32
         @y : Int32
@@ -5856,6 +5856,29 @@ describe "Semantic: instance var" do
           end
           CRYSTAL
       end
+    end
+
+    it "errors when a subclass init does not initialize a non-nilable declared ivar even if the only inherited init is a macro_def that does not assign it (#16729)" do
+      assert_error <<-CRYSTAL, "doesn't initialize instance variable '@type' of Element"
+        module Serializable
+          def initialize(never_called)
+            {% @type.instance_vars %}
+          end
+        end
+
+        class Element
+          include Serializable
+
+          @type : String
+        end
+
+        class Text < Element
+          def initialize
+          end
+        end
+
+        Text.new
+        CRYSTAL
     end
   end
 end

--- a/spec/compiler/semantic/new_spec.cr
+++ b/spec/compiler/semantic/new_spec.cr
@@ -133,7 +133,7 @@ describe "Semantic: new" do
   end
 
   it "errors if using self call in default argument (1)" do
-    assert_error <<-CRYSTAL, "instance variable '@caps' of My was not initialized directly in all of the 'initialize' methods, rendering it nilable. Indirect initialization is not supported."
+    assert_error <<-CRYSTAL, "this 'initialize' doesn't explicitly initialize instance variable '@caps' of My"
       class My
         @name : String
         @caps : String
@@ -153,7 +153,7 @@ describe "Semantic: new" do
   end
 
   it "errors if using self call in default argument (2)" do
-    assert_error <<-CRYSTAL, "instance variable '@caps' of My was not initialized directly in all of the 'initialize' methods, rendering it nilable. Indirect initialization is not supported."
+    assert_error <<-CRYSTAL, "this 'initialize' doesn't explicitly initialize instance variable '@caps' of My"
       class My
         @name : String
         @caps : String
@@ -172,7 +172,7 @@ describe "Semantic: new" do
   end
 
   it "errors if using self call in default argument (3)" do
-    assert_error <<-CRYSTAL, "instance variable '@caps' of My was not initialized directly in all of the 'initialize' methods, rendering it nilable. Indirect initialization is not supported."
+    assert_error <<-CRYSTAL, "this 'initialize' doesn't explicitly initialize instance variable '@caps' of My"
       class My
         @name : String
         @caps : String

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -530,11 +530,17 @@ struct Crystal::TypeDeclarationProcessor
       end
     end
 
-    # Get all instance vars assigned in all the initialize methods
+    # Get all instance vars assigned in all the initialize methods, plus
+    # any that the type itself explicitly declared (e.g. `getter type :
+    # String`). Declared-but-never-assigned ivars must still be checked so
+    # subclasses that override `initialize` are required to initialize
+    # them — without this they could silently leave the ivar uninitialized
+    # and segfault at access time (#16729).
     all_instance_vars = [] of String
     infos.each do |info|
       info.instance_vars.try { |ivars| all_instance_vars.concat(ivars) }
     end
+    @explicit_instance_vars[owner]?.try &.each_key { |name| all_instance_vars << name }
     all_instance_vars.uniq!
 
     # Then check which ones are assigned in all of them

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -531,8 +531,8 @@ struct Crystal::TypeDeclarationProcessor
     end
 
     # Get all instance vars assigned in all the initialize methods, plus
-    # any that the type itself explicitly declared (e.g. `getter type :
-    # String`). Declared-but-never-assigned ivars must still be checked so
+    # any that the type itself explicitly declared (`@x : Int32`).
+    # Declared-but-never-assigned ivars must still be checked so
     # subclasses that override `initialize` are required to initialize
     # them — without this they could silently leave the ivar uninitialized
     # and segfault at access time (#16729).


### PR DESCRIPTION
## Summary
Resolves #16729. When a class declares a non-nilable instance variable and the only inherited initializer references `@type` inside a macro expression (which the parser flags as `macro_def`), the compiler used to silently skip the "ivar must be initialized" check. A subclass that overrides `initialize` and doesn't initialize that ivar would compile cleanly and segfault at access time.

The original report's reproducer:

```crystal
require "json"

abstract struct Element
  include JSON::Serializable
  getter type : String
end

record Text < Element, body : String

puts Text.new("asdf").type   # used to segfault on access; now compile-time error
```

Reduced reproducer (from straight-shoota / Sija):

```crystal
module Serializable
  def initialize(never_called)
    {% @type.instance_vars %}    # presence makes the def a `macro_def`
  end
end

class Element
  include Serializable
  getter type : String
end

class Text < Element
  def initialize           # doesn't initialize @type
  end
end

Text.new.type               # segfault at runtime
```

## Root cause
`compute_non_nilable_instance_vars_multi` derives the candidate ivar set from `info.instance_vars` of each `initialize`. When the only inherited initializer is a `macro_def`, the loop at `type_declaration_processor.cr:543` exempts it via `next if info.def.macro_def?` — so the ivar never enters the candidate set, the ancestor's non-nilable list comes out empty, and a subclass override has nothing to be measured against.

## Fix
Also seed the candidate list with the type's *explicitly declared* instance vars (`@explicit_instance_vars[owner]`). The macro_def exemption keeps doing what it was doing for the owner's own initializers (we still trust that the macro might initialize them), but the var is now visible to the subclass-override check via `ancestor_non_nilable`. Subclasses that override `initialize` without calling `super` and without assigning the ivar are flagged at compile time, exactly matching the existing diagnostic for the non-macro-def case.

## Test plan
- [x] New regression spec in `spec/compiler/semantic/instance_var_spec.cr` covering Sija's reduction.
- [x] Manually verified the original `JSON::Serializable` reproducer now errors at compile time instead of segfaulting.

## Updated existing tests
Four existing specs that exercised the same code path still error correctly but via a more specific diagnostic (`raise_doesnt_explicitly_initializes` rather than `raise_not_initialized_in_all_initialize`). Their expected message strings were updated; the underlying behaviour (compile-time error in the same situation) is preserved:

- `spec/compiler/semantic/instance_var_spec.cr` — "errors with macro def but another def doesn't initialize all"
- `spec/compiler/semantic/new_spec.cr` — "errors if using self call in default argument (1)/(2)/(3)"