### PR TITLE
introduce Process.quiesce and UNIX::Process

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -1169,24 +1169,267 @@ describe Process do
     end
   {% end %}
 
-  {% unless flag?(:preview_mt) || flag?(:win32) %}
-    describe ".fork" do
-      it "executes the new process with exec" do
-        with_tempfile("crystal-spec-exec") do |path|
-          File.exists?(path).should be_false
 
-          fork = Process.fork do
-            Process.exec("/usr/bin/env", {"touch", path})
-          end
-          fork.wait
+  describe ".quiesce" do
+    it "passes the block return value through" do
+      Process.quiesce { 42 }.should eq(42)
+    end
 
-          File.exists?(path).should be_true
-        end
+    it "fires before_quiesce_callbacks before the block and after_quiesce_callbacks after" do
+      # Use a fresh pair of arrays so registered callbacks don't bleed between tests
+      before_log = [] of String
+      after_log = [] of String
+      inside_log = [] of String
+
+      before_cb = ->{ before_log << "before"; nil }
+      after_cb  = ->{ after_log << "after"; nil }
+
+      Process.before_quiesce_callbacks << before_cb
+      Process.after_quiesce_callbacks  << after_cb
+
+      begin
+        Process.quiesce { inside_log << "inside"; nil }
+      ensure
+        Process.before_quiesce_callbacks.delete(before_cb)
+        Process.after_quiesce_callbacks.delete(after_cb)
       end
 
-      typeof(Process.fork)
+      before_log.should eq(["before"])
+      after_log.should eq(["after"])
+      inside_log.should eq(["inside"])
     end
