### PR TITLE
Fix `HTTP::Client` to retry for connection recovery only

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -233,7 +233,7 @@ module HTTP
       end
     end
 
-    it "will retry once on connection error" do
+    it "does not retry on initial connection error" do
       requests = 0
       server = HTTP::Server.new do |context|
         requests += 1
@@ -247,7 +247,7 @@ module HTTP
       end
     end
 
-    it "retries when re-using connection with error" do
+    it "retries when re-using connection with error (non-yielding)" do
       requests = 0
       server = HTTP::Server.new do |context|
         requests += 1
@@ -261,7 +261,7 @@ module HTTP
       end
     end
 
-    it "retries when re-using connection with error" do
+    it "retries when re-using connection with error (yielding)" do
       requests = 0
       server = HTTP::Server.new do |context|
         requests += 1
@@ -275,7 +275,7 @@ module HTTP
       end
     end
 
-    it "retries only once when re-using connection with error" do
+    it "retries only once when re-using connection with error (non-yielding)" do
       requests = 0
       server = HTTP::Server.new do |context|
         requests += 1
@@ -291,7 +291,7 @@ module HTTP
       end
     end
 
-    it "retries only once when re-using connection with error" do
+    it "retries only once when re-using connection with error (yielding)" do
       requests = 0
       server = HTTP::Server.new do |context|
         requests += 1
@@ -307,7 +307,7 @@ module HTTP
       end
     end
 
-    it "no retry unless request is replayable" do
+    it "no retry unless request is replayable (non-yielding)" do
       requests = 0
       server = HTTP::Server.new do |context|
         requests += 1
@@ -323,7 +323,7 @@ module HTTP
       end
     end
 
-    it "no retry unless request is replayable" do
+    it "no retry unless request is replayable (yielding)" do
       requests = 0
       server = HTTP::Server.new do |context|
         requests += 1
@@ -339,7 +339,7 @@ module HTTP
       end
     end
 
-    it "retry if request is replayable" do
+    it "retry if request is replayable (yielding)" do
       requests = 0
       server = HTTP::Server.new do |context|
         requests += 1
@@ -353,7 +353,7 @@ module HTTP
       end
     end
 
-    it "retry if request is replayable" do
+    it "retry if request is replayable (non-yielding)" do
       requests = 0
       server = HTTP::Server.new do |context|
         requests += 1
@@ -367,7 +367,7 @@ module HTTP
       end
     end
 
-    it "retries when error is not econnreset" do
+    it "retries on unexpected EOF when re-using connection (non-yielding)" do
       requests = 0
       server = HTTP::Server.new do |context|
         requests += 1
@@ -384,7 +384,7 @@ module HTTP
       end
     end
 
-    it "retries when error is not econnreset" do
+    it "retries on unexpected EOF when re-using connection (yielding)" do
       requests = 0
       server = HTTP::Server.new do |context|
         requests += 1

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -243,7 +243,67 @@ module HTTP
         expect_raises(IO::Error) do
           client.get(path: "/")
         end
-        requests.should eq 2
+        requests.should eq 1
+      end
+    end
+
+    it "retries when re-using connection with error" do
+      requests = 0
+      server = HTTP::Server.new do |context|
+        requests += 1
+        close_connection(context) if requests == 2
+      end
+      client_for(server) do |client|
+        client.get(path: "/") # first request to establish connection
+        requests.should eq 1
+        client.get(path: "/")
+        requests.should eq 3
+      end
+    end
+
+    it "retries when re-using connection with error" do
+      requests = 0
+      server = HTTP::Server.new do |context|
+        requests += 1
+        close_connection(context) if requests == 2
+      end
+      client_for(server) do |client|
+        client.get(path: "/") { } # first request to establish connection
+        requests.should eq 1
+        client.get(path: "/") { }
+        requests.should eq 3
+      end
+    end
+
+    it "retries only once when re-using connection with error" do
+      requests = 0
+      server = HTTP::Server.new do |context|
+        requests += 1
+        close_connection(context) if requests > 1
+      end
+      client_for(server) do |client|
+        client.get(path: "/") # first request to establish connection
+        requests.should eq 1
+        expect_raises(IO::Error) do
+          client.get(path: "/")
+        end
+        requests.should eq 3
+      end
+    end
+
+    it "retries only once when re-using connection with error" do
+      requests = 0
+      server = HTTP::Server.new do |context|
+        requests += 1
+        close_connection(context) if requests > 1
+      end
+      client_for(server) do |client|
+        client.get(path: "/") { } # first request to establish connection
+        requests.should eq 1
+        expect_raises(IO::Error) do
+          client.get(path: "/") { }
+        end
+        requests.should eq 3
       end
     end
 

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -367,6 +367,40 @@ module HTTP
       end
     end
 
