### PR TITLE
Extract `CRYSTAL_BOOTSTRAP_VERSION` in `bin/ci`

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+: "${CRYSTAL_BOOTSTRAP_VERSION:=1.20.1}"
+
 fail() {
   echo "${*}" >&2
   exit 1
@@ -135,8 +137,8 @@ format() {
 prepare_build() {
   on_linux verify_linux_environment
 
-  on_osx curl -L https://github.com/crystal-lang/crystal/releases/download/1.20.1/crystal-1.20.1-1-darwin-universal.tar.gz -o ~/crystal.tar.gz
-  on_osx 'pushd ~;gunzip -c ~/crystal.tar.gz | tar xopf -;mv crystal-1.20.1-1 crystal;popd'
+  on_osx curl -L "https://github.com/crystal-lang/crystal/releases/download/${CRYSTAL_BOOTSTRAP_VERSION}/crystal-${CRYSTAL_BOOTSTRAP_VERSION}-1-darwin-universal.tar.gz" -o ~/crystal.tar.gz
+  on_osx "pushd ~;gunzip -c ~/crystal.tar.gz | tar xopf -;mv crystal-${CRYSTAL_BOOTSTRAP_VERSION}-1 crystal;popd"
 
   # These commands may take a few minutes to run due to the large size of the repositories.
   # This restriction has been made on GitHub's request because updating shallow
@@ -189,7 +191,7 @@ with_build_env() {
 
   on_linux verify_linux_environment
 
-  export DOCKER_TEST_PREFIX="${DOCKER_TEST_PREFIX:="crystallang/crystal:${CRYSTAL_BOOTSTRAP_VERSION:-1.20.0}"}"
+  export DOCKER_TEST_PREFIX="${DOCKER_TEST_PREFIX:="crystallang/crystal:${CRYSTAL_BOOTSTRAP_VERSION}"}"
 
   case $ARCH in
     aarch64|x86_64)


### PR DESCRIPTION
Using `CRYSTAL_BOOTSTRAP_VERSION` throughout the entire script makes it easier to maintain the bootstrap version in a single config var.