-  {% end %}
+
+    {% unless flag?(:preview_mt) || flag?(:win32) %}
+      it "provides a safe window for fork(2)" do
+        pid, saved_errno = Process.quiesce { r = LibC.fork; {r, Errno.value} }
+        raise RuntimeError.from_os_error("fork", saved_errno) if pid == -1
+
+        case pid
+        when 0
+          ::Process.after_fork_child_callbacks.each(&.call)
+          LibC._exit 0
+        else
+          wstatus = uninitialized Int32
+          LibC.waitpid(pid, pointerof(wstatus), 0)
+          pid.should be > 0
+        end
+      end
+    {% end %}
+
+    {% if flag?(:unix) && !flag?(:interpreted) %}
+      it "fires callbacks and reinit_child works under -Dpreview_mt", tags: %w[slow] do
+        status, output, _ = compile_and_run_source <<-'CRYSTAL', ["-Dpreview_mt"]
+          # Verify quiesce callbacks fire under preview_mt
+          log = [] of String
+          before_cb = ->{ log << "before"; nil }
+          after_cb  = ->{ log << "after"; nil }
+          Process.before_quiesce_callbacks << before_cb
+          Process.after_quiesce_callbacks  << after_cb
+
+          result = Process.quiesce { log << "inside"; 99 }
+
+          abort "FAIL: wrong result #{result}" unless result == 99
+          abort "FAIL: wrong order #{log}" unless log == ["before", "inside", "after"]
+
+          # Verify fork via quiesce + reinit_child under preview_mt
+          fork_result = uninitialized LibC::PidT
+          fork_errno  = uninitialized Errno
+
+          Process.quiesce do
+            fork_result = LibC.fork
+            fork_errno  = Errno.value
+            nil
+          end
+
+          case fork_result
+          when 0
+            Crystal::Scheduler.reinit_child
+            ::Process.after_fork_child_callbacks.each(&.call)
+            LibC._exit 0
+          when -1
+            raise RuntimeError.from_os_error("fork", fork_errno)
+          else
+            wstatus = uninitialized Int32
+            LibC.waitpid(fork_result, pointerof(wstatus), 0)
+            puts "ok"
+          end
+          CRYSTAL
+
+        status.success?.should be_true
+        output.chomp.should eq("ok")
+      end
+
+      it "reinit_child in child doesn't deadlock when workers held GC.lock_read at fork time", tags: %w[slow] do
+        status, output, _ = compile_and_run_source <<-'CRYSTAL', ["-Dpreview_mt"]
+          # Flood the scheduler with fiber switches so workers are highly likely to be
+          # mid-swapcontext (holding GC.lock_read) when fork fires.
+          stop = Atomic(Bool).new(false)
+          256.times { spawn { until stop.get; Fiber.yield; end } }
+          sleep 20.milliseconds
+
+          # Pipe for child → parent result signaling; avoids waitpid races with
+          # Crystal's SIGCHLD handler which reaps all children via waitpid(-1).
+          pipe_fds = uninitialized StaticArray(Int32, 2)
+          abort "pipe failed" unless LibC.pipe(pipe_fds) == 0
+
+          # Repeat 10 times: ~60% deadlock rate per attempt means >99.99% detection.
+          10.times do
+            fork_result = uninitialized LibC::PidT
+            fork_errno  = uninitialized Errno
+            Process.quiesce do
+              fork_result = LibC.fork
+              fork_errno  = Errno.value
+              nil
+            end
+
+            case fork_result
+            when 0
+              LibC.close(pipe_fds[0])
+              Crystal::Scheduler.reinit_child
+              ::Process.after_fork_child_callbacks.each(&.call)
+              # Allocation calls GC.lock_write internally (preview_mt path).
+              # If @readers > 0 was inherited from parent workers, this deadlocks.
+              1_000.times { Array(Int32).new(100) { |i| i } }
+              byte = 42u8
+              LibC.write(pipe_fds[1], pointerof(byte).as(Pointer(Void)), 1)
+              LibC.close(pipe_fds[1])
+              LibC._exit 0
+            when -1
+              LibC.close(pipe_fds[0]); LibC.close(pipe_fds[1])
+              raise RuntimeError.from_os_error("fork", fork_errno)
+            else
+              LibC.close(pipe_fds[1])
+              reader = IO::FileDescriptor.new(pipe_fds[0])
+              reader.read_timeout = 5.seconds
+              begin
+                buf = Bytes.new(1)
+                reader.read(buf)
+                unless buf[0] == 42u8
+                  puts "FAIL: unexpected byte"
+                  exit 1
+                end
+              rescue IO::TimeoutError
+                LibC.kill(fork_result, Signal::KILL.value)
+                puts "DEADLOCK"
+                exit 1
+              ensure
+                reader.close
+              end
+            end
+
+            # Re-open pipe for next iteration (child closed its end; parent closed both)
+            abort "pipe failed" unless LibC.pipe(pipe_fds) == 0
+          end
+
+          stop.set(true)
+          puts "ok"
+          CRYSTAL
+
+        status.success?.should be_true
+        output.chomp.should eq("ok")
+      end
+
+      it "after_fork resets signal mutexes so child can use signal API after fork", tags: %w[slow] do
+        status, output, _ = compile_and_run_source <<-'CRYSTAL', ["-Dpreview_mt"]
+          # Reopen the modules to expose the private mutexes for testing.
+          # This lets us deliberately hold them across a fork to simulate the
+          # race where a worker thread holds a mutex at the moment fork fires.
+          module Crystal::System::Signal
+            def self.lock_for_testing : Nil
+              @@mutex.lock
+            end
+            def self.unlock_for_testing : Nil
+              @@mutex.unlock
+            end
+          end
+          module Crystal::System::SignalChildHandler
+            def self.lock_for_testing : Nil
+              @@mutex.lock
+            end
+            def self.unlock_for_testing : Nil
+              @@mutex.unlock
+            end
+          end
+
+          pipe_fds = uninitialized StaticArray(Int32, 2)
+          abort "pipe failed" unless LibC.pipe(pipe_fds) == 0
+
+          # Two worker fibers each hold one of the signal mutexes while the
+          # main fiber forks. Channel rendezvous ensures both locks are held
+          # at the moment fork(2) is called.
+          sig_held   = Channel(Nil).new
+          schld_held = Channel(Nil).new
+          release_sig   = Channel(Nil).new(1)
+          release_schld = Channel(Nil).new(1)
+
+          spawn(same_thread: false) do
+            Crystal::System::Signal.lock_for_testing
+            sig_held.send(nil)
+            release_sig.receive
+            Crystal::System::Signal.unlock_for_testing
+          end
+
+          spawn(same_thread: false) do
+            Crystal::System::SignalChildHandler.lock_for_testing
+            schld_held.send(nil)
+            release_schld.receive
+            Crystal::System::SignalChildHandler.unlock_for_testing
+          end
+
+          sig_held.receive
+          schld_held.receive
+          # Both mutexes are now held by worker threads on other OS threads.
+
+          fork_result = uninitialized LibC::PidT
+          fork_errno  = uninitialized Errno
+          Process.quiesce do
+            fork_result = LibC.fork
+            fork_errno  = Errno.value
+            nil
+          end
+
+          case fork_result
+          when 0
+            LibC.close(pipe_fds[0])
+            Crystal::Scheduler.reinit_child
+            ::Process.after_fork_child_callbacks.each(&.call)
+            # Without the fix, both mutexes are still locked here (the worker
+            # threads that held them no longer exist in the child). Each call
+            # below will deadlock on the respective mutex.
+            Signal::USR1.trap { }                              # needs Signal.@@mutex
+            _ = Crystal::System::SignalChildHandler.wait(-1)  # needs SignalChildHandler.@@mutex
+            byte = 42u8
+            LibC.write(pipe_fds[1], pointerof(byte).as(Pointer(Void)), 1)
+            LibC.close(pipe_fds[1])
+            LibC._exit 0
+          when -1
+            LibC.close(pipe_fds[0]); LibC.close(pipe_fds[1])
+            raise RuntimeError.from_os_error("fork", fork_errno)
+          else
+            release_sig.send(nil)
+            release_schld.send(nil)
+            LibC.close(pipe_fds[1])
+            reader = IO::FileDescriptor.new(pipe_fds[0])
+            reader.read_timeout = 5.seconds
+            begin
+              buf = Bytes.new(1)
+              reader.read(buf)
+              puts buf[0] == 42u8 ? "ok" : "FAIL"
+            rescue IO::TimeoutError
+              LibC.kill(fork_result, Signal::KILL.value)
+              puts "DEADLOCK"
+              exit 1
+            ensure
+              reader.close
+            end
+          end
+          CRYSTAL
+
+        status.success?.should be_true
+        output.chomp.should eq("ok")
+      end
+    {% end %}
+  end
 
   describe ".exec" do
     it "redirects STDIN and STDOUT to files", tags: %w[slow] do
@@ -1258,3 +1501,4 @@ describe Process do
     {% end %}
   end
 end