+    it "no retry when error is not econnreset" do
+      requests = 0
+      server = HTTP::Server.new do |context|
+        requests += 1
+        next if requests == 1 # first request must go through
+        context.response.@io.as(Socket).close
+      end
+      client_for(server) do |client|
+        client.get(path: "/") # first request to establish connection
+        requests.should eq 1
+        expect_raises(IO::EOFError) do
+          client.get(path: "/")
+        end
+        requests.should eq 2
+      end
+    end
+
+    it "no retry when error is not econnreset" do
+      requests = 0
+      server = HTTP::Server.new do |context|
+        requests += 1
+        next if requests == 1 # first request must go through
+        context.response.@io.as(Socket).close
+      end
+      client_for(server) do |client|
+        client.get(path: "/") { } # first request to establish connection
+        requests.should eq 1
+        expect_raises(IO::EOFError) do
+          client.get(path: "/") { }
+        end
+        requests.should eq 2
+      end
+    end
+
     it "will not retry if IO::Error in request handling" do
       requests = 0
       server = HTTP::Server.new do |context|

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -367,7 +367,7 @@ module HTTP
       end
     end
 
-    it "no retry when error is not econnreset" do
+    it "retries when error is not econnreset" do
       requests = 0
       server = HTTP::Server.new do |context|
         requests += 1
@@ -380,11 +380,11 @@ module HTTP
         expect_raises(IO::EOFError) do
           client.get(path: "/")
         end
-        requests.should eq 2
+        requests.should eq 3
       end
     end
 
-    it "no retry when error is not econnreset" do
+    it "retries when error is not econnreset" do
       requests = 0
       server = HTTP::Server.new do |context|
         requests += 1
@@ -397,7 +397,7 @@ module HTTP
         expect_raises(IO::EOFError) do
           client.get(path: "/") { }
         end
-        requests.should eq 2
+        requests.should eq 3
       end
     end
 

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -307,6 +307,66 @@ module HTTP
       end
     end
 
+    it "no retry unless request is replayable" do
+      requests = 0
+      server = HTTP::Server.new do |context|
+        requests += 1
+        close_connection(context) if requests == 2
+      end
+      client_for(server) do |client|
+        client.get(path: "/") # first request to establish connection
+        requests.should eq 1
+        expect_raises(IO::Error) do
+          client.post(path: "/")
+        end
+        requests.should eq 2
+      end
+    end
+
+    it "no retry unless request is replayable" do
+      requests = 0
+      server = HTTP::Server.new do |context|
+        requests += 1
+        close_connection(context) if requests == 2
+      end
+      client_for(server) do |client|
+        client.get(path: "/") { } # first request to establish connection
+        requests.should eq 1
+        expect_raises(IO::Error) do
+          client.post(path: "/") { }
+        end
+        requests.should eq 2
+      end
+    end
+
+    it "retry if request is replayable" do
+      requests = 0
+      server = HTTP::Server.new do |context|
+        requests += 1
+        close_connection(context) if requests == 2
+      end
+      client_for(server) do |client|
+        client.get(path: "/") { } # first request to establish connection
+        requests.should eq 1
+        client.post(path: "/", headers: HTTP::Headers{"Idempotency-Key" => "123"}) { }
+        requests.should eq 3
+      end
+    end
+
+    it "retry if request is replayable" do
+      requests = 0
+      server = HTTP::Server.new do |context|
+        requests += 1
+        close_connection(context) if requests == 2
+      end
+      client_for(server) do |client|
+        client.get(path: "/") # first request to establish connection
+        requests.should eq 1
+        client.post(path: "/", headers: HTTP::Headers{"Idempotency-Key" => "123"})
+        requests.should eq 3
+      end
+    end
+
     it "will not retry if IO::Error in request handling" do
       requests = 0
       server = HTTP::Server.new do |context|

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -598,5 +598,31 @@ module HTTP
         HTTP::Request.new("GET", "/", HTTP::Headers{"If-Match" => %(W/"1234567" , "12345678")}).if_match.should eq [%(W/"1234567"), %("12345678")]
       end
     end
