### PR TITLE
Register generic instantiations on non-generic module ancestors (#16947)

### DIFF
--- a/spec/compiler/codegen/module_spec.cr
+++ b/spec/compiler/codegen/module_spec.cr
@@ -622,4 +622,66 @@ describe "Code gen: module" do
       foo(a)
       CRYSTAL
   end
+
+  it "registers generic instantiations as including types of non-generic module ancestors (#16947)" do
+    # Before the fix, `GenericClassInstanceType#after_initialize` only notified
+    # `GenericModuleInstanceType` ancestors. A non-generic module like `Foo`
+    # never learned about the generic-class instantiation, so the virtual
+    # dispatch table for `Foo+#inspect` (built from `Foo.including_types`) was
+    # missing the `GenericFoo(String)` branch. At runtime, the dispatch hit an
+    # `unreachable` and produced wrong output — `[#<GenericFoo...>, ]` here.
+    run(<<-CRYSTAL).to_b.should be_true
+      require "prelude"
+
+      module Foo
+        def method
+        end
+      end
+
+      module CompoundFoo
+        include Foo
+        abstract def foos : Enumerable(Foo)
+      end
+
+      class GenericFoo(T)
+        include Foo
+        getter value : T
+        def initialize(@value : T); end
+      end
+
+      class SubGenericFoo(T) < GenericFoo(T)
+      end
+
+      class SingletonFoo
+        include CompoundFoo
+        def foos : Array(Foo)
+          singleton = [] of Foo
+          singleton << GenericFoo(String).new("singleton")
+          String.build { |io| singleton.to_s(io) }
+          singleton
+        end
+        def method
+          foos
+        end
+      end
+
+      class ArrayFoo
+        include CompoundFoo
+        getter foos : Array(Foo)
+        def initialize(@foos : Array(Foo)); end
+      end
+
+      class SubArrayFoo < ArrayFoo
+      end
+
+      SingletonFoo.new.foos
+      [GenericFoo(String).new("x")].select(Foo).each(&.method)
+
+      array = [] of Foo
+      array << GenericFoo(String).new("first")
+      array << SubGenericFoo(String).new("sub")
+      out = String.build { |io| array.to_s(io) }
+      out.includes?("GenericFoo(String)") && out.includes?("SubGenericFoo(String)")
+      CRYSTAL
+  end
 end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2256,7 +2256,21 @@ module Crystal
 
     def self.includers(type)
       case type
-      when NonGenericModuleType, GenericModuleType, GenericModuleInstanceType
+      when NonGenericModuleType
+        types = type.raw_including_types
+        return empty_no_return_array unless types
+        # For non-generic modules, `includers` reports types `self` is
+        # *directly* included in. Generic instantiations are also recorded in
+        # `@including_types` (so virtual dispatch can find them — see #16947)
+        # but they aren't direct includers and shouldn't appear here.
+        direct = types.reject do |t|
+          t.is_a?(GenericClassInstanceType) || t.is_a?(GenericModuleInstanceType)
+        end
+        return empty_no_return_array if direct.empty?
+        ArrayLiteral.map(direct) do |including_type|
+          TypeNode.new including_type
+        end
+      when GenericModuleType, GenericModuleInstanceType
         types = type.raw_including_types
         return empty_no_return_array unless types
         ArrayLiteral.map(types) do |including_type|

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2130,7 +2130,15 @@ module Crystal
     def after_initialize
       superclass.not_nil!.add_subclass(self)
       ancestors.each do |ancestor|
-        ancestor.add_including_type(self) if ancestor.is_a?(GenericModuleInstanceType)
+        # Notify module ancestors (both non-generic and generic-instance forms)
+        # that this instantiation includes them. Without the `NonGenericModuleType`
+        # case, a virtual dispatch built from `Foo.including_types` may miss
+        # this instantiation as a possible runtime element type, producing an
+        # `unreachable` branch in codegen (#16947).
+        case ancestor
+        when GenericModuleInstanceType, NonGenericModuleType
+          ancestor.add_including_type(self)
+        end
       end
     end
 
@@ -2194,7 +2202,10 @@ module Crystal
 
     def after_initialize
       ancestors.each do |ancestor|
-        ancestor.add_including_type(self) if ancestor.is_a?(GenericModuleInstanceType)
+        case ancestor
+        when GenericModuleInstanceType, NonGenericModuleType
+          ancestor.add_including_type(self)
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #16947.

## The bug

For this program, `puts array` prints with the second element missing (`[#<GenericFoo...>, ]`) — and on some setups (LLVM 20.1.8 on Ubuntu 24.04 per the issue) it segfaults instead. Both symptoms are the same underlying undefined behaviour:

```crystal
module Foo
end

class GenericFoo(T)
  include Foo
end

class ArrayFoo
  include Foo
end

class SubArrayFoo < ArrayFoo
end

first = GenericFoo(String).new
sub = GenericFoo(Int32).new

array = [] of Foo
array << first
array << sub
puts array          # before: "[#<GenericFoo(String):0x...>, ]" — empty 2nd element
```

LLVM IR confirms the dispatch generated for `Foo+#inspect(IO::FileDescriptor)` inside `Array(Foo)#to_s` only had branches for `SubArrayFoo` and the `ArrayFoo+` type-id range. There was no entry for `GenericFoo(String)`, so execution hit an `unreachable` — runtime UB.

## Root cause

`GenericClassInstanceType#after_initialize` only notified `GenericModuleInstanceType` ancestors when a new instantiation came into existence:

```crystal
def after_initialize
  superclass.not_nil!.add_subclass(self)
  ancestors.each do |ancestor|
    ancestor.add_including_type(self) if ancestor.is_a?(GenericModuleInstanceType)
  end
end
```

So when `class GenericFoo(T); include Foo; end` (with `Foo` a non-generic module), instantiating `GenericFoo(String)` never told `Foo` about it. `Foo.including_types` — the source of truth for `Foo+`'s virtual dispatch — was missing the instantiation.

For *classes*, the parallel registration goes through `ClassType#add_subclass` so the issue doesn't appear. For *generic modules* included by generic classes, the `GenericModuleInstanceType` branch above handles it. The non-generic-module case was the gap.

## Fix

Two coordinated changes:

1. **`src/compiler/crystal/types.cr`** — extend the `after_initialize` notification on both `GenericClassInstanceType` and `GenericModuleInstanceType` to also cover `NonGenericModuleType` ancestors. The `add_including_type` impl on `NonGenericModuleType` already does the right thing (skips unbound types, fires observers).

2. **`src/compiler/crystal/macros/methods.cr`** — the `includers` macro on a `NonGenericModuleType` continues to report only types directly named in an `include` clause, filtering generic instantiations out of the result. They remain in `@including_types` for dispatch purposes (the point of the fix), but they are not "direct includers" and the existing macro contract is preserved. The behaviour for `GenericModuleType` and `GenericModuleInstanceType` is unchanged.

## Tests

- `spec/compiler/codegen/module_spec.cr` — one `run`-based regression that reproduces the original `#16947` setup (`SingletonFoo`, `CompoundFoo`, the `.select(Foo).each(&.method)` chain) and checks the resulting array prints both elements. Verified to fail on the unpatched compiler and pass on the patched one.

## Out of scope

There is a related, more obscure edge case where two literal `Array(Foo)` values are passed inline to `puts` and the first one is empty (`puts [] of Foo; puts [GenericFoo(String).new] of Foo`). The element still drops there, because the call's subclass observer migrates from `Foo` to `ArrayFoo` during narrowing and is no longer woken when `GenericFoo(String)` is registered. That's a separate observer-handling bug; this PR doesn't address it.
