### PR TITLE
Fix virtual dispatch / type filtering for uninstantiated generic subclasses

### DIFF
--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -1165,6 +1165,51 @@ describe "Code gen: class" do
       CRYSTAL
   end
 
+  it "dispatches virtual metaclass call to uninstantiated generic subclass (#11134)" do
+    run(<<-CRYSTAL).to_i.should eq(2)
+      class Foo
+        def self.foo
+          1
+        end
+      end
+
+      class Bar(T) < Foo
+        def self.foo
+          2
+        end
+      end
+
+      class Baz < Foo
+        def self.foo
+          3
+        end
+      end
+
+      Bar.as(Foo.class).foo
+      CRYSTAL
+  end
+
+  it "does not segfault when an Array(Module) holds an instance of an uninstantiated generic subclass (#16947)" do
+    run(<<-CRYSTAL).to_i.should eq(2)
+      require "prelude"
+
+      module Foo
+      end
+
+      class GenericFoo(T)
+        include Foo
+      end
+
+      class SubGenericFoo(T) < GenericFoo(T)
+      end
+
+      array = [] of Foo
+      array << GenericFoo(String).new
+      array << SubGenericFoo(String).new
+      array.size
+      CRYSTAL
+  end
+
   it "can assign virtual metaclass to virtual metaclass (#3007)" do
     run(<<-CRYSTAL).to_i.should eq(2)
       class Foo

--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -1189,27 +1189,6 @@ describe "Code gen: class" do
       CRYSTAL
   end
 
-  it "does not segfault when an Array(Module) holds an instance of an uninstantiated generic subclass (#16947)" do
-    run(<<-CRYSTAL).to_i.should eq(2)
-      require "prelude"
-
-      module Foo
-      end
-
-      class GenericFoo(T)
-        include Foo
-      end
-
-      class SubGenericFoo(T) < GenericFoo(T)
-      end
-
-      array = [] of Foo
-      array << GenericFoo(String).new
-      array << SubGenericFoo(String).new
-      array.size
-      CRYSTAL
-  end
-
   it "can assign virtual metaclass to virtual metaclass (#3007)" do
     run(<<-CRYSTAL).to_i.should eq(2)
       class Foo

--- a/spec/compiler/semantic/is_a_spec.cr
+++ b/spec/compiler/semantic/is_a_spec.cr
@@ -259,15 +259,17 @@ describe "Semantic: is_a?" do
       CRYSTAL
   end
 
-  it "preserves type info across `is_a?(GenericA) && is_a?(GenericB)` when GenericB <= GenericA (#10831)" do
-    assert_type(<<-CRYSTAL) { bool }
+  it "matches `is_a?(GenericA) && is_a?(GenericB)` when GenericB <= GenericA (#10831)" do
+    # Before the fix, `common_descendent(GenericClassType, GenericClassType)`
+    # only walked one direction, so the chained filter narrowed `x` to `B(T)`
+    # and `is_a?(C)` returned `false` for a runtime value that's actually a C.
+    run(<<-CRYSTAL).to_b.should be_true
       class A; end
       class B(T) < A; end
       class C(T) < B(T); end
 
       x = C(Int32).new.as(A)
-      # If the chain still produced NoReturn, the call would fail to type.
-      (x.is_a?(B) && x.is_a?(C)) ? true : false
+      x.is_a?(B) && x.is_a?(C)
       CRYSTAL
   end
 end

--- a/spec/compiler/semantic/is_a_spec.cr
+++ b/spec/compiler/semantic/is_a_spec.cr
@@ -258,4 +258,16 @@ describe "Semantic: is_a?" do
       end
       CRYSTAL
   end
+
+  it "preserves type info across `is_a?(GenericA) && is_a?(GenericB)` when GenericB <= GenericA (#10831)" do
+    assert_type(<<-CRYSTAL) { bool }
+      class A; end
+      class B(T) < A; end
+      class C(T) < B(T); end
+
+      x = C(Int32).new.as(A)
+      # If the chain still produced NoReturn, the call would fail to type.
+      (x.is_a?(B) && x.is_a?(C)) ? true : false
+      CRYSTAL
+  end
 end

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -428,8 +428,13 @@ module Crystal
       matches = base_type_matches.matches
       changes = nil
 
-      # Traverse all subtypes
-      instance_type.subtypes(base_type).each do |subtype|
+      # Traverse all subtypes. For virtual metaclasses, include uninstantiated
+      # generic subclasses too — their metaclasses are valid dispatch targets
+      # (e.g. `Bar.foo` where `class Bar(T) < Foo`), and without them the
+      # dispatch table is missing a branch and the call hits the unreachable
+      # at runtime (#11134).
+      subtypes = virtual_metaclass? ? instance_type.subtypes_including_generic(base_type) : instance_type.subtypes(base_type)
+      subtypes.each do |subtype|
         next if is_new && subtype.is_a?(GenericClassInstanceType) && subtype.abstract?
 
         subtype_lookup = virtual_lookup(subtype)

--- a/src/compiler/crystal/semantic/type_intersect.cr
+++ b/src/compiler/crystal/semantic/type_intersect.cr
@@ -214,7 +214,12 @@ module Crystal
     def self.common_descendent(type1 : GenericClassType, type2 : GenericClassType)
       return type1 if type1 == type2
 
