### PR TITLE
Makefile: Split `install` target into subcomponents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,14 +198,14 @@ generate_data: ## Run generator scripts for Unicode, SSL config, ...
 
 .PHONY: install
 install: ## Install the crystal compiler package at DESTDIR
-install: install_crystal install_man install_completions
+install: install_compiler install_man install_completions
 
 .PHONY: uninstall
 uninstall: ## Uninstall the Crystal compiler package from DESTDIR
 uninstall: uninstall_compiler uninstall_man uninstall_completions
 
-.PHONY: install_crystal
-install_crystal: $(O)/$(CRYSTAL_BIN)
+.PHONY: install_compiler
+install_compiler: $(O)/$(CRYSTAL_BIN)
 	$(INSTALL) -d -m 0755 "$(DESTDIR)$(BINDIR)/"
 	$(INSTALL) -m 0755 "$(O)/$(CRYSTAL_BIN)" "$(DESTDIR)$(BINDIR)/$(CRYSTAL_BIN)"
 

--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,10 @@ generate_data: ## Run generator scripts for Unicode, SSL config, ...
 install: ## Install the crystal compiler package at DESTDIR
 install: install_crystal install_man install_completions
 
+.PHONY: uninstall
+uninstall: ## Uninstall the Crystal compiler package from DESTDIR
+uninstall: uninstall_compiler uninstall_man uninstall_completions
+
 .PHONY: install_crystal
 install_crystal: $(O)/$(CRYSTAL_BIN)
 	$(INSTALL) -d -m 0755 "$(DESTDIR)$(BINDIR)/"
@@ -212,10 +216,21 @@ install_crystal: $(O)/$(CRYSTAL_BIN)
 	$(INSTALL) -d -m 0755 "$(DESTDIR)$(DATADIR)/licenses/crystal/"
 	$(INSTALL) -m 644 LICENSE "$(DESTDIR)$(DATADIR)/licenses/crystal/LICENSE"
 
+.PHONY: uninstall_compiler
+uninstall_compiler:
+	rm -f "$(DESTDIR)$(BINDIR)/$(CRYSTAL_BIN)"
+
+	rm -rf "$(DESTDIR)$(DATADIR)/crystal/src"
+	rm -f "$(DESTDIR)$(DATADIR)/licenses/crystal/LICENSE"
+
 .PHONY: install_man
 install_man: man/crystal.1.gz
 	$(INSTALL) -d -m 0755 "$(DESTDIR)$(MANDIR)/man1/"
 	$(INSTALL) -m 644 man/crystal.1.gz "$(DESTDIR)$(MANDIR)/man1/crystal.1.gz"
+
+.PHONY: uninstall_man
+uninstall_man:
+	rm -f "$(DESTDIR)$(MANDIR)/man1/crystal.1.gz"
 
 .PHONY: install_completions
 install_completions:
@@ -226,33 +241,18 @@ install_completions:
 	$(INSTALL) -d -m 0755 "$(DESTDIR)$(DATADIR)/fish/vendor_completions.d/"
 	$(INSTALL) -m 644 etc/completion.fish "$(DESTDIR)$(DATADIR)/fish/vendor_completions.d/crystal.fish"
 
+.PHONY: uninstall_completions
+uninstall_completions:
+	rm -f "$(DESTDIR)$(DATADIR)/bash-completion/completions/crystal"
+	rm -f "$(DESTDIR)$(DATADIR)/zsh/site-functions/_crystal"
+	rm -f "$(DESTDIR)$(DATADIR)/fish/vendor_completions.d/crystal.fish"
+
 ifeq ($(WINDOWS),1)
 .PHONY: install_dlls
 install_dlls: $(O)/$(CRYSTAL_BIN) ## Install the compiler's dependent DLLs at DESTDIR (Windows only)
 	$(INSTALL) -d -m 0755 "$(DESTDIR)$(BINDIR)/"
 	@ldd $(O)/$(CRYSTAL_BIN) | grep -iv ' => /c/windows/system32' | sed 's/.* => //; s/ (.*//' | xargs -t -i $(INSTALL) -m 0755 '{}' "$(DESTDIR)$(BINDIR)/"
 endif
