### PR TITLE
Add interpreter `upcast_distinct` for `Pointer` to `Pointer`

### DIFF
--- a/spec/compiler/interpreter/pointers_spec.cr
+++ b/spec/compiler/interpreter/pointers_spec.cr
@@ -292,5 +292,19 @@ describe Crystal::Repl::Interpreter do
         end
       CRYSTAL
     end
+
+    it "autocasts a typed pointer to `Pointer(Void)` in a lib struct (#16649)" do
+      interpret(<<-CRYSTAL).should eq(0xDEAD_u64)
+        lib LibFoo
+          struct S
+            data : Pointer(Void)
+          end
+        end
+
+        s = LibFoo::S.new
+        s.data = Pointer(UInt8).new(0xDEAD_u64)
+        s.data.address
+      CRYSTAL
+    end
   end
 end

--- a/src/compiler/crystal/interpreter/cast.cr
+++ b/src/compiler/crystal/interpreter/cast.cr
@@ -204,6 +204,11 @@ class Crystal::Repl::Compiler
     # Nothing
   end
 
+  private def upcast_distinct(node : ASTNode, from : PointerInstanceType, to : PointerInstanceType)
+    # The stack representation of any pointer is the same, so no transformation
+    # is needed (e.g. autocasting `Pointer(UInt8)` to `Pointer(Void)`, #16649).
+  end
+
   # TODO: remove these two because they are probably not needed
   private def upcast_distinct(node : ASTNode, from : NoReturnType, to : Type)
     # Nothing


### PR DESCRIPTION
Fixes #16649.

## Bug

Assigning a typed pointer to a `Pointer(Void)` field of a lib struct crashed the interpreter:

```crystal
lib Foo
  struct S
    data : Pointer(Void)
  end
end

s = Foo::S.new
s.data = Pointer(UInt8).null
```

```
Error: BUG: missing upcast_distinct from Pointer(UInt8) to Pointer(Void)
       (Crystal::PointerInstanceType to Crystal::PointerInstanceType)
```

The compiled (LLVM) path handled this fine — only the interpreter was missing the case.

## Fix

The compiled path matches via `upcast_distinct(value, to_type : GenericClassInstanceType, from_type : Type)` and emits a bitcast (effectively a no-op with opaque pointers).

In the interpreter the on-stack representation of every pointer is the same (machine word sized), so the corresponding overload just has to be present and do nothing. Added in `src/compiler/crystal/interpreter/cast.cr`:

```crystal
private def upcast_distinct(node : ASTNode, from : PointerInstanceType, to : PointerInstanceType)
  # The stack representation of any pointer is the same, so no transformation
  # is needed (e.g. autocasting `Pointer(UInt8)` to `Pointer(Void)`, #16649).
end
```

## Tests

Added a regression test in `spec/compiler/interpreter/pointers_spec.cr` that exercises the lib-struct autocast pattern from the issue and round-trips a known pointer address through the void-pointer field.