### PR TITLE
Split error helper for compiler CLI into independent methods

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -163,7 +163,7 @@ class Crystal::Command
     # errors in order to trace the require path. The causes are listed similarly
     # to `#inspect_with_backtrace` but without the backtrace.
     while cause = ex.cause
-      error ex.message, exit_code: nil
+      print_error ex.message
       ex = cause
     end
 
@@ -770,9 +770,18 @@ class Crystal::Command
   end
 
   private def error(msg, exit_code = 1)
+    set_color
+    Crystal.error msg, @color, exit_code
+  end
+
+  private def print_error(msg)
+    set_color
+    Crystal.print_error(msg, @color)
+  end
+
+  private def set_color
     # This is for the case where the main command is wrong
     @color = false if ARGV.includes?("--no-color") || !Colorize.default_enabled?(STDOUT, STDERR)
-    Crystal.error msg, @color, exit_code: exit_code
   end
 
   private def self.crystal_opts

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -130,7 +130,7 @@ class Crystal::Command
       run_command(single_file: true)
     else
       if command.ends_with?(".cr")
-        error "file '#{command}' does not exist"
+        abort "file '#{command}' does not exist"
       elsif external_command = Process.find_executable("crystal-#{command}")
         options.shift
 
@@ -142,7 +142,7 @@ class Crystal::Command
           "CRYSTAL_EXEC_PATH" => crystal_exec_path,
         })
       else
-        error "unknown command: #{command}"
+        abort "unknown command: #{command}"
       end
     end
   rescue ex : Crystal::CodeError
@@ -167,14 +167,14 @@ class Crystal::Command
       ex = cause
     end
 
-    error ex.message
+    abort ex.message
   rescue ex : OptionParser::Exception
-    error ex.message
+    abort ex.message
   rescue ex
     report_warnings
 
     ex.inspect_with_backtrace STDERR
-    error "you've found a bug in the Crystal compiler. Please open an issue, including source code that will allow us to reproduce the bug: https://github.com/crystal-lang/crystal/issues"
+    abort "you've found a bug in the Crystal compiler. Please open an issue, including source code that will allow us to reproduce the bug: https://github.com/crystal-lang/crystal/issues"
   end
 
   private def tool
@@ -217,7 +217,7 @@ class Crystal::Command
       puts COMMANDS_USAGE
       exit
     else
-      error "unknown tool: #{tool}"
+      abort "unknown tool: #{tool}"
     end
   end
 
@@ -398,7 +398,7 @@ class Crystal::Command
           if frame_pointers = FramePointers.parse?(value)
             compiler.frame_pointers = frame_pointers
           else
-            error "Invalid value `#{value}` for frame-pointers"
+            abort "Invalid value `#{value}` for frame-pointers"
           end
         end
       end
@@ -418,7 +418,7 @@ class Crystal::Command
         opts.on("--x86-asm-syntax att|intel", "X86 dialect for --emit=asm: AT&T (default), Intel") do |value|
           case value = LLVM::InlineAsmDialect.parse?(value)
           in Nil
-            error "Invalid value `#{value}` for x86-asm-syntax"
+            abort "Invalid value `#{value}` for x86-asm-syntax"
           in .att?
             # Do nothing
           in .intel?
@@ -612,7 +612,7 @@ class Crystal::Command
 
       # Check if we'll overwrite the main source file
       if !compiler.no_codegen? && !run && first_filename == File.expand_path(output_filename)
-        error "compilation will overwrite source file '#{Crystal.relative_filename(first_filename)}', either change its extension to '.cr' or specify an output file with '-o'"
+        abort "compilation will overwrite source file '#{Crystal.relative_filename(first_filename)}', either change its extension to '.cr' or specify an output file with '-o'"
       end
     else
       output_filename = output_path.to_s
@@ -623,13 +623,13 @@ class Crystal::Command
 
     output_format ||= allowed_formats[0]
     unless output_format.in?(allowed_formats)
-      error "You have input an invalid format: #{output_format}. Supported formats: #{allowed_formats.join(", ")}"
+      abort "You have input an invalid format: #{output_format}. Supported formats: #{allowed_formats.join(", ")}"
     end
 
-    error "maximum number of threads cannot be lower than 1" if compiler.n_threads < 1
+    abort "maximum number of threads cannot be lower than 1" if compiler.n_threads < 1
 
     if !compiler.no_codegen? && !run && Dir.exists?(output_filename)
-      error "can't use `#{output_filename}` as output filename because it's a directory"
+      abort "can't use `#{output_filename}` as output filename because it's a directory"
     end
 
     if run
@@ -647,7 +647,7 @@ class Crystal::Command
       Compiler::Source.new(filename, File.read(filename))
     end
   rescue exc : IO::Error
-    error exc
+    abort exc
   end
 
   private def setup_simple_compiler_options(compiler, opts)