-
-.PHONY: uninstall
-uninstall: ## Uninstall the Crystal compiler package from DESTDIR
-uninstall: uninstall_compiler uninstall_man uninstall_completions
-
-.PHONY: uninstall_compiler
-uninstall_compiler:
-	rm -f "$(DESTDIR)$(BINDIR)/$(CRYSTAL_BIN)"
-
-	rm -rf "$(DESTDIR)$(DATADIR)/crystal/src"
-	rm -f "$(DESTDIR)$(DATADIR)/licenses/crystal/LICENSE"
-
-.PHONY: uninstall_man
-uninstall_man:
-	rm -f "$(DESTDIR)$(MANDIR)/man1/crystal.1.gz"
-
-.PHONY: uninstall_completions
-uninstall_completions:
-	rm -f "$(DESTDIR)$(DATADIR)/bash-completion/completions/crystal"
-	rm -f "$(DESTDIR)$(DATADIR)/zsh/site-functions/_crystal"
-	rm -f "$(DESTDIR)$(DATADIR)/fish/vendor_completions.d/crystal.fish"
 
 .PHONY: install_docs
 install_docs: docs ## Install docs at DESTDIR

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,11 @@ generate_data: ## Run generator scripts for Unicode, SSL config, ...
 	$(MAKE) -B -f scripts/generate_data.mk
 
 .PHONY: install
-install: $(O)/$(CRYSTAL_BIN) man/crystal.1.gz ## Install the compiler at DESTDIR
+install: ## Install the crystal compiler package at DESTDIR
+install: install_crystal install_man install_completions
+
+.PHONY: install_crystal
+install_crystal: $(O)/$(CRYSTAL_BIN)
 	$(INSTALL) -d -m 0755 "$(DESTDIR)$(BINDIR)/"
 	$(INSTALL) -m 0755 "$(O)/$(CRYSTAL_BIN)" "$(DESTDIR)$(BINDIR)/$(CRYSTAL_BIN)"
 
@@ -205,11 +209,16 @@ install: $(O)/$(CRYSTAL_BIN) man/crystal.1.gz ## Install the compiler at DESTDIR
 	cp -R -p $(if $(deref_symlinks),-L,-P) src "$(DESTDIR)$(DATADIR)/crystal/src"
 	rm -rf "$(DESTDIR)$(DATADIR)/crystal/$(LLVM_EXT_OBJ)" # Don't install llvm_ext.o
 
-	$(INSTALL) -d -m 0755 "$(DESTDIR)$(MANDIR)/man1/"
-	$(INSTALL) -m 644 man/crystal.1.gz "$(DESTDIR)$(MANDIR)/man1/crystal.1.gz"
 	$(INSTALL) -d -m 0755 "$(DESTDIR)$(DATADIR)/licenses/crystal/"
 	$(INSTALL) -m 644 LICENSE "$(DESTDIR)$(DATADIR)/licenses/crystal/LICENSE"
 
+.PHONY: install_man
+install_man: man/crystal.1.gz
+	$(INSTALL) -d -m 0755 "$(DESTDIR)$(MANDIR)/man1/"
+	$(INSTALL) -m 644 man/crystal.1.gz "$(DESTDIR)$(MANDIR)/man1/crystal.1.gz"
+
+.PHONY: install_completions
+install_completions:
 	$(INSTALL) -d -m 0755 "$(DESTDIR)$(DATADIR)/bash-completion/completions/"
 	$(INSTALL) -m 644 etc/completion.bash "$(DESTDIR)$(DATADIR)/bash-completion/completions/crystal"
 	$(INSTALL) -d -m 0755 "$(DESTDIR)$(DATADIR)/zsh/site-functions/"
@@ -225,14 +234,22 @@ install_dlls: $(O)/$(CRYSTAL_BIN) ## Install the compiler's dependent DLLs at DE
 endif
 
 .PHONY: uninstall
-uninstall: ## Uninstall the compiler from DESTDIR
+uninstall: ## Uninstall the Crystal compiler package from DESTDIR
+uninstall: uninstall_compiler uninstall_man uninstall_completions
+
+.PHONY: uninstall_compiler
+uninstall_compiler:
 	rm -f "$(DESTDIR)$(BINDIR)/$(CRYSTAL_BIN)"
 
 	rm -rf "$(DESTDIR)$(DATADIR)/crystal/src"