+
+    describe "#replayable?" do
+      it "GET is replayable" do
+        HTTP::Request.new("GET", "/").replayable?.should be_true
+      end
+
+      it "GET with body is not replayable" do
+        HTTP::Request.new("GET", "/", body: "body").replayable?.should be_false
+      end
+
+      it "POST is not replayable" do
+        HTTP::Request.new("POST", "/").replayable?.should be_false
+      end
+
+      it "POST with Idempotency-Key header is replayable" do
+        HTTP::Request.new("POST", "/", HTTP::Headers{"Idempotency-Key" => "key"}).replayable?.should be_true
+      end
+
+      it "POST with X-Idempotency-Key header is replayable" do
+        HTTP::Request.new("POST", "/", HTTP::Headers{"X-Idempotency-Key" => "key"}).replayable?.should be_true
+      end
+
+      it "POST with body and Idempotency-Key header is not replayable" do
+        HTTP::Request.new("POST", "/", HTTP::Headers{"Idempotency-Key" => "key"}, "body").replayable?.should be_false
+      end
+    end
   end
 end

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -654,13 +654,20 @@ class HTTP::Client
 
   # Determine whether we should retry a request after an IO error happened,
   # which might've been caused by a stale connection broken down.
-  private def should_retry_request?(request, reusing_connection) : Bool
+  #
+  # The conditions are inspired from the implementation in Go's net/http library:
+  # https://github.com/golang/go/blob/608e9fac9055aa188c513f4dd53f12e692bc3c0c/src/net/http/transport.go#L808
+  private def should_retry_request?(request, exc, reusing_connection) : Bool
     # The client was closed explicitly
     return false if @io.nil?
 
     # If the connection is fresh, the server should not have hung up on us and
     # there's no reason to retry.
     return false unless reusing_connection
+
+    # Only retry if the error connection was reset by the peer, which is a
+    # strong indicator of a stale connection.
+    return false unless exc && exc.os_error.in?(Errno::ECONNRESET, WinError::WSAECONNRESET)
 
     # Do not retry requests if they are not replayable
     return false unless request.replayable?
@@ -674,7 +681,7 @@ class HTTP::Client
     begin
       return yield
     rescue exc : IO::Error
-      unless should_retry_request?(request, reusing_connection)
+      unless should_retry_request?(request, exc, reusing_connection)
         raise exc
       end
     end

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -584,21 +584,23 @@ class HTTP::Client
     set_defaults request
     run_before_request_callbacks(request)
 
-    begin
-      response = exec_internal_single(request, implicit_compression: implicit_compression)
+    response = begin
+      exec_internal_single(request, implicit_compression: implicit_compression)
     rescue exc : IO::Error
-      raise exc if @io.nil? # do not retry if client was closed
-      response = nil
+      if @io.nil?
+        # do not retry if client was closed
+        raise exc
+      end
+
+      # Server probably closed the connection, so retry once
+      close
+      request.body.try &.rewind
+      exec_internal_single(request, implicit_compression: implicit_compression)
     end
-    return handle_response(response) if response
 
-    # Server probably closed the connection, so retry once
-    close
-    request.body.try &.rewind
-    response = exec_internal_single(request, implicit_compression: implicit_compression)
-    return handle_response(response) if response
+    raise IO::EOFError.new("Unexpected end of http response") unless response
 
-    raise IO::EOFError.new("Unexpected end of http response")
+    handle_response(response)
   end
 
   private def exec_internal_single(request, implicit_compression = false)

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -667,7 +667,7 @@ class HTTP::Client
 
     # Only retry if the error connection was reset by the peer, which is a
     # strong indicator of a stale connection.
-    return false unless exc.os_error.in?(Errno::ECONNRESET, WinError::WSAECONNRESET, Errno::EPIPE)
+    return false unless exc.nil? || exc.os_error.in?(Errno::ECONNRESET, WinError::WSAECONNRESET, Errno::EPIPE)
 
     # Do not retry requests if they are not replayable
     return false unless request.replayable?
