### PR TITLE
[CI] Fix tags for nightly docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,14 +359,14 @@ jobs:
             source build.env
             cd docker
             docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-            make all TARBALLS=/tmp/workspace/build/ VERSION=${CRYSTAL_VERSION} PUSH=1
+            make all TARBALLS=/tmp/workspace/build/ VERSION=${CRYSTAL_VERSION} PUSH=1 TAG=crystallang/crystal:${DOCKER_TAG}
       - run:
           name: Smoke tests
           command: |
             cd /tmp/workspace/distribution-scripts
             source build.env
             cd docker
-            make smoke-all VERSION=${CRYSTAL_VERSION}
+            make smoke-all VERSION=${CRYSTAL_VERSION} TAG=crystallang/crystal:${DOCKER_TAG}
 
   dist_snap:
     machine:


### PR DESCRIPTION
It seems there hasn't been an update to nightly docker tag for 5 months.

Nightly images are still built and uploaded, but not tagged as `nightly`. The current ones are tagged `1.21.0-dev`.

This is a regression from https://github.com/crystal-lang/crystal/pull/16488, which is related to the multiarch refactor. It stopped using `$DOCKER_TAG` and defaults to pushing images as `$VERSION` instead.