### PR TITLE
Set `optsize` and `minsize` fun attributes for the `-Os` and `-Oz` optimization modes

### DIFF
--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -467,6 +467,13 @@ class Crystal::CodeGenVisitor
       context.fun.add_attribute LLVM::Attribute::NoInline if target_def.no_inline?
     end
 
+    {% unless LibLLVM::IS_LT_130 %}
+      case @program.optimization_mode
+      when .os? then context.fun.add_attribute LLVM::Attribute::OptimizeForSize
+      when .oz? then context.fun.add_attribute LLVM::Attribute::MinSize
+      end
+    {% end %}
+
     context.fun.add_attribute LLVM::Attribute::ReturnsTwice if target_def.returns_twice?
     context.fun.add_attribute LLVM::Attribute::Naked if target_def.naked?
     context.fun.add_attribute LLVM::Attribute::NoReturn if target_def.no_returns?

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -290,6 +290,7 @@ module Crystal
       program.show_error_trace = show_error_trace?
       program.progress_tracker = @progress_tracker
       program.warnings = @warnings
+      program.optimization_mode = @optimization_mode
       program
     end
 
@@ -884,15 +885,11 @@ module Crystal
       {% if LibLLVM::IS_LT_130 %}
         optimize_with_pass_manager(llvm_mod)
       {% else %}
-        {% if LibLLVM::IS_LT_170 %}
-          # PassBuilder doesn't support Os and Oz before LLVM 17
-          if @optimization_mode.os? || @optimization_mode.oz?
-            return optimize_with_pass_manager(llvm_mod)
-          end
-        {% end %}
+        optimization_mode = @optimization_mode
+        optimization_mode = OptimizationMode::O2 if optimization_mode.os? || optimization_mode.oz?
 
         LLVM::PassBuilderOptions.new do |options|
-          LLVM.run_passes(llvm_mod, "default<#{@optimization_mode}>", target_machine, options)
+          LLVM.run_passes(llvm_mod, "default<#{optimization_mode}>", target_machine, options)
         end
       {% end %}
     end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -155,7 +155,7 @@ module Crystal
 
     property compiler : Compiler?
 
-    property optimization_mode : Compiler::OptimizationMode = Compiler::OptimizationMode::O0
+    property optimization_mode = Compiler::OptimizationMode::O0
 
     def initialize
       super(self, self, "main")

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -155,6 +155,8 @@ module Crystal
 
     property compiler : Compiler?
 
+    property optimization_mode : Compiler::OptimizationMode = Compiler::OptimizationMode::O0
+
     def initialize
       super(self, self, "main")
 


### PR DESCRIPTION
LLVM 23 removes the `PassBuilder` support for `default<Os>` and `default<Oz>` that was introduced in LLVM 17.

Instead, we shall use the `default<O2>` optimization level, and set the `optsize` (`-Os`) or `minsize` (`-Oz`) function attribute to every functions, which has the same behavior. This in turn enables support for `-Oz` and `-Oz` for LLVM 13 to 16.

I manually tested against different LLVM versions (15, 18, 21 and 23): `-Os` is smaller than any `-O0` to `-O3` level, and `-Oz` is even smaller.

closes #16895
related to #14463