### PR TITLE
Emit unreachable when reading a NoReturn-typed instance var (#12733)

### DIFF
--- a/spec/compiler/codegen/no_return_spec.cr
+++ b/spec/compiler/codegen/no_return_spec.cr
@@ -89,4 +89,17 @@ describe "Code gen: no return" do
       typeof(raise("").foo)
       CRYSTAL
   end
+
+  it "doesn't ICE when reading a NoReturn-typed instance var (#12733)" do
+    codegen(<<-CRYSTAL)
+      struct Entry
+        def initialize(@key : NoReturn)
+        end
+      end
+
+      entry = uninitialized Entry
+      entry.@key
+      0
+      CRYSTAL
+  end
 end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1424,6 +1424,13 @@ module Crystal
     end
 
     def end_visit(node : ReadInstanceVar)
+      # Reading a `NoReturn`-typed ivar (e.g. `@x : NoReturn`) is statically
+      # unreachable. Emit `unreachable` and stop, so any following code is
+      # treated as dead — otherwise codegen would emit a wrong-shape load
+      # whose value flows into the enclosing function's `ret`, producing an
+      # LLVM module-validation error (#12733).
+      return unreachable if node.type.no_return?
+
       obj_type = node.obj.type
       if obj_type.is_a?(UnionType)
         union_ptr = @last


### PR DESCRIPTION
Fixes #12733.

Reading a `NoReturn`-typed instance variable from an `uninitialized` struct produces an LLVM module-validation ICE:

```crystal
struct Entry
  def initialize(@key : NoReturn)
  end
end

entry = uninitialized Entry
entry.@key
0
```

```
Module validation failed: Function return type does not match operand type of return inst!
  ret i8 %25
 i32
```

## Root cause

`CleanupTransformer#transform(Expressions)` drops the trailing `0` because the previous expression (`entry.@key`) is `NoReturn`. But the `Expressions` node's *type binding* still points at the old last (`Int32` from `0`). At codegen, the function's signature uses that stale `Int32`, while the actual body `@last` is the i8 produced by the NoReturn ivar load → ill-typed `ret i8 %25` against `i32` return.

I tried rebinding the `Expressions` node in `CleanupTransformer` so the body's type would become `NoReturn`. That worked for the reduced repro but broke 8 existing specs — Crystal's existing convention is that a `def bar : Int32 ... LibC.exit; 1 end` keeps `Int32` as the def's type even though the body actually never returns, and the "stale" type binding was what made that work. Updating the binding propagated `NoReturn` up and broke that convention.

## Fix

`end_visit(ReadInstanceVar)` in `codegen.cr` was missing the `unreachable`-on-NoReturn check that `visit(Var)` already has (`codegen.cr:1406`):

```crystal
return unreachable if node.type.no_return?
```

When the ivar read is `NoReturn`-typed, emit `unreachable` and stop. `@builder.end` becomes true, `visit_any` short-circuits the rest of the body, and `codegen_return` early-returns without emitting an ill-typed `ret`.

This leaves the type lattice alone — only fixes the actual IR emission.

## Tests

`spec/compiler/codegen/no_return_spec.cr` — regression test using `codegen(...)` covering the reduced reproducer from the issue.

---

Split out from #16985 per reviewer request.