@@ -728,7 +728,7 @@ class Crystal::Command
                          when "medium"  then LLVM::CodeModel::Medium
                          when "large"   then LLVM::CodeModel::Large
                          else
-                           error "--mcmodel should be one of: default, kernel, tiny, small, medium, large"
+                           abort "--mcmodel should be one of: default, kernel, tiny, small, medium, large"
                            raise "unreachable"
                          end
     end
@@ -742,7 +742,7 @@ class Crystal::Command
                                 when "none"
                                   Crystal::WarningLevel::None
                                 else
-                                  error "--warnings should be all, or none"
+                                  abort "--warnings should be all, or none"
                                   raise "unreachable"
                                 end
     end
@@ -763,15 +763,15 @@ class Crystal::Command
       if target = Compiler::EmitTarget.parse?(value.gsub('-', '_'))
         emit_targets |= target
       else
-        error "invalid emit value '#{value}'"
+        abort "invalid emit value '#{value}'"
       end
     end
     emit_targets
   end
 
-  private def error(msg, exit_code = 1)
+  private def abort(msg, exit_code = 1)
     set_color
-    Crystal.error msg, @color, exit_code
+    Crystal.abort msg, @color, exit_code
   end
 
   private def print_error(msg)

--- a/src/compiler/crystal/command/cursor.cr
+++ b/src/compiler/crystal/command/cursor.cr
@@ -34,7 +34,7 @@ class Crystal::Command
     begin
       loc = Location.parse(config.cursor_location.not_nil!, expand: true)
     rescue ex : ArgumentError
-      error ex.message
+      abort ex.message
     end
 
     result = @progress_tracker.stage("Tool (#{command.split(' ')[1]})") do

--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -170,7 +170,7 @@ class Crystal::Command
     end
 
     private def error(msg)
-      Crystal.error msg, @color, exit_code: nil, stderr: @stderr, leading_error: false
+      Crystal.print_error msg, @color, stderr: @stderr, leading_error: false
     end
   end
 end

--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -124,7 +124,7 @@ class Crystal::Command
         filenames = Dir["#{filename}/**/*.cr"]
         format_many filenames
       else
-        error "file or directory does not exist: #{filename}"
+        print_error "file or directory does not exist: #{filename}"
       end
     end
 
@@ -139,7 +139,7 @@ class Crystal::Command
       return if result == source
 
       if @check
-        error "formatting '#{filename}' produced changes"
+        print_error "formatting '#{filename}' produced changes"
         @status_code = 1
       else
         unless @format_stdin
@@ -148,18 +148,18 @@ class Crystal::Command
         end
       end
     rescue ex : InvalidByteSequenceError
-      error "file '#{filename}' is not a valid Crystal source file: #{ex.message}"
+      print_error "file '#{filename}' is not a valid Crystal source file: #{ex.message}"
       @status_code = 1
     rescue ex : Crystal::SyntaxException
-      error "syntax error in '#{filename}:#{ex.line_number}:#{ex.column_number}': #{ex.message}"
+      print_error "syntax error in '#{filename}:#{ex.line_number}:#{ex.column_number}': #{ex.message}"
       @status_code = 1
     rescue ex
       if @show_backtrace
         ex.inspect_with_backtrace @stderr
         @stderr.puts
-        error "couldn't format '#{filename}', please report a bug including the contents of it: https://github.com/crystal-lang/crystal/issues"
+        print_error "couldn't format '#{filename}', please report a bug including the contents of it: https://github.com/crystal-lang/crystal/issues"
       else
-        error "there's a bug formatting '#{filename}', to show more information, please run:\n\n  $ crystal tool format --show-backtrace #{@format_stdin ? "-" : "'#{filename}'"}\n"
+        print_error "there's a bug formatting '#{filename}', to show more information, please run:\n\n  $ crystal tool format --show-backtrace #{@format_stdin ? "-" : "'#{filename}'"}\n"
       end
       @status_code = 1
     end
@@ -169,7 +169,7 @@ class Crystal::Command
       Crystal.format(source, filename: filename, report_warnings: STDERR)
     end
 
-    private def error(msg)
+    private def print_error(msg)
       Crystal.print_error msg, @color, stderr: @stderr, leading_error: false
     end
   end

--- a/src/compiler/crystal/command/repl.cr
+++ b/src/compiler/crystal/command/repl.cr
@@ -40,7 +40,7 @@ class Crystal::Command
     else
       filename = options.shift
       unless File.file?(filename)
-        error "File '#{filename}' doesn't exist"
+        abort "File '#{filename}' doesn't exist"
       end
 
       show_banner

--- a/src/compiler/crystal/command/spec.cr
+++ b/src/compiler/crystal/command/spec.cr
@@ -54,7 +54,7 @@ class Crystal::Command
         if filename =~ /\A(.+?)\:(\d+)\Z/
           file, line = $1, $2
           unless File.file?(file)
-            error "'#{file}' is not a file"
+            abort "'#{file}' is not a file"
           end
           target_filenames << file
           locations << {file, line}
