### PR TITLE
Refactor bubbling exceptions from user code in `HTTP::Client#exec(&)`

### DIFF
--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -636,11 +636,28 @@ class HTTP::Client
     set_defaults request
     run_before_request_callbacks(request)
 
-    exec_internal_single(request, ignore_io_error: true, implicit_compression: implicit_compression) do |response|
-      if response
-        return handle_response(response) { yield response }
+    user_exception = nil
+    begin
+      exec_internal_single(request, implicit_compression: implicit_compression) do |response|
+        if response
+          handle_response(response) do
+            result = yield response
+          rescue exc : Exception
+            # Capture exception in user code to re-raise it afterwards, so it
+            # does not interfere with the retry logic in case of an IO error in
+            # user code.
+            user_exception = exc
+            break
+          else
+            return result
+          end
+        end
       end
+    rescue exc : IO::Error
+      raise exc if @io.nil? # do not retry if client was closed
     end
+
+    raise user_exception if user_exception
 
     # Server probably closed the connection, so retry once
     close
@@ -650,16 +667,12 @@ class HTTP::Client
         return handle_response(response) { yield response }
       end
     end
+
     raise IO::EOFError.new("Unexpected end of http response")
   end
 
-  private def exec_internal_single(request, ignore_io_error = false, implicit_compression = false, &)
-    begin
-      send_request(request)
-    rescue ex : IO::Error
-      return yield nil if ignore_io_error && !@io.nil? # ignore_io_error only if client was not closed
-      raise ex
-    end
+  private def exec_internal_single(request, implicit_compression = false, &)
+    send_request(request)
     HTTP::Client::Response.from_io?(io, ignore_body: request.ignore_body?, decompress: implicit_compression) do |response|
       yield response
     end

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -637,7 +637,7 @@ class HTTP::Client
     run_before_request_callbacks(request)
 
     user_exception = nil
-    begin
+    exec_internal_helper do
       exec_internal_single(request, implicit_compression: implicit_compression) do |response|
         if response
           handle_response(response) do
@@ -653,8 +653,6 @@ class HTTP::Client
           end
         end
       end
-    rescue exc : IO::Error
-      raise exc if @io.nil? # do not retry if client was closed
     end
 
     raise user_exception if user_exception
@@ -669,6 +667,13 @@ class HTTP::Client
     end
 
     raise IO::EOFError.new("Unexpected end of http response")
+  end
+
+  # FIXME: This helper is only needed when compiling against Crystal 1.3 or earlier, due to #9769.
+  private def exec_internal_helper(&)
+    yield
+  rescue exc : IO::Error
+    raise exc if @io.nil? # do not retry if client was closed
   end
 
   private def exec_internal_single(request, implicit_compression = false, &)


### PR DESCRIPTION
In the yielding client methods we want to ignore exceptions raised in the user code. But it goes through multiple layers of nested yielding methods which makes this a bit challenging.
The previous attempt was incomplete as it did not take into account connection errors while reading the response. This is less likely, because most broken connections will already raise when we try to write. But there could be scenarios where we only notice a broken connection when we try to read from it.

This patch now rescues all exceptions from user code and cleanly re-raises them afterwards. Thus we can consider all exceptions raised in the scopes between as coming from the HTTP implementation.

The non-yielding client methods already account for read errors as well, so this change aligns the behaviour of both implementations.