### PR TITLE
Add splat overloads for `Process.capture`, `.run` and `.new`

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -76,7 +76,12 @@ private def to_ary(tuple)
 end
 
 private def to_splat(cmd)
-  {cmd[0], *cmd[1]}
+  {% if compare_versions(Crystal::VERSION, "1.1.0") >= 0 %}
+    {cmd[0], *cmd[1]}
+  {% else %}
+    args = cmd[1]
+    {cmd[0], args[0], args[1]}
+  {% end %}
 end
 
 # interpreted code doesn't receive SIGCHLD for `#wait` to work (#12241)

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -75,6 +75,10 @@ private def to_ary(tuple)
   [tuple[0]].concat(tuple[1])
 end
 
+private def to_splat(cmd)
+  {cmd[0], *cmd[1]}
+end
+
 # interpreted code doesn't receive SIGCHLD for `#wait` to work (#12241)
 {% if flag?(:interpreted) && !flag?(:win32) %}
   pending Process
@@ -154,6 +158,12 @@ describe Process do
 
     it "accepts tuple args" do
       Process.new({path_search_command[0]}).wait.success?.should be_true
+    end
+  end
+
+  describe ".new (splat)" do
+    it "works" do
+      Process.new(*to_splat(exit_code_command(0))).wait.success?.should be_true
     end
   end
 
@@ -278,9 +288,22 @@ describe Process do
     end
   end
 
+  describe ".run? (splat)" do
+    it "works" do
+      status = Process.run?(*to_splat(exit_code_command(0))).should be_a(Process::Status)
+      status.exit_code.should eq(0)
+    end
+  end
+
   describe ".run" do
     it "waits for the process" do
       Process.run(to_ary(exit_code_command(0))).exit_code.should eq(0)
+    end
+  end
+
+  describe ".run (splat)" do
+    it "works" do
+      status = Process.run(*to_splat(exit_code_command(0))).exit_code.should eq(0)
     end
   end
 
@@ -778,6 +801,13 @@ describe Process do
   end
 
   describe ".capture_result" do
+    it "splat overload" do
+      result = Process.capture_result(*to_splat(shell_command("echo hello")))
+      result.status.success?.should be_true
+      result.output?.should eq "hello#{newline}"
+      result.error?.should eq ""
+    end
+
     it "captures stdout" do
       result = Process.capture_result(to_ary(shell_command("echo hello")))
       result.status.success?.should be_true
@@ -872,6 +902,13 @@ describe Process do
   end
 
   describe ".capture_result?" do
+    it "splat overload" do
+      result = Process.capture_result?(*to_splat(shell_command("echo hello"))).should be_a(Process::Result)
+      result.status.success?.should be_true
+      result.output?.should eq "hello#{newline}"
+      result.error?.should eq ""
+    end
+
     it "captures stdout" do
       result = Process.capture_result?(to_ary(shell_command("echo hello"))).should be_a(Process::Result)
       result.status.success?.should be_true
@@ -966,6 +1003,10 @@ describe Process do
   end
 
   describe ".capture" do
+    it "splat overload" do
+      Process.capture(*to_splat(shell_command("echo hello"))).should eq "hello#{newline}"
+    end
+
     it "captures stdout" do
       Process.capture(to_ary(shell_command("echo hello"))).should eq "hello#{newline}"
     end
@@ -996,6 +1037,10 @@ describe Process do
   end
 
   describe ".capture?" do
+    it "splat overload" do
+      Process.capture?(*to_splat(shell_command("echo hello"))).should eq "hello#{newline}"
+    end
+
     it "captures stdout" do
       Process.capture?(to_ary(shell_command("echo hello"))).should eq "hello#{newline}"
     end
@@ -1006,6 +1051,10 @@ describe Process do
 
     it "returns nil on unsuccessful exit" do
       Process.capture?(to_ary(exit_code_command(1))).should be_nil
+    end
+
+    it "returns nil on unsuccessful exit (splat)" do
+      Process.capture?(*to_splat(exit_code_command(1))).should be_nil
     end
 
     it "raises if process cannot execute" do

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -76,7 +76,9 @@ private def to_ary(tuple)
 end
 
 private def to_splat(cmd)
-  {% if compare_versions(Crystal::VERSION, "1.1.0") >= 0 %}
+  # Splatting in literals was only introduced in Crystal 1.1
+  # FIXME: The interpreter still doesn't support it (#13183).
+  {% if compare_versions(Crystal::VERSION, "1.1.0") >= 0 && !flag?(:interpreted) %}
     {cmd[0], *cmd[1]}
   {% else %}
     args = cmd[1]