+

--- a/spec/std/unix/process_spec.cr
+++ b/spec/std/unix/process_spec.cr
@@ -1,0 +1,112 @@
+{% skip_file unless flag?(:unix) %}
+
+require "spec"
+require "unix/process"
+require "../spec_helper"
+require "../../support/env"
+
+private def exit_code_command(code)
+  {"/bin/sh", {"-c", "exit #{code}"}}
+end
+
+describe UNIX::Process do
+  describe ".fork (no block)" do
+    it "returns UNIX::Process in parent and nil in child" do
+      if child = UNIX::Process.fork
+        child.should be_a(UNIX::Process)
+        child.wait
+      else
+        LibC._exit 0
+      end
+    end
+
+    it "typeof returns UNIX::Process?" do
+      typeof(UNIX::Process.fork).should eq(UNIX::Process?)
+    end
+  end
+
+  describe ".fork (with block)" do
+    it "returns UNIX::Process from parent side" do
+      child = UNIX::Process.fork { LibC._exit 0 }
+      child.should be_a(UNIX::Process)
+      child.wait
+    end
+
+    it "executes a command in the child via exec" do
+      with_tempfile("unix-process-fork-exec") do |path|
+        File.exists?(path).should be_false
+        child = UNIX::Process.fork do
+          UNIX::Process.exec("/usr/bin/env", {"touch", path})
+        end
+        child.wait
+        File.exists?(path).should be_true
+      end
+    end
+  end
+
+  describe ".exec" do
+    it "replaces the process" do
+      with_tempfile("unix-exec-stdout") do |stdout_path|
+        status, _, _ = compile_and_run_source <<-CRYSTAL
+          require "unix/process"
+          File.open(#{stdout_path.inspect}, "w") do |fd|
+            UNIX::Process.exec(#{exit_code_command(0)[0].inspect},
+              #{exit_code_command(0)[1].to_a.inspect} of String,
+              output: fd)
+          end
+          CRYSTAL
+        status.success?.should be_true
+      end
+    end
+
+    it "raises on missing executable" do
+      expect_raises(File::NotFoundError) do
+        UNIX::Process.exec("__no_such_binary__")
+      end
+    end
+  end
+
+  describe ".pgid" do
+    it "returns an integer for the current process" do
+      UNIX::Process.pgid.should be_a(Int64)
+    end
+
+    it "returns an integer for a known pid" do
+      UNIX::Process.pgid(Process.pid).should be_a(Int64)
+    end
+  end
+
+  describe ".signal" do
+    it "sends a signal to a child process" do
+      child = UNIX::Process.fork
+      if child
+        UNIX::Process.signal(Signal::TERM, child.pid)
+        child.wait
+      else
+        sleep
+      end
+    end
+  end
+
+  describe "#signal" do
+    it "sends a signal to a child UNIX::Process" do
+      child = UNIX::Process.fork
+      if child
+        child.signal(Signal::KILL)
+        child.wait
+      else
+        sleep
+      end
+    end
+  end
+
+  {% unless flag?(:android) %}
+    describe ".chroot" do
+      it "raises when unprivileged" do
+        expect_raises(RuntimeError, /EPERM/) do
+          UNIX::Process.chroot(".")
+        end
+      end
+    end
+  {% end %}
+end

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -683,7 +683,7 @@ module Crystal
       channel = Channel(String).new(n_threads)
       completed = Channel(Nil).new(n_threads)
 
-      workers.each do |pid, input, output|
+      workers.each do |child, input, output|
         spawn do
           overqueued = 0
 
@@ -718,7 +718,7 @@ module Crystal
           input.close
           output.close
 
-          Process.new(Crystal::System::Process.new(pid)).wait
+          child.wait
           completed.send(nil)
         end
       end
@@ -749,7 +749,7 @@ module Crystal
     end
 
     private def fork_workers(n_threads, &)
-      workers = [] of {Int32, IO::FileDescriptor, IO::FileDescriptor}
+      workers = [] of {UNIX::Process, IO::FileDescriptor, IO::FileDescriptor}
 
       n_threads.times do
         iread, iwrite = IO.pipe
@@ -758,7 +758,7 @@ module Crystal
         iwrite.flush_on_newline = true
         owrite.flush_on_newline = true
 
-        pid = Crystal::System::Process.fork do
+        child = UNIX::Process.fork do
           iwrite.close
           oread.close
 
@@ -772,7 +772,7 @@ module Crystal
         iread.close
         owrite.close
 
-        workers << {pid, iwrite, oread}
+        workers << {child, iwrite, oread}
       end
 
       workers

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -93,6 +93,10 @@ class Crystal::Scheduler
   protected def each_scheduler(& : Scheduler ->) : Nil
   end
 
+  protected def clear_runnables : Nil
+    @lock.sync { @runnables.clear }
+  end
+
   protected def enqueue(fiber : Fiber) : Nil
     @lock.sync { @runnables << fiber }
   end
@@ -151,6 +155,8 @@ class Crystal::Scheduler
   end
 
   {% if flag?(:preview_mt) %}
+    @@workers : Array(Thread)?
+
     private getter! worker_fiber : Fiber
     @rr_target = 0
 
@@ -237,6 +243,21 @@ class Crystal::Scheduler
         # In the future we could use the number of cores or something associated to it.
         4
       end
+    end
+
+    def self.reinit_child : Nil
+      @@workers = nil
+      # Reset the GC RWLock before any GC operation: parent workers may have
+      # held lock_read across swapcontext, leaving @readers > 0 in the child.
+      GC.reinit_child
+      Thread.reinit_child
+      Thread.current.scheduler.reinit_child
+    end
+
+    protected def reinit_child : Nil
+      # Reset the SpinLock in case a parent worker held it at fork time.
+      @lock = Crystal::SpinLock.new
+      @runnables.clear
     end
   {% else %}
     def self.init : Nil

--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -287,6 +287,13 @@ class Thread
   def self.start_world : Nil
     GC.start_world
   end
+
+  def self.reinit_child : Nil
+    @@threads = Thread::LinkedList(Thread).new
+    Thread.current.previous = nil
+    Thread.current.next = nil
+    @@threads.push(Thread.current)
+  end
 end
 
 require "./thread_linked_list"

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -204,32 +204,15 @@ struct Crystal::System::Process
     {% end %}
   end
 
-  # Only used by deprecated `::Process.fork`
-  def self.fork
-    {% raise("Process fork is unsupported with multithreaded mode") if flag?(:preview_mt) %}
-
-    pid, errno = lock_write do
+  def self.quiesce(& : -> T) : T forall T
+    result = lock_write do
+      ::Process.before_quiesce_callbacks.each(&.call)
       pthread_disable_cancelstate do
-        block_signals do
-          pid = LibC.fork
-          {pid, Errno.value}
-        end
+        block_signals { yield }
       end
     end
-
-    case pid
-    when 0
-      # forked process
-      ::Process.after_fork_child_callbacks.each(&.call)
-
-      nil
-    when -1
-      # forking process: error
-      raise RuntimeError.from_os_error("fork", errno)
-    else
-      # forking process: success
-      pid
-    end
+    ::Process.after_quiesce_callbacks.each(&.call)
+    result
   end
 
   private def self.block_signals(&)
@@ -267,26 +250,6 @@ struct Crystal::System::Process
         LibC.pthread_setcancelstate(cancel_state, nil)
       end
     {% end %}
-  end
-
-  # Duplicates the current process.
-  # Returns a `Process` representing the new child process in the current process
-  # and `nil` inside the new child process.
-  # Only used by deprecated `::Process.fork(&)` and compiler `fork_codegen`
-  def self.fork(&)
-    pid = fork
-    return pid if pid
-
-    begin
-      yield
-      LibC._exit 0
-    rescue ex
-      ex.inspect_with_backtrace STDERR
-      STDERR.flush
-      LibC._exit 1
-    ensure
-      LibC._exit 254 # not reached
-    end
   end
 
   def self.prepare_args(command : String, args : Enumerable(String)?, shell : Bool) : {String, LibC::Char**}

--- a/src/crystal/system/unix/signal.cr
+++ b/src/crystal/system/unix/signal.cr
@@ -121,6 +121,9 @@ module Crystal::System::Signal
       Crystal::EventLoop.remove(pipe_io)
       pipe_io.file_descriptor_close { }
     end
+    # Reset the mutex: a parent worker may have held it (e.g. inside trap)
+    # at fork time, leaving the child with an unreleasable inherited lock.
+    @@mutex = Sync::Mutex.new(:unchecked)
   ensure
     @@pipe = IO.pipe(read_blocking: false, write_blocking: true)
   end
@@ -333,5 +336,8 @@ module Crystal::System::SignalChildHandler
     @@pending.clear
     @@waiting.each_value(&.close)
     @@waiting.clear
+    # Reset the mutex: a parent worker may have held it (inside the SIGCHLD
+    # handler) at fork time, leaving the child with an unreleasable lock.
+    @@mutex = Sync::Mutex.new(:unchecked)
   end
 end

--- a/src/crystal/system/wasi/process.cr
+++ b/src/crystal/system/wasi/process.cr
@@ -23,6 +23,13 @@ struct Crystal::System::Process
     raise NotImplementedError.new("Process#terminate")
   end
 
+  def self.quiesce(& : -> T) : T forall T
+    ::Process.before_quiesce_callbacks.each(&.call)
+    result = yield
+    ::Process.after_quiesce_callbacks.each(&.call)
+    result
+  end
+
   def self.exit(status)
     LibC.exit(status)
   end
@@ -32,20 +39,8 @@ struct Crystal::System::Process
     1
   end
 
-  def self.pgid
-    raise NotImplementedError.new("Process.pgid")
-  end
-
-  def self.pgid(pid)
-    raise NotImplementedError.new("Process.pgid")
-  end
-
   def self.ppid
     raise NotImplementedError.new("Process.ppid")
-  end
-
-  def self.signal(pid, signal)
-    raise NotImplementedError.new("Process.signal")
   end
 
   @[Deprecated("Use `#on_terminate` instead")]
@@ -80,14 +75,6 @@ struct Crystal::System::Process
     raise NotImplementedError.new("Process.times")
   end
 
-  def self.fork
-    raise NotImplementedError.new("Process.fork")
-  end
-
-  def self.fork(&)
-    raise NotImplementedError.new("Process.fork")
-  end
-
   def self.spawn(command, args, shell, env, clear_env, input, output, error, chdir)
     raise NotImplementedError.new("Process.spawn")
   end
@@ -96,7 +83,4 @@ struct Crystal::System::Process
     raise NotImplementedError.new("Process.replace")
   end
 
-  def self.chroot(path)
-    raise NotImplementedError.new("Process.chroot")
-  end
 end

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -127,6 +127,13 @@ struct Crystal::System::Process
     LibC.TerminateProcess(@process_handle, 1)
   end
 
+  def self.quiesce(& : -> T) : T forall T
+    ::Process.before_quiesce_callbacks.each(&.call)
+    result = yield
+    ::Process.after_quiesce_callbacks.each(&.call)
+    result
+  end
+
   def self.exit(status : Int32)
     LibC.exit(status)
   end
@@ -137,14 +144,6 @@ struct Crystal::System::Process
 
   def self.pid
     LibC.GetCurrentProcessId
-  end
-
-  def self.pgid
-    raise NotImplementedError.new("Process.pgid")
-  end
-
-  def self.pgid(pid)
-    raise NotImplementedError.new("Process.pgid")
   end
 
   def self.ppid
@@ -170,10 +169,6 @@ struct Crystal::System::Process
     ensure
       LibC.CloseHandle(h)
     end
-  end
-
-  def self.signal(pid, signal)
-    raise NotImplementedError.new("Process.signal")
   end
 
   @[Deprecated("Use `#on_terminate` instead")]
@@ -268,14 +263,6 @@ struct Crystal::System::Process
       Crystal::System::Time.filetime_to_f64secs(kernel),
       0,
       0)
