### PR TITLE
Downcast wider union body to narrower declared return type (#14596)

### DIFF
--- a/spec/compiler/codegen/return_spec.cr
+++ b/spec/compiler/codegen/return_spec.cr
@@ -103,4 +103,22 @@ describe "Code gen: return" do
       v[3] &- v[2]
       CRYSTAL
   end
+
+  it "doesn't ICE when body is a wider union than the declared return type (#14596)" do
+    codegen(<<-CRYSTAL)
+      class Foo
+        @x = uninitialized -> Bool
+      end
+
+      def foo(cond) : -> Bool
+        if cond.is_a?(Foo)
+          -> { foo(cond.@x).call }
+        else
+          cond
+        end
+      end
+
+      foo(Foo.new)
+      CRYSTAL
+  end
 end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -889,7 +889,17 @@ module Crystal
       elsif method_type.no_return?
         unreachable
       else
-        value = upcast(@last, method_type, type)
+        # When a typed def's `freeze_type` restricts a wider body type
+        # (e.g. body is `Proc(Bool) | Proc(NoReturn)` and freeze_type narrowed
+        # the def's type to `Proc(Bool)`), the body's `@last` value is in the
+        # wider type's representation. Extract via `downcast` instead of
+        # `upcast`, which would either no-op the wrong shape or hit the
+        # generic `cast_to` and produce an LLVM type mismatch (#14596).
+        if type.is_a?(UnionType) && !method_type.is_a?(UnionType)
+          value = downcast(@last, method_type, type, already_loaded: true)
+        else
+          value = upcast(@last, method_type, type)
+        end
         ret to_rhs(value, method_type)
       end
     end


### PR DESCRIPTION
Fixes #14596.

Recursive proc with a declared return type produces an LLVM module-validation ICE:

```crystal
class Foo
  @x = uninitialized -> Bool
end

def foo(cond) : -> Bool
  if cond.is_a?(Foo)
    -> { foo(cond.@x).call }
  else
    cond
  end
end

foo(Foo.new)
```

```
Module validation failed: Function return type does not match operand type of return inst!
  ret ptr %0, !dbg !592
 %"->" = type { ptr, ptr }
```

## Root cause

I instrumented `ProcLiteral#update`, `If#bind_to`, and `codegen_return` to trace types around the failing function:

1. The recursive `-> { foo(cond.@x).call }` is typed *twice* (one ProcLiteral per `foo` instantiation). One ends up as `Proc(Bool)` (outer instantiation), the other settles at `Proc(NoReturn)` because of the recursion cycle — when the inner instantiation visits its body, the recursive `foo(cond.@x)` call has no resolved type yet, so `.call` returns `NoReturn`, and the proc literal types as `Proc(NoReturn)`.
2. The `if` therefore types as `Proc(Bool) | Proc(NoReturn)`.
3. The def's `freeze_type` (from `: -> Bool`) restricts `typed_def.type` to `Proc(Bool)` via `restrict_type_to_freeze_type`. But the *body's* `If`-type stays as the union.
4. At `codegen_return`: `method_type = Proc(Bool)`, `type = (Proc(Bool) | Proc(NoReturn))`. The existing code did `upcast` (wrong direction — the body is *wider*, not narrower), and the LLVM `ret` got a value with the union's shape rather than `Proc(Bool)`'s `{ptr, ptr}` shape.

## Fix

In `CodeGenVisitor#codegen_return`: when the body's type is a `UnionType` and the method's declared return type is not, the existing `cast.cr#downcast_distinct(Type, MixedUnionType)` path already knows how to extract a value from a union. Switch to `downcast` in that case.

## What I tried first (and abandoned)

A deeper type-inference fix — seeding `typed_def.type` with `freeze_type` so recursive calls would see `Proc(Bool)` from the start. Didn't fix the bug: even with `typed_def.type` pre-seeded, the body's `If`-expression still ends up as the union because the freeze restriction only narrows the node carrying the `freeze_type`, not sub-expressions inside its body. Pushing the restriction down through every body sub-node is much larger surgery.

## Tests

`spec/compiler/codegen/return_spec.cr` — regression test using `codegen(...)` covering the exact reproducer.

Full `make compiler_spec`: **13479 examples, 0 failures, 0 errors** (18 pre-existing pending).

---

Split out from a combined PR per reviewer request. The companion fix for #12733 (NoReturn-typed instance var read) is in a separate PR.
