### PR TITLE
Preserve `nil_if_read?` across while cond filters

### DIFF
--- a/spec/compiler/semantic/while_spec.cr
+++ b/spec/compiler/semantic/while_spec.cr
@@ -335,6 +335,14 @@ describe "Semantic: while" do
       CRYSTAL
   end
 
+  it "keeps storage of var assigned only in short-circuited cond branch nilable (#16483)" do
+    assert_type(<<-CRYSTAL) { nilable string }
+      until true || (text = "hello")
+      end
+      text
+      CRYSTAL
+  end
+
   it "finds all while cond assign targets in expressions (#10350)" do
     assert_type(<<-CRYSTAL) { int32 }
       a = 1

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2161,6 +2161,7 @@ module Crystal
 
       # `node.body` may reset this status, so we capture them in a set
       # (we don't need the full MetaVars at the moment).
+      #
       # We capture *before* `filter_vars` because filtering may replace a var
       # with a fresh MetaVar that drops the `nil_if_read?` flag, even though
       # the variable could still legitimately be nil on loop exit (#16483).

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2159,14 +2159,17 @@ module Crystal
       after_cond_vars = @vars.dup
       @while_vars = after_cond_vars
 
-      filter_vars cond_type_filters
-
       # `node.body` may reset this status, so we capture them in a set
-      # (we don't need the full MetaVars at the moment)
+      # (we don't need the full MetaVars at the moment).
+      # We capture *before* `filter_vars` because filtering may replace a var
+      # with a fresh MetaVar that drops the `nil_if_read?` flag, even though
+      # the variable could still legitimately be nil on loop exit (#16483).
       after_cond_vars_nil_if_read = Set(String).new
       @vars.each do |name, var|
         after_cond_vars_nil_if_read << name if var.nil_if_read?
       end
+
+      filter_vars cond_type_filters
 
       @type_filters = nil
       @block, old_block = nil, @block


### PR DESCRIPTION
Fixes #16483.

## Bug

```crystal
until true || (text = "hello")
end
pp text
```

```
BUG: trying to downcast (String | Nil) (Crystal::NilableType) <- String (Crystal::NonGenericClassType) (Exception)
  from src/compiler/crystal/codegen/cast.cr:521:5 in 'downcast_distinct'
```

And the variant in the issue body — a function returning `Qux?` that wraps a `hash[tpath]?` lookup the same way — SEGFAULTs at runtime by reading the `@b : Int32` payload as a pointer (`0xdead`).

## Root cause

In `MainVisitor#visit(While)`, the order was:

```crystal
after_cond_vars = @vars.dup
@while_vars = after_cond_vars

filter_vars cond_type_filters            # <-- replaces vars

after_cond_vars_nil_if_read = Set(String).new
@vars.each do |name, var|
  after_cond_vars_nil_if_read << name if var.nil_if_read?
end
```

`filter_vars` substitutes a *fresh* `MetaVar` into `@vars` for every variable touched by the truthy/falsy filter, and the fresh meta var has `nil_if_read?` reset to `false`. So a variable that only ever gets a value in a short-circuited cond branch (`text = "hello"` here) loses its `nil_if_read?` flag before the set is captured.

`merge_while_vars` then skips:

```crystal
if after_cond_vars_nil_if_read.includes?(name)
  after_while_var.nil_if_read = true
  ...
end
```

…so the post-while `after_while_var` ends up with `nil_if_read? == false`. At the read site in `visit(Var)`, the `if var.nil_if_read?` block doesn't run, so the storage `MetaVar` is never `bind_to(@program.nil_var)`. Storage type stays `String`, node type resolves to `(String | Nil)`, and codegen calls `downcast` in the wrong direction (codegen.cr:1400 → cast.cr:297). In the realistic case the storage is sized for one type but read as another → SEGV.

## Fix

Capture `after_cond_vars_nil_if_read` *before* `filter_vars`, since the filter is what loses the flag. The comment also moved so the rationale is in the file.

## Tests

Added a semantic test in `spec/compiler/semantic/while_spec.cr` next to the existing `#10345` `while !(...)` cond-assign test, asserting that `text` types as `String | Nil` (which would have failed at codegen before, but is also the correct semantic result).

- Reduced reproducer (`until true || (text = "hello"); end; pp text`) now prints `nil`.
- Full reproducer from the issue body now prints `nil`.