### PR TITLE
Keep wider subclass observer when call owner narrows (#16947)

### DIFF
--- a/spec/compiler/codegen/module_spec.cr
+++ b/spec/compiler/codegen/module_spec.cr
@@ -622,4 +622,38 @@ describe "Code gen: module" do
       foo(a)
       CRYSTAL
   end
+
+  it "rebuilds dispatch when new generic instantiation flows through Array(Module) element (#16947)" do
+    # `Call#attach_subclass_observer` used to remove the existing observer
+    # before adding the new one. When a call narrowed from `Foo+` to
+    # `ArrayFoo+` during re-lookup, the observer migrated away from `Foo`,
+    # so subsequent `GenericFoo(String)` instantiations never woke the call.
+    # The dispatch table for `Foo+#inspect` was then frozen without a
+    # `GenericFoo(String)` branch and execution hit an `unreachable` at
+    # runtime — segfaulting on some setups, printing wrong output on others.
+    # The bug only reproduces with `puts` (IO::FileDescriptor), so the
+    # regression test runs the program and asserts the captured stdout.
+    output = run(<<-CRYSTAL).to_string
+      require "prelude"
+
+      module Foo
+      end
+
+      class GenericFoo(T)
+        include Foo
+      end
+
+      class ArrayFoo
+        include Foo
+      end
+
+      class SubArrayFoo < ArrayFoo
+      end
+
+      puts [] of Foo
+      puts [GenericFoo(String).new] of Foo
+      nil
+      CRYSTAL
+    output.should contain("GenericFoo(String)")
+  end
 end

--- a/spec/compiler/codegen/module_spec.cr
+++ b/spec/compiler/codegen/module_spec.cr
@@ -624,15 +624,6 @@ describe "Code gen: module" do
   end
 
   it "rebuilds dispatch when new generic instantiation flows through Array(Module) element (#16947)" do
-    # `Call#attach_subclass_observer` used to remove the existing observer
-    # before adding the new one. When a call narrowed from `Foo+` to
-    # `ArrayFoo+` during re-lookup, the observer migrated away from `Foo`,
-    # so subsequent `GenericFoo(String)` instantiations never woke the call.
-    # The dispatch table for `Foo+#inspect` was then frozen without a
-    # `GenericFoo(String)` branch and execution hit an `unreachable` at
-    # runtime — segfaulting on some setups, printing wrong output on others.
-    # The bug only reproduces with `puts` (IO::FileDescriptor), so the
-    # regression test runs the program and asserts the captured stdout.
     output = run(<<-CRYSTAL).to_string
       require "prelude"
 

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1261,6 +1261,11 @@ class Crystal::Call
 
   def attach_subclass_observer(type : Type)
     if subclass_notifier = @subclass_notifier
+      # If the new notifier is a subtype of (or equal to) the current one,
+      # keep observing the wider type. Migrating to the narrower type would
+      # stop us from being woken when sibling subtypes are later added to
+      # the wider one — leaving the dispatch table stale (#16947).
+      return if type.implements?(subclass_notifier)
       subclass_notifier.as(SubclassObservable).remove_subclass_observer(self)
     end
 


### PR DESCRIPTION
Fixes #16947. **Supersedes #16989** — the 4-line `Call` fix here covers both the original reproducer and a minimal edge case the previous PR couldn't reach.

## The bug

```crystal
module Foo
end

class GenericFoo(T)
  include Foo
end

class ArrayFoo
  include Foo
end

class SubArrayFoo < ArrayFoo
end

puts [] of Foo
puts [GenericFoo(String).new] of Foo
# expected: "[]\n[#<GenericFoo(String):0x...>]\n"
# actual:   "[]\n[]\n"            ← element silently dropped
```

On the reporter's setup (LLVM 20.1.8 / Ubuntu 24.04) the same defect surfaces as a segfault rather than dropped output, but it's the same undefined behaviour — LLVM IR for `Foo+#inspect` inside `Array(Foo)#to_s(IO::FileDescriptor)` is missing the `GenericFoo(String)` branch and execution falls through to `unreachable`.

## Root cause

`Call#attach_subclass_observer` always migrated the observer to the latest type:

```crystal
def attach_subclass_observer(type : Type)
  if subclass_notifier = @subclass_notifier
    subclass_notifier.as(SubclassObservable).remove_subclass_observer(self)
  end
  type.as(SubclassObservable).add_subclass_observer(self)
  @subclass_notifier = type
end
```

The `elem.inspect(io)` call inside `Array(Foo)#to_s` first attaches to `Foo` (its static element type's base). During subsequent re-lookup the call's owner narrows (`Foo+` → `ArrayFoo+` once that hierarchy covers everything currently in scope), and the observer migrates from `Foo` to `ArrayFoo`. When `GenericFoo(String)` is later instantiated, the cascade through `notify_parents_subclass_added` notifies `Foo` — but `Foo` has no observers anymore, so the call never recalculates. The dispatch table stays frozen without the `GenericFoo(String)` branch.

## Fix

Skip the migration when the new notifier is a subtype of (or equal to) the current one. The wider type's `notify_parents_subclass_added` cascade already covers every notification the narrower one would have produced, so the call still recalculates on every relevant change — and it stays subscribed to sibling-subtype additions on the wider type.

## Tests

- `spec/compiler/codegen/module_spec.cr` — new `run`-based regression that exercises the exact `puts [] of Foo; puts [GenericFoo(String).new] of Foo` pattern and asserts the captured stdout contains the element representation. Verified to fail on master and pass on this branch.

## Why this supersedes #16989

#16989 (which I opened first) attacked the symptom in `GenericClassInstanceType#after_initialize` by also registering the new instantiation with `NonGenericModuleType` ancestors. That sidestepped the observer issue by ensuring `Foo.@including_types` was up-to-date *before* the relevant lookups ran, but it only worked when the generic was instantiated before the call site was processed. It also forced a compensating filter in the `includers` macro to preserve "direct includers" semantics.

This fix is structurally smaller and addresses the actual root cause: the observer should not narrow itself out of the notification path. With the observer kept on the wider type, the existing dynamic expansion of `Foo.including_types` (which already iterates `each_instantiated_type` on any `GenericType` it finds) does the right thing whenever a new instantiation appears.

I'll close #16989 once this one lands.