-
-	rm -f "$(DESTDIR)$(MANDIR)/man1/crystal.1.gz"
 	rm -f "$(DESTDIR)$(DATADIR)/licenses/crystal/LICENSE"
 
+.PHONY: uninstall_man
+uninstall_man:
+	rm -f "$(DESTDIR)$(MANDIR)/man1/crystal.1.gz"
+
+.PHONY: uninstall_completions
+uninstall_completions:
 	rm -f "$(DESTDIR)$(DATADIR)/bash-completion/completions/crystal"
 	rm -f "$(DESTDIR)$(DATADIR)/zsh/site-functions/_crystal"
 	rm -f "$(DESTDIR)$(DATADIR)/fish/vendor_completions.d/crystal.fish"
@@ -296,7 +313,6 @@ man/%.1: doc/man/%.adoc
 .PHONY: clean
 clean: clean_crystal ## Clean up built directories and files
 	rm -rf $(LLVM_EXT_OBJ)
-	rm -rf man/*.gz
 
 .PHONY: clean_crystal
 clean_crystal: ## Clean up crystal built files

--- a/Makefile.win
+++ b/Makefile.win
@@ -165,10 +165,10 @@ generate_data: ## Run generator scripts for Unicode, SSL config, ...
 
 .PHONY: install
 install: ## Install the crystal compiler package at prefix
-install: install_crystal
+install: install_compiler
 
-.PHONY: install_crystal
-install_crystal: $(O)\crystal.exe
+.PHONY: install_compiler
+install_compiler: $(O)\crystal.exe
 	$(call MKDIR,"$(BINDIR)")
 	$(call INSTALL,"$(O)\crystal.exe","$(BINDIR)\crystal.exe")
 	$(call INSTALL,"$(O)\crystal.pdb","$(BINDIR)\crystal.pdb")
@@ -180,10 +180,10 @@ install_crystal: $(O)\crystal.exe
 	$(call INSTALL,LICENSE,"$(DATADIR)\LICENSE.txt")
 
 .PHONY: uninstall ## Uninstall the Crystal compiler package from prefix
-uninstall: uninstall_crystal
+uninstall: uninstall_compiler
 
-.PHONY: uninstall_crystal
-uninstall_crystal:
+.PHONY: uninstall_compiler
+uninstall_compiler:
 	$(call RM,"$(DATADIR)\LICENSE.txt")
 
 	$(call RMDIR,"$(DATADIR)\src")

--- a/Makefile.win
+++ b/Makefile.win
@@ -164,7 +164,11 @@ generate_data: ## Run generator scripts for Unicode, SSL config, ...
 	$(MAKE) -B -f scripts/generate_data.mk
 
 .PHONY: install
-install: $(O)\crystal.exe ## Install the compiler at prefix
+install: ## Install the crystal compiler package at prefix
+install: install_crystal
+
+.PHONY: install_crystal
+install_crystal: $(O)\crystal.exe
 	$(call MKDIR,"$(BINDIR)")
 	$(call INSTALL,"$(O)\crystal.exe","$(BINDIR)\crystal.exe")
 	$(call INSTALL,"$(O)\crystal.pdb","$(BINDIR)\crystal.pdb")
@@ -175,8 +179,11 @@ install: $(O)\crystal.exe ## Install the compiler at prefix
 
 	$(call INSTALL,LICENSE,"$(DATADIR)\LICENSE.txt")
 
-.PHONY: uninstall
-uninstall: ## Uninstall the compiler from prefix
+.PHONY: uninstall ## Uninstall the Crystal compiler package from prefix
+uninstall: uninstall_crystal
+
+.PHONY: uninstall_crystal
+uninstall_crystal:
 	$(call RM,"$(DATADIR)\LICENSE.txt")
 
 	$(call RMDIR,"$(DATADIR)\src")


### PR DESCRIPTION
This is a pure restructuring and should not change any behaviour. It makes it a bit more clear what each `install` target does and makes it easier to select different behaviour.

Preparation for adding manpages to the build process (https://github.com/crystal-lang/crystal/issues/15536).