-      common_descendent_instance_and_generic(type1, type2)
+      # Try both directions: e.g. for `class C(T) < B(T)`, `common_descendent(B, C)`
+      # should resolve to `C` because every C is also a B. Without the symmetric
+      # check, chained type filters like `x.is_a?(B) && x.is_a?(C)` collapse to
+      # `NoReturn` (#10831).
+      common_descendent_instance_and_generic(type1, type2) ||
+        common_descendent_instance_and_generic(type2, type1)
     end
 
     def self.common_descendent(type1 : Type, type2 : AliasType)

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3431,10 +3431,27 @@ module Crystal
       subtypes
     end
 
-    def subtypes(type)
+    def subtypes(type : Type)
       subtypes = [] of Type
       type.subclasses.each do |subclass|
         collect_subtypes subclass, subtypes
+      end
+      subtypes
+    end
+
+    # Like `subtypes`, but also yields uninstantiated generic subclasses.
+    # Used for virtual *metaclass* dispatch, where `Bar.foo` is callable
+    # even when `class Bar(T)` has no instantiation (#11134).
+    def subtypes_including_generic
+      subtypes = [] of Type
+      collect_subtypes_including_generic(base_type, subtypes)
+      subtypes
+    end
+
+    def subtypes_including_generic(type : Type)
+      subtypes = [] of Type
+      type.subclasses.each do |subclass|
+        collect_subtypes_including_generic subclass, subtypes
       end
       subtypes
     end
@@ -3443,6 +3460,21 @@ module Crystal
       subtypes << type unless type.is_a?(GenericType) || type.unbound?
       type.subclasses.each do |subclass|
         collect_subtypes subclass, subtypes
+      end
+    end
+
+    def collect_subtypes_including_generic(type, subtypes)
+      if type.is_a?(GenericType)
+        # Only include the uninstantiated generic if it has no instantiations:
+        # those carry the dispatch otherwise. Including the uninstantiated form
+        # when instantiations exist can fail later if a class method on it
+        # references the type parameter (e.g. `def self.x; T.foo; end`).
+        subtypes << type if type.instantiated_types.empty? && !type.unbound?
+      elsif !type.unbound?
+        subtypes << type
+      end
+      type.subclasses.each do |subclass|
+        collect_subtypes_including_generic subclass, subtypes
       end
     end
 
@@ -3519,7 +3551,10 @@ module Crystal
     end
 
     def each_concrete_type(&)
-      instance_type.subtypes.each do |type|
+      # Include uninstantiated generic subclasses: their metaclasses are
+      # callable (e.g. `Bar.foo` where `class Bar(T)`) and must have a
+      # matching branch in virtual dispatch on `Foo+.class` (#11134).
+      instance_type.subtypes_including_generic.each do |type|
         yield type.metaclass
       end
     end


### PR DESCRIPTION
Fixes #11134, #10831.

Two open bugs both trace back to the type lattice treating uninstantiated generic subclasses as outside the "virtual" view of their parent class:

- **#11134**: `Bar.as(Foo.class).foo` segfaults. The dispatch table for `Foo+.class.foo` has no branch for `Bar.metaclass`, so it falls through the `unreachable`.
- **#10831** (deeper case): `x.is_a?(B) && x.is_a?(C)` returns `false` (and the typeof collapses to `NoReturn` in some shapes) when `class C(T) < B(T)`. After the first `is_a?(B)`, `x` is narrowed to `B` — and `common_descendent(B, C)` then doesn't find a path back to `C` because it only walks one side of the generic relationship.

The same code paths likely affect #16947 (`Array(Foo)` containing a `SubGenericFoo(String)`), but I couldn't reproduce its segfault on current master in any build mode, so I'm not claiming it as a fixed issue. The codegen change here plausibly helps it, but without a deterministic reproducer there's no regression test, so I'd rather leave it open and let it be closed only when someone can confirm.

## Root cause

`Type#collect_subtypes` in `src/compiler/crystal/types.cr` filters out `GenericType` from a virtual type's subtypes:

```crystal
subtypes << type unless type.is_a?(GenericType) || type.unbound?
```

That's right for *instance* virtual dispatch — `Bar(T)` itself isn't instantiable — but for *metaclass* dispatch the uninstantiated `Bar` IS a callable class value. And in the intersection logic, the absence of the relationship in both directions makes chained `is_a?` filters collapse.

## Fix

Three coordinated changes:

1. **`Type::VirtualType`** (`types.cr`): add `subtypes_including_generic` and `collect_subtypes_including_generic`. They yield uninstantiated `GenericType` subclasses *only when no instantiations exist* — if instantiations exist, those already carry the dispatch, and including the uninstantiated form would trip up class methods that reference the type parameter (e.g. `def self.x; T.foo; end`, the pattern in spec #9621). This is what kept the regression scope small.

2. **`VirtualMetaclassType#each_concrete_type`** (`types.cr`) and **`VirtualTypeLookup#lookup_matches`** (`method_lookup.cr`): use the new method when iterating subtypes for a virtual *metaclass*. This adds the missing branch for `Bar.metaclass` in `Foo+.class`'s dispatch table and `~match` function. Instance virtual dispatch is unchanged.

3. **`common_descendent(GenericClassType, GenericClassType)`** (`type_intersect.cr`): try `common_descendent_instance_and_generic` in both directions, so the relationship `C(T) < B(T)` flows in either order through chained `is_a?`.

## Tests

- `spec/compiler/codegen/class_spec.cr` — one `run`-based regression for #11134 (return value `2`).
- `spec/compiler/semantic/is_a_spec.cr` — one `run(...).to_b` regression for #10831 deep case. (Verified to fail on the unpatched compiler and pass on the patched one.)

The simple case of #10831 (`x.is_a?(B) && x.is_a?(B(Int32))`) was already fixed previously and continues to pass.