@@ -679,11 +679,16 @@ class HTTP::Client
     reusing_connection = !@io.nil?
 
     begin
-      return yield
+      result = yield
     rescue exc : IO::Error
       unless should_retry_request?(request, exc, reusing_connection)
         raise exc
       end
+    else
+      return result if result
+
+      # Reading resulted in EOF which might be caused by a stale connection
+      return unless should_retry_request?(request, nil, reusing_connection)
     end
 
     # Server probably closed the connection, so retry once

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -667,7 +667,7 @@ class HTTP::Client
 
     # Only retry if the error connection was reset by the peer, which is a
     # strong indicator of a stale connection.
-    return false unless exc && exc.os_error.in?(Errno::ECONNRESET, WinError::WSAECONNRESET)
+    return false unless exc.os_error.in?(Errno::ECONNRESET, WinError::WSAECONNRESET, Errno::EPIPE)
 
     # Do not retry requests if they are not replayable
     return false unless request.replayable?

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -652,12 +652,20 @@ class HTTP::Client
     raise IO::EOFError.new("Unexpected end of http response")
   end
 
+  # Determine whether we should retry a request after an IO error happened,
+  # which might've been caused by a stale connection broken down.
+  private def should_retry_request? : Bool
+    # The client was closed explicitly
+    return false if @io.nil?
+
+    true
+  end
+
   private def retry_once(request, &)
     begin
       return yield
     rescue exc : IO::Error
-      if @io.nil?
-        # do not retry if client was closed
+      unless should_retry_request?
         raise exc
       end
     end

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -654,18 +654,24 @@ class HTTP::Client
 
   # Determine whether we should retry a request after an IO error happened,
   # which might've been caused by a stale connection broken down.
-  private def should_retry_request? : Bool
+  private def should_retry_request?(reusing_connection) : Bool
     # The client was closed explicitly
     return false if @io.nil?
+
+    # If the connection is fresh, the server should not have hung up on us and
+    # there's no reason to retry.
+    return false unless reusing_connection
 
     true
   end
 
   private def retry_once(request, &)
+    reusing_connection = !@io.nil?
+
     begin
       return yield
     rescue exc : IO::Error
-      unless should_retry_request?
+      unless should_retry_request?(reusing_connection)
         raise exc
       end
     end

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -667,7 +667,7 @@ class HTTP::Client
 
     # Only retry if the error connection was reset by the peer, which is a
     # strong indicator of a stale connection.
-    return false unless exc.nil? || exc.os_error.in?(Errno::ECONNRESET, WinError::WSAECONNRESET, Errno::EPIPE)
+    return false unless exc.nil? || exc.os_error.in?(Errno::ECONNRESET, WinError::WSAECONNRESET, Errno::EPIPE, WinError::WSAECONNABORTED)
 
     # Do not retry requests if they are not replayable
     return false unless request.replayable?

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -654,13 +654,16 @@ class HTTP::Client
 
   # Determine whether we should retry a request after an IO error happened,
   # which might've been caused by a stale connection broken down.
-  private def should_retry_request?(reusing_connection) : Bool
+  private def should_retry_request?(request, reusing_connection) : Bool
     # The client was closed explicitly
     return false if @io.nil?
 
     # If the connection is fresh, the server should not have hung up on us and
     # there's no reason to retry.
     return false unless reusing_connection
+
+    # Do not retry requests if they are not replayable
+    return false unless request.replayable?
 
     true
   end
@@ -671,14 +674,13 @@ class HTTP::Client
     begin
       return yield
     rescue exc : IO::Error
-      unless should_retry_request?(reusing_connection)
+      unless should_retry_request?(request, reusing_connection)
         raise exc
       end
     end
 
     # Server probably closed the connection, so retry once
     close
-    request.body.try &.rewind
 
     yield
   end

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -584,17 +584,7 @@ class HTTP::Client
     set_defaults request
     run_before_request_callbacks(request)
 
-    response = begin
-      exec_internal_single(request, implicit_compression: implicit_compression)
-    rescue exc : IO::Error
-      if @io.nil?
-        # do not retry if client was closed
-        raise exc
-      end
-
-      # Server probably closed the connection, so retry once
-      close
-      request.body.try &.rewind
+    response = retry_once(request) do
       exec_internal_single(request, implicit_compression: implicit_compression)
     end
 