-  end
-
-  def self.fork
-    raise NotImplementedError.new("Process.fork")
-  end
-
-  def self.fork(&)
-    raise NotImplementedError.new("Process.fork")
   end
 
   private def self.handle_from_io(io : IO::FileDescriptor, parent_io)
@@ -466,9 +453,6 @@ struct Crystal::System::Process
     handle
   end
 
-  def self.chroot(path)
-    raise NotImplementedError.new("Process.chroot")
-  end
 end
 
 private def close_handle(handle)

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -451,6 +451,18 @@ module GC
   {% end %}
 
   # :nodoc:
+  #
+  # Called in the child process immediately after `fork(2)` to reset the
+  # RWLock whose reader count may have been > 0 in the parent (workers hold
+  # `lock_read` across `swapcontext`). The child has no workers, so a fresh
+  # lock with zero readers is correct.
+  def self.reinit_child : Nil
+    {% if flag?(:preview_mt) %}
+      @@lock = Crystal::RWLock.new
+    {% end %}
+  end
+
+  # :nodoc:
   def self.lock_read
     {% if flag?(:preview_mt) %}
       @@lock.read_lock

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -577,15 +577,18 @@ def abort(message = nil, status = 1) : NoReturn
   exit status
 end
 
-{% if !flag?(:preview_mt) && flag?(:unix) %}
+{% if flag?(:unix) %}
   class Process
     # :nodoc:
     #
     # Hooks are defined here due to load order problems.
     def self.after_fork_child_callbacks
       @@after_fork_child_callbacks ||= [
-        # reinit event loop first:
-        -> { Crystal::EventLoop.current.after_fork },
+        {% unless flag?(:preview_mt) %}
+          # reinit event loop first:
+          # (Crystal::EventLoop::Polling#after_fork is only defined without preview_mt)
+          -> { Crystal::EventLoop.current.after_fork },
+        {% end %}
 
         # reinit signal handling:
         ->Crystal::System::Signal.after_fork,

--- a/src/process.cr
+++ b/src/process.cr
@@ -12,6 +12,41 @@ end
 require "crystal/system/process"
 
 class Process
+  # Callbacks to run in the current process immediately before the syscall
+  # inside `quiesce`. On macOS and Windows these run while the write lock is
+  # held; on Linux/BSD and WASM no lock is held.
+  def self.before_quiesce_callbacks : Array(-> Nil)
+    @@before_quiesce_callbacks ||= [] of -> Nil
+  end
+
+  # Callbacks to run immediately after `quiesce` returns in every process that
+  # continues execution (both parent and child on Unix fork, parent only on
+  # Windows CreateProcess).
+  def self.after_quiesce_callbacks : Array(-> Nil)
+    @@after_quiesce_callbacks ||= [] of -> Nil
+  end
+
+  # Runs *block* inside a process-spawn consistency window: signals are blocked,
+  # thread cancellation is disabled, and on platforms that need it the FD
+  # creation lock is held. Registered `before_quiesce_callbacks` fire just before
+  # the block; `after_quiesce_callbacks` fire just after.
+  #
+  # Callers that call `fork(2)` inside the block are responsible for calling
+  # `::Process.after_fork_child_callbacks.each(&.call)` in the child branch
+  # themselves. `quiesce` cannot do this because it has no way to know whether
+  # a fork occurred.
+  #
+  # Example:
+  # ```
+  # pid, saved_errno = Process.quiesce { r = LibC.fork; {r, Errno.value} }
+  # raise RuntimeError.from_os_error("fork", saved_errno) if pid == -1
+  # ```
+  def self.quiesce(& : -> T) : T forall T
+    Crystal::System::Process.quiesce { yield }
+  end
+end
+
+class Process
   # Terminate the current process immediately. All open files, pipes and sockets
   # are flushed and closed, all child processes are inherited by PID 1. This does
   # not run any handlers registered with `at_exit`, use `::exit` for that.
@@ -26,15 +61,23 @@ class Process
     Crystal::System::Process.pid.to_i64
   end
 
-  # Returns the process group identifier of the current process.
-  def self.pgid : Int64
-    Crystal::System::Process.pgid.to_i64
-  end
+  {% if flag?(:unix) %}
+    # Returns the process group identifier of the current process.
+    #
+    # Deprecated: use `UNIX::Process.pgid` instead.
+    @[Deprecated("Use `UNIX::Process.pgid` instead.")]
+    def self.pgid : Int64
+      UNIX::Process.pgid
+    end
 
-  # Returns the process group identifier of the process identified by *pid*.
-  def self.pgid(pid : Int) : Int64
-    Crystal::System::Process.pgid(pid).to_i64
-  end
+    # Returns the process group identifier of the process identified by *pid*.
+    #
+    # Deprecated: use `UNIX::Process.pgid` instead.
+    @[Deprecated("Use `UNIX::Process.pgid` instead.")]
+    def self.pgid(pid : Int) : Int64
+      UNIX::Process.pgid(pid)
+    end
+  {% end %}
 
   # Returns the process identifier of the parent process of the current process.
   #
@@ -45,10 +88,15 @@ class Process
     Crystal::System::Process.ppid.to_i64
   end
 
-  # Sends *signal* to the process identified by *pid*.
-  def self.signal(signal : Signal, pid : Int) : Nil
-    Crystal::System::Process.signal(pid, signal.value)
-  end
+  {% if flag?(:unix) %}
+    # Sends *signal* to the process identified by *pid*.
+    #
+    # Deprecated: use `UNIX::Process.signal` instead.
+    @[Deprecated("Use `UNIX::Process.signal` instead.")]
+    def self.signal(signal : Signal, pid : Int) : Nil
+      UNIX::Process.signal(signal, pid)
+    end
+  {% end %}
 
   # Installs *handler* as the new handler for interrupt requests. Removes any
   # previously set interrupt handler.
@@ -132,32 +180,27 @@ class Process
     Crystal::System::Process.times
   end
 
-  # :nodoc:
-  #
-  # Runs the given block inside a new process and
-  # returns a `Process` representing the new child process.
-  #
-  # Available only on Unix-like operating systems.
-  @[Deprecated("Fork is no longer supported.")]
-  def self.fork(&) : Process
-    new Crystal::System::Process.new(Crystal::System::Process.fork { yield })
-  end
-
-  # :nodoc:
-  #
-  # Duplicates the current process.
-  # Returns a `Process` representing the new child process in the current process
-  # and `nil` inside the new child process.
-  #
-  # Available only on Unix-like operating systems.
-  @[Deprecated("Fork is no longer supported.")]
-  def self.fork : Process?
-    {% raise("Process fork is unsupported with multithread mode") if flag?(:preview_mt) %}
-
-    if pid = Crystal::System::Process.fork
-      new Crystal::System::Process.new(pid)
+  {% if flag?(:unix) %}
+    # Runs the given block in a new child process and returns a `Process`
+    # representing it.
+    #
+    # Deprecated: use `UNIX::Process.fork` instead.
+    @[Deprecated("Use `UNIX::Process.fork` instead.")]
+    def self.fork(&) : Process
+      UNIX::Process.fork { yield }
     end
-  end
+
+    # Duplicates the current process.
+    #
+    # Returns a `Process` wrapping the child in the parent, and `nil` inside
+    # the child.
+    #
+    # Deprecated: use `UNIX::Process.fork` instead.
+    @[Deprecated("Use `UNIX::Process.fork` instead.")]
+    def self.fork : Process?
+      UNIX::Process.fork
+    end
+  {% end %}
 
   # How to redirect the standard input, output and error IO of a process.
   enum Redirect
@@ -347,9 +390,8 @@ class Process
     end
   end
 
-  # Replaces the current process with a new one. This function never returns.
-  #
-  # Raises `IO::Error` if executing the command fails (for example if the executable doesn't exist).
+  # Deprecated: use `UNIX::Process.exec` instead.
+  @[Deprecated("Use `UNIX::Process.exec` instead.")]
   def self.exec(command : String, args : Enumerable(String)? = nil, env : Env = nil, clear_env : Bool = false, shell : Bool = false,
                 input : ExecStdio = Redirect::Inherit, output : ExecStdio = Redirect::Inherit, error : ExecStdio = Redirect::Inherit, chdir : Path | String? = nil) : NoReturn
     input = exec_stdio_to_fd(input, for: STDIN)
@@ -359,7 +401,7 @@ class Process
     Crystal::System::Process.replace(command, args, shell, env, clear_env, input, output, error, chdir)
   end
 
-  private def self.exec_stdio_to_fd(stdio : ExecStdio, for dst_io : IO::FileDescriptor) : IO::FileDescriptor
+  protected def self.exec_stdio_to_fd(stdio : ExecStdio, for dst_io : IO::FileDescriptor) : IO::FileDescriptor
     case stdio
     when IO::FileDescriptor
       stdio
@@ -631,14 +673,18 @@ class Process
   def initialize(@process_info : Crystal::System::Process)
   end
 
-  # Sends *signal* to this process.
-  #
-  # NOTE: `#terminate` is preferred over `signal(Signal::TERM)` and
-  # `signal(Signal::KILL)` as a portable alternative which also works on
-  # Windows.
-  def signal(signal : Signal) : Nil
-    Crystal::System::Process.signal(@process_info.pid, signal)
-  end
+  {% if flag?(:unix) %}
+    # Sends *signal* to this process.
+    #
+    # NOTE: `#terminate` is preferred as a portable alternative that also works
+    # on Windows. Use `UNIX::Process` to access this method without deprecation.
+    #
+    # Deprecated: use `#signal` on a `UNIX::Process` instance instead.
+    @[Deprecated("Use `#signal` on a `UNIX::Process` instance instead.")]
+    def signal(signal : Signal) : Nil
+      Crystal::System::Process.signal(@process_info.pid, signal.value)
+    end
+  {% end %}
 
   # Waits for this process to complete and closes any pipes.
   def wait : Process::Status
@@ -724,23 +770,16 @@ class Process
     io.close if io
   end
 
-  # Changes the root directory and the current working directory for the current
-  # process.
-  #
-  # Available only on Unix-like operating systems.
-  #
-  # Security: `chroot` on its own is not an effective means of mitigation. At minimum
-  # the process needs to also drop privileges as soon as feasible after the `chroot`.
-  # Changes to the directory hierarchy or file descriptors passed via `recvmsg(2)` from
-  # outside the `chroot` jail may allow a restricted process to escape, even if it is
-  # unprivileged.
-  #
-  # ```
-  # Process.chroot("/var/empty")
-  # ```
-  def self.chroot(path : String) : Nil
-    Crystal::System::Process.chroot(path)
-  end
+  {% if flag?(:unix) %}
+    # Changes the root directory and the current working directory for the
+    # current process.
+    #
+    # Deprecated: use `UNIX::Process.chroot` instead.
+    @[Deprecated("Use `UNIX::Process.chroot` instead.")]
+    def self.chroot(path : String) : Nil
+      UNIX::Process.chroot(path)
+    end
+  {% end %}
 end
 
 # Executes the given command in a subshell.
@@ -794,3 +833,6 @@ def `(command : String) : String
 end
 
 require "./process/*"
+{% if flag?(:unix) %}
+  require "unix/process"
+{% end %}

--- a/src/unix/process.cr
+++ b/src/unix/process.cr
@@ -1,0 +1,154 @@
+require "../process"
+
+module UNIX
+  # Unix-specific process operations.
+  #
+  # Provides `fork` and `exec` as first-class, non-deprecated methods in a
+  # namespace that makes their Unix-only nature explicit.
+  #
+  # ```
+  # require "unix/process"
+  # ```
+  #
+  # This class is automatically required on Unix when `"process"` is required.
+  class Process < ::Process
+    {% if flag?(:unix) %}
+      # Duplicates the current process.
+      #
+      # Returns a `UNIX::Process` wrapping the child in the parent, and `nil`
+      # inside the child. The event loop, signal handlers, and RNG are
+      # reinitialized in the child automatically via
+      # `Process.after_fork_child_callbacks`.
+      #
+      # NOTE: `Thread.stop_world` and `GC.lock_write` are intentionally absent.
+      # `Thread.stop_world` can freeze workers mid-Boehm-allocator-lock; Boehm's
+      # own `pthread_atfork` prepare handler then tries to acquire the same lock,
+      # deadlocking inside `fork(2)`. `GC.lock_write` has the same issue because
+      # `Crystal::Scheduler.resume` holds `GC.lock_read` across `swapcontext`.
+      # Boehm handles its own allocator state via `LibGC.set_handle_fork(1)`;
+      # under `-Dpreview_mt`, call `Crystal::Scheduler.reinit_child` in the child
+      # to reset Crystal's own GC RWLock and scheduler state.
+      #
+      # ```
+      # if child = UNIX::Process.fork
+      #   child.wait  # parent
+      # else
+      #   # child work here — runtime already reinitialized
+      # end
+      # ```
+      def self.fork : UNIX::Process?
+        pid, errno = ::Process.quiesce { r = LibC.fork; {r, Errno.value} }
+
+        case pid
+        when 0
+          {% if flag?(:preview_mt) %}
+            Crystal::Scheduler.reinit_child
+          {% end %}
+          ::Process.after_fork_child_callbacks.each(&.call)
+          nil
+        when -1
+          raise RuntimeError.from_os_error("fork", errno)
+        else
+          new Crystal::System::Process.new(pid)
+        end
+      end
+
+      # Runs the given block in a new child process and returns a
+      # `UNIX::Process` representing it. The child calls `LibC._exit` when the
+      # block returns or raises, so at-exit handlers and finalizers do not run.
+      #
+      # ```
+      # child = UNIX::Process.fork do
+      #   puts "I am the child (pid #{Process.pid})"
+      # end
+      # child.wait
+      # ```
+      def self.fork(&) : UNIX::Process
+        if child = fork
+          return child
+        end
+
+        begin
+          yield
+          LibC._exit 0
+        rescue ex
+          ex.inspect_with_backtrace STDERR
+          STDERR.flush
+          LibC._exit 1
+        ensure
+          LibC._exit 254 # not reached
+        end
+      end
+
+      # Returns the process group identifier of the current process.
+      def self.pgid : Int64
+        Crystal::System::Process.pgid.to_i64
+      end
+
+      # Returns the process group identifier of the process identified by *pid*.
+      def self.pgid(pid : Int) : Int64
+        Crystal::System::Process.pgid(pid).to_i64
+      end
+
+      # Sends *signal* to the process identified by *pid*.
+      def self.signal(signal : Signal, pid : Int) : Nil
+        Crystal::System::Process.signal(pid, signal.value)
+      end
+
+      # Changes the root directory and the current working directory for the
+      # current process.
+      #
+      # Security: `chroot` on its own is not an effective means of mitigation.
+      # At minimum the process needs to also drop privileges as soon as feasible
+      # after the `chroot`. Changes to the directory hierarchy or file descriptors
+      # passed via `recvmsg(2)` from outside the `chroot` jail may allow a
+      # restricted process to escape, even if it is unprivileged.
+      #
+      # ```
+      # UNIX::Process.chroot("/var/empty")
+      # ```
+      def self.chroot(path : String) : Nil
+        Crystal::System::Process.chroot(path)
+      end
+
+      # Sends *signal* to this process.
+      def signal(signal : Signal) : Nil
+        Crystal::System::Process.signal(@process_info.pid, signal.value)
+      end
+    {% end %}
+
+    # Replaces the current process with a new one. This function never returns.
+    #
+    # *command* is the name or path of the executable to replace the current
+    # process with. If *shell* is `true`, the command string is passed to the
+    # system shell (`/bin/sh -c`) instead.
+    #
+    # *args* are the arguments passed to the new process. If *shell* is `true`
+    # and *args* is given, the args are appended after a `--` separator.
+    #
+    # *env* provides additional or overriding environment variables. If
+    # *clear_env* is `true`, only the variables in *env* are set; otherwise the
+    # child inherits the parent's environment with *env* merged in.
+    #
+    # *input*, *output*, *error* configure the standard streams of the new
+    # process. Each accepts a `Process::Redirect` value or an
+    # `IO::FileDescriptor`. `Redirect::Pipe` is not valid here.
+    #
+    # *chdir* changes the working directory before exec.
+    #
+    # Raises `IO::Error` if executing the command fails (for example if the
+    # executable doesn't exist).
+    #
+    # ```
+    # UNIX::Process.exec("echo", ["hello"])
+    # ```
+    def self.exec(command : String, args : Enumerable(String)? = nil, env : ::Process::Env = nil, clear_env : Bool = false, shell : Bool = false,
+                  input : ::Process::ExecStdio = ::Process::Redirect::Inherit, output : ::Process::ExecStdio = ::Process::Redirect::Inherit,
+                  error : ::Process::ExecStdio = ::Process::Redirect::Inherit, chdir : Path | String? = nil) : NoReturn
+      input_fd  = exec_stdio_to_fd(input,  for: STDIN)
+      output_fd = exec_stdio_to_fd(output, for: STDOUT)
+      error_fd  = exec_stdio_to_fd(error,  for: STDERR)
+      Crystal::System::Process.replace(command, args, shell, env, clear_env, input_fd, output_fd, error_fd, chdir)
+    end
+  end
+end


### PR DESCRIPTION
Add `Process.quiesce`, `UNIX::Process`, and fix fork safety under `-Dpreview_mt`

Closes #16994.

## New

Two related changes shipped together:

1. **`Process.quiesce`** — a public safety window for custom Unix process-creation syscalls. Runs a caller-supplied block with signals blocked, pthread cancellation disabled, and the FD-creation lock held (on macOS). Lets shards call `fork(2)`, `pdfork(2)`, `clone3`, etc. without duplicating Crystal internals.

2. **`UNIX::Process`** — a new `unix/process` module exposing `fork`, `exec`, `pgid`, `signal`, and `chroot` as first-class Unix-only APIs in an explicit namespace. The existing methods on `::Process` are deprecated in its favour. `UNIX::Process.fork` is the canonical way to fork a Crystal process.

## Significant Changes

Also attempts to fix several bugs that made fork unsafe under `-Dpreview_mt`.

* Fix: `Crystal::Scheduler.resume` holds `GC.lock_read` (a `Crystal::RWLock`) across `Fiber.swapcontext`. Worker threads suspended mid-swap at fork time leave `@readers > 0` in the child, preventing `GC.lock_write` from ever returning the first allocation deadlocks.
* Fix:** `GC.reinit_child` replaces `@@lock` with a fresh `Crystal::RWLock`. 
* Improvement: `Thread.reinit_child` creates a fresh `LinkedList`, resets the current thread's `previous`/`next` pointers, and inserts it as the sole entry.
* Improvement: `Crystal::System::Signal.@@mutex` and `Crystal::System::SignalChildHandler.@@mutex` may be held by a worker at fork time. Both `after_fork` methods now replace their mutex with a fresh instance.
* Fix: `after_fork_child_callbacks` incorrectly gated on `!preview_mt`
* Crystal inferred `Array(Thread)` for `@@workers`, preventing `reinit_child` from assigning `nil`

## Tests

Fork-related tests moved to `spec/std/unix/process_spec.cr`:

- `Process.quiesce` basic — return value passthrough, callback ordering
- Safe fork window (non-mt) — `quiesce` + `LibC.fork` + `after_fork_child_callbacks` round-trip
- Callbacks and `reinit_child` under `-Dpreview_mt` (`slow`) 
- GC read-lock deadlock detection (`slow`) 
- Signal mutex detection (`slow`)