@@ -65,7 +65,7 @@ class Crystal::Command
           elsif File.file?(filename)
             target_filenames << filename
           else
-            error "'#{filename}' is not a file"
+            abort "'#{filename}' is not a file"
           end
         end
       end

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -467,7 +467,7 @@ module Crystal
             extra_suffix = static? ? "-static" : "-dynamic"
             search_result = Loader.search_libraries(Process.parse_arguments_windows(link_args.join(' ').gsub('\n', ' ')), extra_suffix: extra_suffix)
             if not_found = search_result.not_found?
-              error "Cannot locate the .lib files for the following libraries: #{not_found.join(", ")}"
+              abort "Cannot locate the .lib files for the following libraries: #{not_found.join(", ")}"
             end
 
             link_args = search_result.remaining_args.concat(search_result.library_paths).map { |arg| Process.quote_windows(arg) }
@@ -570,11 +570,11 @@ module Crystal
           end
           unless $?.success?
             error_io.rewind
-            error "Error executing subcommand for linker flags: #{command.inspect}: #{error_io}"
+            abort "Error executing subcommand for linker flags: #{command.inspect}: #{error_io}"
           end
           output.chomp
         rescue exc
-          error "Error executing subcommand for linker flags: #{command.inspect}: #{exc}"
+          abort "Error executing subcommand for linker flags: #{command.inspect}: #{exc}"
         end
       end
     end
@@ -600,7 +600,7 @@ module Crystal
 
       # We check again because maybe this directory was created in between (maybe with a macro run)
       if Dir.exists?(output_filename)
-        error "can't use `#{output_filename}` as output filename because it's a directory"
+        abort "can't use `#{output_filename}` as output filename because it's a directory"
       end
 
       output_filename = File.expand_path(output_filename)
@@ -927,7 +927,7 @@ module Crystal
           # abnormal exit
           exit_code = 1
         end
-        error "execution of command failed with exit status #{status}: #{command}", exit_code: exit_code
+        abort "execution of command failed with exit status #{status}: #{command}", status: exit_code
       end
     end
 
@@ -935,14 +935,14 @@ module Crystal
       verbose_info = "\nRun with `--verbose` to print the full linker command." unless verbose?
       case exc_class
       when File::AccessDeniedError
-        error "Could not execute linker: `#{linker_name}`: Permission denied#{verbose_info}"
+        abort "Could not execute linker: `#{linker_name}`: Permission denied#{verbose_info}"
       else
-        error "Could not execute linker: `#{linker_name}`: File not found#{verbose_info}"
+        abort "Could not execute linker: `#{linker_name}`: File not found#{verbose_info}"
       end
     end
 
-    private def error(msg, exit_code = 1)
-      Crystal.error msg, @color, exit_code, stderr: stderr
+    private def abort(msg, exit_code = 1)
+      Crystal.abort msg, @color, exit_code, stderr: stderr
     end
 
     private def colorize(obj)

--- a/src/compiler/crystal/tools/flags.cr
+++ b/src/compiler/crystal/tools/flags.cr
@@ -44,7 +44,7 @@ class Crystal::Command
           end
         end
       else
-        Crystal.error "file or directory does not exist: #{path}", @color, leading_error: false
+        Crystal.abort "file or directory does not exist: #{path}", @color, leading_error: false
       end
     end
   end

--- a/src/compiler/crystal/util.cr
+++ b/src/compiler/crystal/util.cr
@@ -15,9 +15,9 @@ module Crystal
     filename
   end
 
-  def self.error(msg, color, exit_code : Int = 1, stderr = STDERR, leading_error = true) : NoReturn
+  def self.abort(msg, color, exit_code : Int = 1, stderr = STDERR, leading_error = true) : NoReturn
     print_error(msg, color, stderr, leading_error)
-    exit(exit_code)
+    ::abort(exit_code)
   end
 
   def self.print_error(msg, color, stderr = STDERR, leading_error = true)

--- a/src/compiler/crystal/util.cr
+++ b/src/compiler/crystal/util.cr
@@ -16,11 +16,11 @@ module Crystal
   end
 
   def self.error(msg, color, exit_code : Int = 1, stderr = STDERR, leading_error = true) : NoReturn
-    error(msg, color, nil, stderr, leading_error)
+    print_error(msg, color, stderr, leading_error)
     exit(exit_code)
   end
 
-  def self.error(msg, color, exit_code : Nil, stderr = STDERR, leading_error = true)
+  def self.print_error(msg, color, stderr = STDERR, leading_error = true)
     stderr.print "Error: ".colorize.toggle(color).red.bold if leading_error
     stderr.puts msg.colorize.toggle(color).bright
   end


### PR DESCRIPTION
Simplifies error reporting helpers for the compiler CLI: with two separate helper methods `#abort` and `#print_error` with clearly assigned responsibilities. They replace the single `#error` method which may or may not exit the program, depending on the type of the `exit_code` parameter.