--- a/src/process.cr
+++ b/src/process.cr
@@ -195,9 +195,16 @@ class Process
   # status  # => Process::Status[0]
   # ```
   @[Experimental]
-  def self.run(args : Enumerable(String), *, env : Env = nil, clear_env : Bool = false,
+  def self.run(args : Enumerable(String), *, env : Env? = nil, clear_env : Bool = false,
                input : Stdio = Redirect::Close, output : Stdio = Redirect::Close, error : Stdio = Redirect::Close, chdir : Path | String? = nil) : Process::Status
     new(args, env: env, clear_env: clear_env, input: input, output: output, error: error, chdir: chdir).wait
+  end
+
+  # :ditto:
+  @[Experimental]
+  def self.run(*args : String, env : Env? = nil, clear_env : Bool = false,
+               input : Stdio = Redirect::Close, output : Stdio = Redirect::Close, error : Stdio = Redirect::Close, chdir : Path | String? = nil) : Process::Status
+    run(args, env: env, clear_env: clear_env, input: input, output: output, error: error, chdir: chdir)
   end
 
   # Executes a child process and waits for it to complete, returning its status.
@@ -243,11 +250,19 @@ class Process
   # ```
   @[Experimental]
   def self.run?(args : Enumerable(String), *,
-                env : Env = nil, clear_env : Bool = false,
+                env : Env? = nil, clear_env : Bool = false,
                 input : Stdio = Redirect::Close, output : Stdio = Redirect::Close, error : Stdio = Redirect::Close,
                 chdir : Path | String? = nil) : Process::Status?
     status = new(args, env: env, clear_env: clear_env, input: input, output: output, error: error, chdir: chdir) { return nil }.wait
     status
+  end
+
+  # :ditto:
+  @[Experimental]
+  def self.run?(*args : String, env : Env? = nil, clear_env : Bool = false,
+                input : Stdio = Redirect::Close, output : Stdio = Redirect::Close, error : Stdio = Redirect::Close,
+                chdir : Path | String? = nil) : Process::Status?
+    run?(args, env: env, clear_env: clear_env, input: input, output: output, error: error, chdir: chdir)
   end
 
   # Executes a child process, yields the block, and then waits for it to finish.
@@ -284,6 +299,15 @@ class Process
     rescue ex
       process.terminate
       raise ex
+    end
+  end
+
+  # :ditto:
+  @[Experimental]
+  def self.run(*args : String, env : Env? = nil, clear_env : Bool = false,
+               input : Stdio = Redirect::Pipe, output : Stdio = Redirect::Pipe, error : Stdio = Redirect::Pipe, chdir : Path | String? = nil, & : Process -> _)
+    run(args, env: env, clear_env: clear_env, input: input, output: output, error: error, chdir: chdir) do |process|
+      yield process
     end
   end
 
@@ -417,10 +441,17 @@ class Process
   # * `Process.exec` replaces the current process.
   @[Experimental]
   def self.new(args : Enumerable(String), *, env : Env = nil, clear_env : Bool = false,
-               input : Stdio = Redirect::Close, output : Stdio = Redirect::Close, error : Stdio = Redirect::Close, chdir : Path | String? = nil)
+               input : Stdio = Redirect::Close, output : Stdio = Redirect::Close, error : Stdio = Redirect::Close, chdir : Path | String? = nil) : self
     new(args, env: env, clear_env: clear_env, input: input, output: output, error: error, chdir: chdir) do |error, command|
       raise ::File::Error.from_os_error("Error executing process", error, file: command)
     end
+  end
+
+  # :ditto:
+  @[Experimental]
+  def self.new(*args : String, env : Env = nil, clear_env : Bool = false,
+               input : Stdio = Redirect::Close, output : Stdio = Redirect::Close, error : Stdio = Redirect::Close, chdir : Path | String? = nil) : self
+    new(args, env: env, clear_env: clear_env, input: input, output: output, error: error, chdir: chdir)
   end
 
   # :nodoc:

--- a/src/process/capture.cr
+++ b/src/process/capture.cr
@@ -71,11 +71,18 @@ class Process
   # Process.capture_result(%w[nonexist])        # raises Process::ExitError
   # ```
   @[Experimental]
