### PR TITLE
Fix parser silently ignoring `&(...)`, `&[...]`, `&{...}` in assignment

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -323,6 +323,11 @@ module Crystal
 
     assert_syntax_error "b? = 1", %(unexpected token: "=")
     assert_syntax_error "b! = 1", %(unexpected token: "=")
+
+    # #16713
+    assert_syntax_error "x &(a) = 1", %(unexpected token: "=")
+    assert_syntax_error "y &[b] = 2", %(unexpected token: "=")
+    assert_syntax_error "z &{c} = 3", %(unexpected token: "=")
     assert_syntax_error "a, B = 1, 2", "can't assign to constant in multiple assignment"
 
     assert_syntax_error "1 == 2, a = 4"

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -6340,7 +6340,7 @@ module Crystal
         true
       when Call
         return false if node.has_parentheses?
-        no_args = node.args.empty? && node.named_args.nil? && node.block.nil?
+        no_args = node.args.empty? && node.named_args.nil? && node.block.nil? && node.block_arg.nil?
         return true if Lexer.ident?(node.name) && no_args
         node.name == "[]" && (node.args_in_brackets? || no_args)
       else


### PR DESCRIPTION
Fixes #16713.

`x &(a) = 1` was silently parsed as `x = 1`, with the `&(a)`, `&[b]`, `&{c}` portions dropped on the floor. Same for the `[]` / `{}` shapes.

## Root cause

When parsing `x &(a) = 1`:

1. `x` is parsed as a `Call`. The trailing space puts us in `parse_call_args_space_consumed`, which sees `&` followed by `(` (non-whitespace) and calls `parse_call_block_arg`.
2. `parse_call_block_arg` recurses into `parse_op_assign` to parse the block-arg expression. The inner `parse_op_assign` parses `(a)` as a parenthesized `Expressions`, sees `=`, but `can_be_assigned?` rejects `Expressions`, so it bails — leaving the `=` for the outer parser. `block_arg` is set to `(a)`.
3. Back in `parse_var_or_call`, we get `Call("x", block_arg: (a))`.
4. Outer `parse_op_assign` now sees `=`. `can_be_assigned?` checks the `Call`: `args.empty? && named_args.nil? && block.nil?` — all true. **It never looked at `block_arg`.** So it treats the call as assignable, replaces it with `Var.new("x")` (dropping the `block_arg`), and parses `= 1` into a plain `Assign(Var(x), 1)`.

## Fix

Include `node.block_arg.nil?` in the `no_args` check in `can_be_assigned?`. Now the call is correctly recognized as having an argument, so the assignment path is rejected and the outer parser surfaces `unexpected token: "="`.

Legitimate uses like `foo &(a)` (with `foo` taking a block argument) continue to work — they just can't be followed by `= value`.

## Tests

Added three regression tests next to the existing `b? = 1` / `b! = 1` syntax error tests in `spec/compiler/parser/parser_spec.cr`, covering all three shapes from the issue.