@@ -639,7 +629,7 @@ class HTTP::Client
     run_before_request_callbacks(request)
 
     user_exception = nil
-    exec_internal_helper do
+    retry_once(request) do
       exec_internal_single(request, implicit_compression: implicit_compression) do |response|
         if response
           handle_response(response) do
@@ -659,23 +649,24 @@ class HTTP::Client
 
     raise user_exception if user_exception
 
-    # Server probably closed the connection, so retry once
-    close
-    request.body.try &.rewind
-    exec_internal_single(request, implicit_compression: implicit_compression) do |response|
-      if response
-        return handle_response(response) { yield response }
-      end
-    end
-
     raise IO::EOFError.new("Unexpected end of http response")
   end
 
-  # FIXME: This helper is only needed when compiling against Crystal 1.3 or earlier, due to #9769.
-  private def exec_internal_helper(&)
+  private def retry_once(request, &)
+    begin
+      return yield
+    rescue exc : IO::Error
+      if @io.nil?
+        # do not retry if client was closed
+        raise exc
+      end
+    end
+
+    # Server probably closed the connection, so retry once
+    close
+    request.body.try &.rewind
+
     yield
-  rescue exc : IO::Error
-    raise exc if @io.nil? # do not retry if client was closed
   end
 
   private def exec_internal_single(request, implicit_compression = false, &)

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -350,12 +350,12 @@ class HTTP::Request
   # single request.
   #
   # This is only an expectation based on request properties. The actual server
-  # maybe behave differently, and even a `GET` request might cause side effects.
+  # may behave differently, and even a `GET` request might cause side effects.
   #
-  # Closely related to [idempotency] in the HTTP spec, but potentially unsafe
-  # methods `PATCH` and `DELETE` are excluded, unless there is an explicit
-  # idempotency header.  Requests with a body or form params are never
-  # replayable.
+  # Closely related to [idempotency] in the HTTP spec, but only the “safe”
+  # methods `GET`, `HEAD`, `OPTIONS`, and `TRACE` are considered replayable unless
+  # there is an explicit idempotency header. Requests with a body (including form
+  # params) are never replayable.
   #
   # [idempotency]: https://httpwg.org/specs/rfc9110.html#idempotent.methods
   def replayable? : Bool

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -342,6 +342,29 @@ class HTTP::Request
     uri.query = query_params.to_s
   end
 
+  # :nodoc:
+  #
+  # This method is used by `HTTP::Client` to determine whether it can safely retry a request.
+  # Returns `true` if this request is expected to be replayable, i.e. if making
+  # multiple identical requests has the same effect on the server as making a
+  # single request.
+  #
+  # This is only an expectation based on request properties. The actual server
+  # maybe behave differently, and even a `GET` request might cause side effects.
+  #
+  # Closely related to [idempotency] in the HTTP spec, but potentially unsafe
+  # methods `PATCH` and `DELETE` are excluded, unless there is an explicit
+  # idempotency header.  Requests with a body or form params are never
+  # replayable.
+  #
+  # [idempotency]: https://httpwg.org/specs/rfc9110.html#idempotent.methods
+  def replayable? : Bool
+    @body.nil? && @form_params.nil? && (
+      @method.in?("GET", "HEAD", "OPTIONS", "TRACE") ||
+        headers.has_key?("Idempotency-Key") || headers.has_key?("X-Idempotency-Key")
+    )
+  end
+
   def if_match : Array(String)?
     parse_etags("If-Match")
   end


### PR DESCRIPTION
Defines clear rules for when `HTTP::Client` should retry a failed request in order to recover from a connection reset.

The criteria are inspired by https://github.com/golang/go/blob/608e9fac9055aa188c513f4dd53f12e692bc3c0c/src/net/http/transport.go#L808

* Only retry when re-using an existing connection
* Only retry for EOF error OR when we didn't send anything yet
* Only retry requests that are replayable (NO body AND (method is one of `GET, HEAD, OPTIONS, TRACE` OR `Idempotency-Key` header exists) (https://github.com/golang/go/blob/2403e594a5b279bd7b393c32f74528fd4ef29c4a/src/net/http/request.go#L1539)

Resolves #16920
Closes https://github.com/crystal-lang/crystal/pull/16921