-  def self.capture_result(args : Enumerable(String), *, env : Env = nil, clear_env : Bool = false,
+  def self.capture_result(args : Enumerable(String), *, env : Env? = nil, clear_env : Bool = false,
                           input : Stdio = Redirect::Close, output : Stdio = Redirect::Pipe, error : Stdio = Redirect::Pipe, chdir : Path | String? = nil) : Result
     capture_result_impl(output, error) do |error|
       Process.new(args, env: env, clear_env: clear_env, input: input, output: output, error: error, chdir: chdir)
     end
+  end
+
+  # :ditto:
+  @[Experimental]
+  def self.capture_result(*args : String, env : Env? = nil, clear_env : Bool = false,
+                          input : Stdio = Redirect::Close, output : Stdio = Redirect::Pipe, error : Stdio = Redirect::Pipe, chdir : Path | String? = nil) : Result
+    capture_result(args, env: env, clear_env: clear_env, input: input, output: output, error: error, chdir: chdir)
   end
 
   # Executes a process and returns its result.
@@ -90,11 +97,18 @@ class Process
   # Process.capture_result?(%w[nonexist])               # => nil
   # ```
   @[Experimental]
-  def self.capture_result?(args : Enumerable(String), *, env : Env = nil, clear_env : Bool = false,
+  def self.capture_result?(args : Enumerable(String), *, env : Env? = nil, clear_env : Bool = false,
                            input : Stdio = Redirect::Close, output : Stdio = Redirect::Pipe, error : Stdio = Redirect::Pipe, chdir : Path | String? = nil) : Result?
     capture_result_impl(output, error) do |error|
       Process.new(args, env: env, clear_env: clear_env, input: input, output: output, error: error, chdir: chdir) { return nil }
     end
+  end
+
+  # :ditto:
+  @[Experimental]
+  def self.capture_result?(*args : String, env : Env? = nil, clear_env : Bool = false,
+                           input : Stdio = Redirect::Close, output : Stdio = Redirect::Pipe, error : Stdio = Redirect::Pipe, chdir : Path | String? = nil) : Result?
+    capture_result?(args, env: env, clear_env: clear_env, input: input, output: output, error: error, chdir: chdir)
   end
 
   private def self.capture_result_impl(output, error, & : -> Process)
@@ -127,7 +141,7 @@ class Process
   # Process.capture(%w[nonexist]) # raises Process::ExitError
   # ```
   @[Experimental]
-  def self.capture(args : Enumerable(String), *, env : Env = nil, clear_env : Bool = false,
+  def self.capture(args : Enumerable(String), *, env : Env? = nil, clear_env : Bool = false,
                    input : Stdio = Redirect::Close, error : Stdio = Redirect::Pipe, chdir : Path | String? = nil) : String
     result = capture_result(args, env: env, clear_env: clear_env, input: input, error: error, chdir: chdir)
     if result.status.success?
@@ -135,6 +149,13 @@ class Process
     else
       raise Process::ExitError.new(args, result)
     end
+  end
+
+  # :ditto:
+  @[Experimental]
+  def self.capture(*args : String, env : Env? = nil, clear_env : Bool = false,
+                   input : Stdio = Redirect::Close, error : Stdio = Redirect::Pipe, chdir : Path | String? = nil) : String
+    capture(args, env: env, clear_env: clear_env, input: input, error: error, chdir: chdir)
   end
 
   # Executes a process and returns its captured standard output or `nil` on failure.
@@ -150,12 +171,19 @@ class Process
   # Process.capture(%w[nonexist]) # => nil
   # ```
   @[Experimental]
-  def self.capture?(args : Enumerable(String), *, env : Env = nil, clear_env : Bool = false,
+  def self.capture?(args : Enumerable(String), *, env : Env? = nil, clear_env : Bool = false,
                     input : Stdio = Redirect::Close, error : Stdio = Redirect::Close, chdir : Path | String? = nil) : String?
     result = capture_result(args, env: env, clear_env: clear_env, input: input, error: error, chdir: chdir)
 
     if result.status.success?
       result.output
     end
+  end
+
+  # :ditto:
+  @[Experimental]
+  def self.capture?(*args : String, env : Env? = nil, clear_env : Bool = false,
+                    input : Stdio = Redirect::Close, error : Stdio = Redirect::Close, chdir : Path | String? = nil) : String?
+    capture?(args, env: env, clear_env: clear_env, input: input, error: error, chdir: chdir)
   end
 end


### PR DESCRIPTION
This implements a final piece of the new overloads introduced in https://github.com/crystal-lang/rfcs/pull/25

Further improvement could be splatting into an array, which requires compiler support (https://forum.crystal-lang.org/t/idea-splat-def-parameters-into-array/8898).