### PR TITLE
Hide platform-specific `Process::Status` constructor

### DIFF
--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -55,12 +55,12 @@ describe "exit" do
   end
 
   it "exists with Process::Status", tags: %w[slow] do
-    status, _, _ = compile_and_run_source "exit Process::Status.new(0)"
+    status, _, _ = compile_and_run_source "exit Process::Status.new(system_exit_status: 0)"
     status.success?.should be_true
   end
 
   it "exists with abnormal status", tags: %w[slow] do
-    status, _, _ = compile_and_run_source "exit Process::Status.new({% if flag?(:unix) %}Signal::INT.value{% else %}LibC::STATUS_CONTROL_C_EXIT{% end %})"
+    status, _, _ = compile_and_run_source "exit Process::Status.new(system_exit_status: {% if flag?(:unix) %}Signal::INT.value{% else %}LibC::STATUS_CONTROL_C_EXIT{% end %})"
     status.exit_reason.should eq Process::ExitReason::Interrupted
   end
 end

--- a/spec/std/process/status_spec.cr
+++ b/spec/std/process/status_spec.cr
@@ -10,22 +10,22 @@ private def exit_status(status)
 end
 
 private def status_for(exit_reason : Process::ExitReason)
-  exit_code = case exit_reason
-              when .interrupted?
-                {% if flag?(:unix) %}Signal::INT.value{% else %}LibC::STATUS_CONTROL_C_EXIT{% end %}
-              else
-                raise NotImplementedError.new("status_for")
-              end
-  Process::Status.new(exit_code)
+  system_exit_status = case exit_reason
+                       when .interrupted?
+                         {% if flag?(:unix) %}Signal::INT.value{% else %}LibC::STATUS_CONTROL_C_EXIT{% end %}
+                       else
+                         raise NotImplementedError.new("status_for")
+                       end
+  Process::Status.new(system_exit_status: system_exit_status)
 end
 
 describe Process::Status do
   it "#exit_code" do
-    Process::Status.new(exit_status(0)).exit_code.should eq 0
-    Process::Status.new(exit_status(1)).exit_code.should eq 1
-    Process::Status.new(exit_status(127)).exit_code.should eq 127
-    Process::Status.new(exit_status(128)).exit_code.should eq 128
-    Process::Status.new(exit_status(255)).exit_code.should eq 255
+    Process::Status.new(system_exit_status: exit_status(0)).exit_code.should eq 0
+    Process::Status.new(system_exit_status: exit_status(1)).exit_code.should eq 1
+    Process::Status.new(system_exit_status: exit_status(127)).exit_code.should eq 127
+    Process::Status.new(system_exit_status: exit_status(128)).exit_code.should eq 128
+    Process::Status.new(system_exit_status: exit_status(255)).exit_code.should eq 255
 
     expect_raises(RuntimeError, "Abnormal exit has no exit code") do
       status_for(:interrupted).exit_code
@@ -33,70 +33,70 @@ describe Process::Status do
   end
 
   it "#exit_code?" do
-    Process::Status.new(exit_status(0)).exit_code?.should eq 0
-    Process::Status.new(exit_status(1)).exit_code?.should eq 1
-    Process::Status.new(exit_status(127)).exit_code?.should eq 127
-    Process::Status.new(exit_status(128)).exit_code?.should eq 128
-    Process::Status.new(exit_status(255)).exit_code?.should eq 255
+    Process::Status.new(system_exit_status: exit_status(0)).exit_code?.should eq 0
+    Process::Status.new(system_exit_status: exit_status(1)).exit_code?.should eq 1
+    Process::Status.new(system_exit_status: exit_status(127)).exit_code?.should eq 127
+    Process::Status.new(system_exit_status: exit_status(128)).exit_code?.should eq 128
+    Process::Status.new(system_exit_status: exit_status(255)).exit_code?.should eq 255
 
     status_for(:interrupted).exit_code?.should be_nil
   end
 
   it "#system_exit_status" do
-    Process::Status.new(exit_status(0)).system_exit_status.should eq 0_u32
-    Process::Status.new(exit_status(1)).system_exit_status.should eq({{ flag?(:unix) ? 0x0100_u32 : 1_u32 }})
-    Process::Status.new(exit_status(127)).system_exit_status.should eq({{ flag?(:unix) ? 0x7f00_u32 : 127_u32 }})
-    Process::Status.new(exit_status(128)).system_exit_status.should eq({{ flag?(:unix) ? 0x8000_u32 : 128_u32 }})
-    Process::Status.new(exit_status(255)).system_exit_status.should eq({{ flag?(:unix) ? 0xFF00_u32 : 255_u32 }})
+    Process::Status.new(system_exit_status: exit_status(0)).system_exit_status.should eq 0_u32
+    Process::Status.new(system_exit_status: exit_status(1)).system_exit_status.should eq({{ flag?(:unix) ? 0x0100_u32 : 1_u32 }})
+    Process::Status.new(system_exit_status: exit_status(127)).system_exit_status.should eq({{ flag?(:unix) ? 0x7f00_u32 : 127_u32 }})
+    Process::Status.new(system_exit_status: exit_status(128)).system_exit_status.should eq({{ flag?(:unix) ? 0x8000_u32 : 128_u32 }})
+    Process::Status.new(system_exit_status: exit_status(255)).system_exit_status.should eq({{ flag?(:unix) ? 0xFF00_u32 : 255_u32 }})
 
     status_for(:interrupted).system_exit_status.should eq({% if flag?(:unix) %}Signal::INT.value{% else %}LibC::STATUS_CONTROL_C_EXIT{% end %})
   end
 
   it "#success?" do
-    Process::Status.new(exit_status(0)).success?.should be_true
-    Process::Status.new(exit_status(1)).success?.should be_false
-    Process::Status.new(exit_status(127)).success?.should be_false
-    Process::Status.new(exit_status(128)).success?.should be_false
-    Process::Status.new(exit_status(255)).success?.should be_false
+    Process::Status.new(system_exit_status: exit_status(0)).success?.should be_true
+    Process::Status.new(system_exit_status: exit_status(1)).success?.should be_false
+    Process::Status.new(system_exit_status: exit_status(127)).success?.should be_false
+    Process::Status.new(system_exit_status: exit_status(128)).success?.should be_false
+    Process::Status.new(system_exit_status: exit_status(255)).success?.should be_false
 
     status_for(:interrupted).success?.should be_false
   end
 
   it "#normal_exit?" do
-    Process::Status.new(exit_status(0)).normal_exit?.should be_true
-    Process::Status.new(exit_status(1)).normal_exit?.should be_true
-    Process::Status.new(exit_status(127)).normal_exit?.should be_true
-    Process::Status.new(exit_status(128)).normal_exit?.should be_true
-    Process::Status.new(exit_status(255)).normal_exit?.should be_true
+    Process::Status.new(system_exit_status: exit_status(0)).normal_exit?.should be_true
+    Process::Status.new(system_exit_status: exit_status(1)).normal_exit?.should be_true
+    Process::Status.new(system_exit_status: exit_status(127)).normal_exit?.should be_true
+    Process::Status.new(system_exit_status: exit_status(128)).normal_exit?.should be_true
+    Process::Status.new(system_exit_status: exit_status(255)).normal_exit?.should be_true
 
     status_for(:interrupted).normal_exit?.should be_false
   end
 
   it "#abnormal_exit?" do
-    Process::Status.new(exit_status(0)).abnormal_exit?.should be_false
-    Process::Status.new(exit_status(1)).abnormal_exit?.should be_false
-    Process::Status.new(exit_status(127)).abnormal_exit?.should be_false
-    Process::Status.new(exit_status(128)).abnormal_exit?.should be_false
-    Process::Status.new(exit_status(255)).abnormal_exit?.should be_false
+    Process::Status.new(system_exit_status: exit_status(0)).abnormal_exit?.should be_false
+    Process::Status.new(system_exit_status: exit_status(1)).abnormal_exit?.should be_false
+    Process::Status.new(system_exit_status: exit_status(127)).abnormal_exit?.should be_false
+    Process::Status.new(system_exit_status: exit_status(128)).abnormal_exit?.should be_false
+    Process::Status.new(system_exit_status: exit_status(255)).abnormal_exit?.should be_false
 
     status_for(:interrupted).abnormal_exit?.should be_true
   end
 
   it "#signal_exit?" do
-    Process::Status.new(exit_status(0)).signal_exit?.should be_false
-    Process::Status.new(exit_status(1)).signal_exit?.should be_false
-    Process::Status.new(exit_status(127)).signal_exit?.should be_false
-    Process::Status.new(exit_status(128)).signal_exit?.should be_false
-    Process::Status.new(exit_status(255)).signal_exit?.should be_false
+    Process::Status.new(system_exit_status: exit_status(0)).signal_exit?.should be_false
+    Process::Status.new(system_exit_status: exit_status(1)).signal_exit?.should be_false
+    Process::Status.new(system_exit_status: exit_status(127)).signal_exit?.should be_false
+    Process::Status.new(system_exit_status: exit_status(128)).signal_exit?.should be_false
+    Process::Status.new(system_exit_status: exit_status(255)).signal_exit?.should be_false
 
     status_for(:interrupted).signal_exit?.should eq {{ !flag?(:win32) }}
   end
 
   it "equality" do
-    ok1 = Process::Status.new(exit_status(0))
-    ok2 = Process::Status.new(exit_status(0))
-    err1 = Process::Status.new(exit_status(1))
-    err2 = Process::Status.new(exit_status(1))
+    ok1 = Process::Status.new(system_exit_status: exit_status(0))
+    ok2 = Process::Status.new(system_exit_status: exit_status(0))
+    err1 = Process::Status.new(system_exit_status: exit_status(1))
+    err2 = Process::Status.new(system_exit_status: exit_status(1))
 
     ok1.should eq(ok2)
     ok1.should_not eq(err2)
@@ -110,160 +110,160 @@ describe Process::Status do
   end
 
   it "#exit_signal?" do
-    Process::Status.new(exit_status(0)).exit_signal?.should be_nil
-    Process::Status.new(exit_status(1)).exit_signal?.should be_nil
+    Process::Status.new(system_exit_status: exit_status(0)).exit_signal?.should be_nil
+    Process::Status.new(system_exit_status: exit_status(1)).exit_signal?.should be_nil
 
     status_for(:interrupted).exit_signal?.should eq({% if flag?(:unix) %}Signal::INT{% else %}nil{% end %})
   end
 
   {% if flag?(:unix) && !flag?(:wasi) %}
     it "#exit_signal" do
-      Process::Status.new(Signal::HUP.value).exit_signal.should eq Signal::HUP
-      Process::Status.new(Signal::INT.value).exit_signal.should eq Signal::INT
+      Process::Status.new(system_exit_status: Signal::HUP.value).exit_signal.should eq Signal::HUP
+      Process::Status.new(system_exit_status: Signal::INT.value).exit_signal.should eq Signal::INT
       last_signal = Signal.values[-1]
-      Process::Status.new(last_signal.value).exit_signal.should eq last_signal
+      Process::Status.new(system_exit_status: last_signal.value).exit_signal.should eq last_signal
 
       unknown_signal = Signal.new(126)
-      Process::Status.new(unknown_signal.value).exit_signal.should eq unknown_signal
+      Process::Status.new(system_exit_status: unknown_signal.value).exit_signal.should eq unknown_signal
     end
 
     it "#exit_signal?" do
-      Process::Status.new(Signal::HUP.value).exit_signal?.should eq Signal::HUP
-      Process::Status.new(Signal::INT.value).exit_signal?.should eq Signal::INT
+      Process::Status.new(system_exit_status: Signal::HUP.value).exit_signal?.should eq Signal::HUP
+      Process::Status.new(system_exit_status: Signal::INT.value).exit_signal?.should eq Signal::INT
       last_signal = Signal.values[-1]
-      Process::Status.new(last_signal.value).exit_signal?.should eq last_signal
+      Process::Status.new(system_exit_status: last_signal.value).exit_signal?.should eq last_signal
 
       unknown_signal = Signal.new(126)
-      Process::Status.new(unknown_signal.value).exit_signal?.should eq unknown_signal
+      Process::Status.new(system_exit_status: unknown_signal.value).exit_signal?.should eq unknown_signal
     end
 
     it "#normal_exit? with signal code" do
-      Process::Status.new(0x00).normal_exit?.should be_true
-      Process::Status.new(0x01).normal_exit?.should be_false
-      Process::Status.new(0x7e).normal_exit?.should be_false
-      Process::Status.new(0x7f).normal_exit?.should be_false
+      Process::Status.new(system_exit_status: 0x00).normal_exit?.should be_true
+      Process::Status.new(system_exit_status: 0x01).normal_exit?.should be_false
+      Process::Status.new(system_exit_status: 0x7e).normal_exit?.should be_false
+      Process::Status.new(system_exit_status: 0x7f).normal_exit?.should be_false
     end
 
     it "#signal_exit? with signal code" do
-      Process::Status.new(0x00).signal_exit?.should be_false
-      Process::Status.new(0x01).signal_exit?.should be_true
-      Process::Status.new(0x7e).signal_exit?.should be_true
-      Process::Status.new(0x7f).signal_exit?.should be_true
+      Process::Status.new(system_exit_status: 0x00).signal_exit?.should be_false
+      Process::Status.new(system_exit_status: 0x01).signal_exit?.should be_true
+      Process::Status.new(system_exit_status: 0x7e).signal_exit?.should be_true
+      Process::Status.new(system_exit_status: 0x7f).signal_exit?.should be_true
     end
   {% end %}
 
   {% if flag?(:win32) %}
     describe "#exit_reason" do
       it "returns Normal" do
-        Process::Status.new(exit_status(0)).exit_reason.normal?.should be_true
-        Process::Status.new(exit_status(1)).exit_reason.normal?.should be_true
-        Process::Status.new(exit_status(127)).exit_reason.normal?.should be_true
-        Process::Status.new(exit_status(128)).exit_reason.normal?.should be_true
-        Process::Status.new(exit_status(255)).exit_reason.normal?.should be_true
+        Process::Status.new(system_exit_status: exit_status(0)).exit_reason.normal?.should be_true
+        Process::Status.new(system_exit_status: exit_status(1)).exit_reason.normal?.should be_true
+        Process::Status.new(system_exit_status: exit_status(127)).exit_reason.normal?.should be_true
+        Process::Status.new(system_exit_status: exit_status(128)).exit_reason.normal?.should be_true
+        Process::Status.new(system_exit_status: exit_status(255)).exit_reason.normal?.should be_true
 
-        Process::Status.new(0x3FFFFFFF_u32).exit_reason.normal?.should be_true
-        Process::Status.new(0x40001234_u32).exit_reason.normal?.should be_false
-        Process::Status.new(0x80001234_u32).exit_reason.normal?.should be_false
-        Process::Status.new(0xC0001234_u32).exit_reason.normal?.should be_false
+        Process::Status.new(system_exit_status: 0x3FFFFFFF_u32).exit_reason.normal?.should be_true
+        Process::Status.new(system_exit_status: 0x40001234_u32).exit_reason.normal?.should be_false
+        Process::Status.new(system_exit_status: 0x80001234_u32).exit_reason.normal?.should be_false
+        Process::Status.new(system_exit_status: 0xC0001234_u32).exit_reason.normal?.should be_false
       end
 
       it "returns Aborted" do
-        Process::Status.new(LibC::STATUS_FATAL_APP_EXIT).exit_reason.aborted?.should be_true
+        Process::Status.new(system_exit_status: LibC::STATUS_FATAL_APP_EXIT).exit_reason.aborted?.should be_true
       end
 
       it "returns Interrupted" do
-        Process::Status.new(LibC::STATUS_CONTROL_C_EXIT).exit_reason.interrupted?.should be_true
+        Process::Status.new(system_exit_status: LibC::STATUS_CONTROL_C_EXIT).exit_reason.interrupted?.should be_true
       end
 
       it "returns Breakpoint" do
-        Process::Status.new(LibC::STATUS_BREAKPOINT).exit_reason.breakpoint?.should be_true
+        Process::Status.new(system_exit_status: LibC::STATUS_BREAKPOINT).exit_reason.breakpoint?.should be_true
       end
 
       it "returns AccessViolation" do
-        Process::Status.new(LibC::STATUS_ACCESS_VIOLATION).exit_reason.access_violation?.should be_true
-        Process::Status.new(LibC::STATUS_STACK_OVERFLOW).exit_reason.access_violation?.should be_true
+        Process::Status.new(system_exit_status: LibC::STATUS_ACCESS_VIOLATION).exit_reason.access_violation?.should be_true
+        Process::Status.new(system_exit_status: LibC::STATUS_STACK_OVERFLOW).exit_reason.access_violation?.should be_true
       end
 
       it "returns BadMemoryAccess" do
-        Process::Status.new(LibC::STATUS_DATATYPE_MISALIGNMENT).exit_reason.bad_memory_access?.should be_true
+        Process::Status.new(system_exit_status: LibC::STATUS_DATATYPE_MISALIGNMENT).exit_reason.bad_memory_access?.should be_true
       end
 
       it "returns BadInstruction" do
-        Process::Status.new(LibC::STATUS_ILLEGAL_INSTRUCTION).exit_reason.bad_instruction?.should be_true
-        Process::Status.new(LibC::STATUS_PRIVILEGED_INSTRUCTION).exit_reason.bad_instruction?.should be_true
+        Process::Status.new(system_exit_status: LibC::STATUS_ILLEGAL_INSTRUCTION).exit_reason.bad_instruction?.should be_true
+        Process::Status.new(system_exit_status: LibC::STATUS_PRIVILEGED_INSTRUCTION).exit_reason.bad_instruction?.should be_true
       end
 
       it "returns FloatException" do
-        Process::Status.new(LibC::STATUS_FLOAT_DIVIDE_BY_ZERO).exit_reason.float_exception?.should be_true
-        Process::Status.new(LibC::STATUS_FLOAT_INEXACT_RESULT).exit_reason.float_exception?.should be_true
-        Process::Status.new(LibC::STATUS_FLOAT_INVALID_OPERATION).exit_reason.float_exception?.should be_true
-        Process::Status.new(LibC::STATUS_FLOAT_OVERFLOW).exit_reason.float_exception?.should be_true
-        Process::Status.new(LibC::STATUS_FLOAT_UNDERFLOW).exit_reason.float_exception?.should be_true
+        Process::Status.new(system_exit_status: LibC::STATUS_FLOAT_DIVIDE_BY_ZERO).exit_reason.float_exception?.should be_true
+        Process::Status.new(system_exit_status: LibC::STATUS_FLOAT_INEXACT_RESULT).exit_reason.float_exception?.should be_true
+        Process::Status.new(system_exit_status: LibC::STATUS_FLOAT_INVALID_OPERATION).exit_reason.float_exception?.should be_true
+        Process::Status.new(system_exit_status: LibC::STATUS_FLOAT_OVERFLOW).exit_reason.float_exception?.should be_true
+        Process::Status.new(system_exit_status: LibC::STATUS_FLOAT_UNDERFLOW).exit_reason.float_exception?.should be_true
       end
     end
   {% elsif flag?(:unix) && !flag?(:wasi) %}
     describe "#exit_reason" do
       it "returns Normal" do
-        Process::Status.new(exit_status(0)).exit_reason.normal?.should be_true
-        Process::Status.new(exit_status(1)).exit_reason.normal?.should be_true
-        Process::Status.new(exit_status(127)).exit_reason.normal?.should be_true
-        Process::Status.new(exit_status(128)).exit_reason.normal?.should be_true
-        Process::Status.new(exit_status(255)).exit_reason.normal?.should be_true
+        Process::Status.new(system_exit_status: exit_status(0)).exit_reason.normal?.should be_true
+        Process::Status.new(system_exit_status: exit_status(1)).exit_reason.normal?.should be_true
+        Process::Status.new(system_exit_status: exit_status(127)).exit_reason.normal?.should be_true
+        Process::Status.new(system_exit_status: exit_status(128)).exit_reason.normal?.should be_true
+        Process::Status.new(system_exit_status: exit_status(255)).exit_reason.normal?.should be_true
 
-        Process::Status.new(0x01).exit_reason.normal?.should be_false
-        Process::Status.new(0x7e).exit_reason.normal?.should be_false
+        Process::Status.new(system_exit_status: 0x01).exit_reason.normal?.should be_false
+        Process::Status.new(system_exit_status: 0x7e).exit_reason.normal?.should be_false
 
-        Process::Status.new(0x017f).exit_reason.normal?.should be_false
-        Process::Status.new(0xffff).exit_reason.normal?.should be_false
+        Process::Status.new(system_exit_status: 0x017f).exit_reason.normal?.should be_false
+        Process::Status.new(system_exit_status: 0xffff).exit_reason.normal?.should be_false
       end
 
       it "returns Aborted" do
-        Process::Status.new(Signal::ABRT.value).exit_reason.aborted?.should be_true
-        Process::Status.new(Signal::KILL.value).exit_reason.aborted?.should be_true
-        Process::Status.new(Signal::QUIT.value).exit_reason.aborted?.should be_true
+        Process::Status.new(system_exit_status: Signal::ABRT.value).exit_reason.aborted?.should be_true
+        Process::Status.new(system_exit_status: Signal::KILL.value).exit_reason.aborted?.should be_true
+        Process::Status.new(system_exit_status: Signal::QUIT.value).exit_reason.aborted?.should be_true
       end
 
       it "returns TerminalDisconnected" do
-        Process::Status.new(Signal::HUP.value).exit_reason.terminal_disconnected?.should be_true
+        Process::Status.new(system_exit_status: Signal::HUP.value).exit_reason.terminal_disconnected?.should be_true
       end
 
       it "returns SessionEnded" do
-        Process::Status.new(Signal::TERM.value).exit_reason.session_ended?.should be_true
+        Process::Status.new(system_exit_status: Signal::TERM.value).exit_reason.session_ended?.should be_true
       end
 
       it "returns Interrupted" do
-        Process::Status.new(Signal::INT.value).exit_reason.interrupted?.should be_true
+        Process::Status.new(system_exit_status: Signal::INT.value).exit_reason.interrupted?.should be_true
       end
 
       it "returns Breakpoint" do
-        Process::Status.new(Signal::TRAP.value).exit_reason.breakpoint?.should be_true
+        Process::Status.new(system_exit_status: Signal::TRAP.value).exit_reason.breakpoint?.should be_true
       end
 
       it "returns AccessViolation" do
-        Process::Status.new(Signal::SEGV.value).exit_reason.access_violation?.should be_true
+        Process::Status.new(system_exit_status: Signal::SEGV.value).exit_reason.access_violation?.should be_true
       end
 
       it "returns BadMemoryAccess" do
-        Process::Status.new(Signal::BUS.value).exit_reason.bad_memory_access?.should be_true
+        Process::Status.new(system_exit_status: Signal::BUS.value).exit_reason.bad_memory_access?.should be_true
       end
 
       it "returns BadInstruction" do
-        Process::Status.new(Signal::ILL.value).exit_reason.bad_instruction?.should be_true
+        Process::Status.new(system_exit_status: Signal::ILL.value).exit_reason.bad_instruction?.should be_true
       end
 
       it "returns FloatException" do
-        Process::Status.new(Signal::FPE.value).exit_reason.float_exception?.should be_true
+        Process::Status.new(system_exit_status: Signal::FPE.value).exit_reason.float_exception?.should be_true
       end
     end
   {% end %}
 
   describe "#to_s" do
     it "with exit status" do
-      assert_prints Process::Status.new(exit_status(0)).to_s, "0"
-      assert_prints Process::Status.new(exit_status(1)).to_s, "1"
-      assert_prints Process::Status.new(exit_status(127)).to_s, "127"
-      assert_prints Process::Status.new(exit_status(128)).to_s, "128"
-      assert_prints Process::Status.new(exit_status(255)).to_s, "255"
+      assert_prints Process::Status.new(system_exit_status: exit_status(0)).to_s, "0"
+      assert_prints Process::Status.new(system_exit_status: exit_status(1)).to_s, "1"
+      assert_prints Process::Status.new(system_exit_status: exit_status(127)).to_s, "127"
+      assert_prints Process::Status.new(system_exit_status: exit_status(128)).to_s, "128"
+      assert_prints Process::Status.new(system_exit_status: exit_status(255)).to_s, "255"
     end
 
     it "on abnormal exit" do
@@ -276,30 +276,30 @@ describe Process::Status do
 
     {% if flag?(:unix) && !flag?(:wasi) %}
       it "with exit signal" do
-        assert_prints Process::Status.new(Signal::HUP.value).to_s, "HUP"
+        assert_prints Process::Status.new(system_exit_status: Signal::HUP.value).to_s, "HUP"
         last_signal = Signal.values[-1]
-        assert_prints Process::Status.new(last_signal.value).to_s, last_signal.to_s
+        assert_prints Process::Status.new(system_exit_status: last_signal.value).to_s, last_signal.to_s
 
-        assert_prints Process::Status.new(Signal.new(126).value).to_s, "Signal[126]"
+        assert_prints Process::Status.new(system_exit_status: Signal.new(126).value).to_s, "Signal[126]"
       end
     {% end %}
 
     {% if flag?(:win32) %}
       it "hex format" do
-        assert_prints Process::Status.new(UInt16::MAX).to_s, "0x0000FFFF"
-        assert_prints Process::Status.new(0x01234567).to_s, "0x01234567"
-        assert_prints Process::Status.new(UInt32::MAX).to_s, "0xFFFFFFFF"
+        assert_prints Process::Status.new(system_exit_status: UInt16::MAX).to_s, "0x0000FFFF"
+        assert_prints Process::Status.new(system_exit_status: 0x01234567).to_s, "0x01234567"
+        assert_prints Process::Status.new(system_exit_status: UInt32::MAX).to_s, "0xFFFFFFFF"
       end
     {% end %}
   end
 
   describe "#inspect" do
     it "with exit status" do
-      assert_prints Process::Status.new(exit_status(0)).inspect, "Process::Status[0]"
-      assert_prints Process::Status.new(exit_status(1)).inspect, "Process::Status[1]"
-      assert_prints Process::Status.new(exit_status(127)).inspect, "Process::Status[127]"
-      assert_prints Process::Status.new(exit_status(128)).inspect, "Process::Status[128]"
-      assert_prints Process::Status.new(exit_status(255)).inspect, "Process::Status[255]"
+      assert_prints Process::Status.new(system_exit_status: exit_status(0)).inspect, "Process::Status[0]"
+      assert_prints Process::Status.new(system_exit_status: exit_status(1)).inspect, "Process::Status[1]"
+      assert_prints Process::Status.new(system_exit_status: exit_status(127)).inspect, "Process::Status[127]"
+      assert_prints Process::Status.new(system_exit_status: exit_status(128)).inspect, "Process::Status[128]"
+      assert_prints Process::Status.new(system_exit_status: exit_status(255)).inspect, "Process::Status[255]"
     end
 
     it "on abnormal exit" do
@@ -312,28 +312,28 @@ describe Process::Status do
 
     {% if flag?(:unix) && !flag?(:wasi) %}
       it "with exit signal" do
-        assert_prints Process::Status.new(Signal::HUP.value).inspect, "Process::Status[Signal::HUP]"
+        assert_prints Process::Status.new(system_exit_status: Signal::HUP.value).inspect, "Process::Status[Signal::HUP]"
         last_signal = Signal.values[-1]
-        assert_prints Process::Status.new(last_signal.value).inspect, "Process::Status[#{last_signal.inspect}]"
+        assert_prints Process::Status.new(system_exit_status: last_signal.value).inspect, "Process::Status[#{last_signal.inspect}]"
 
         unknown_signal = Signal.new(126)
-        assert_prints Process::Status.new(unknown_signal.value).inspect, "Process::Status[Signal[126]]"
+        assert_prints Process::Status.new(system_exit_status: unknown_signal.value).inspect, "Process::Status[Signal[126]]"
       end
     {% end %}
 
     {% if flag?(:win32) %}
       it "hex format" do
-        assert_prints Process::Status.new(UInt16::MAX).inspect, "Process::Status[0x0000FFFF]"
-        assert_prints Process::Status.new(0x01234567).inspect, "Process::Status[0x01234567]"
-        assert_prints Process::Status.new(UInt32::MAX).inspect, "Process::Status[0xFFFFFFFF]"
+        assert_prints Process::Status.new(system_exit_status: UInt16::MAX).inspect, "Process::Status[0x0000FFFF]"
+        assert_prints Process::Status.new(system_exit_status: 0x01234567).inspect, "Process::Status[0x01234567]"
+        assert_prints Process::Status.new(system_exit_status: UInt32::MAX).inspect, "Process::Status[0xFFFFFFFF]"
       end
     {% end %}
   end
 
   describe "#description" do
     it "with exit status" do
-      Process::Status.new(exit_status(0)).description.should eq "Process exited normally"
-      Process::Status.new(exit_status(255)).description.should eq "Process exited normally"
+      Process::Status.new(system_exit_status: exit_status(0)).description.should eq "Process exited normally"
+      Process::Status.new(system_exit_status: exit_status(255)).description.should eq "Process exited normally"
     end
 
     it "on interrupt" do
@@ -342,14 +342,14 @@ describe Process::Status do
 
     {% if flag?(:unix) && !flag?(:wasi) %}
       it "with exit signal" do
-        Process::Status.new(Signal::HUP.value).description.should eq "Process terminated abnormally"
-        Process::Status.new(Signal::KILL.value).description.should eq "Process terminated abnormally"
-        Process::Status.new(Signal::STOP.value).description.should eq "Process received and didn't handle signal STOP"
+        Process::Status.new(system_exit_status: Signal::HUP.value).description.should eq "Process terminated abnormally"
+        Process::Status.new(system_exit_status: Signal::KILL.value).description.should eq "Process terminated abnormally"
+        Process::Status.new(system_exit_status: Signal::STOP.value).description.should eq "Process received and didn't handle signal STOP"
         last_signal = Signal.values[-1]
-        Process::Status.new(last_signal.value).description.should eq "Process received and didn't handle signal #{last_signal}"
+        Process::Status.new(system_exit_status: last_signal.value).description.should eq "Process received and didn't handle signal #{last_signal}"
 
         unknown_signal = Signal.new(126)
-        Process::Status.new(unknown_signal.value).description.should eq "Process received and didn't handle signal 126"
+        Process::Status.new(system_exit_status: unknown_signal.value).description.should eq "Process received and didn't handle signal 126"
       end
     {% end %}
   end

--- a/src/process.cr
+++ b/src/process.cr
@@ -648,7 +648,7 @@ class Process
     end
     @wait_count = 0
 
-    Process::Status.new(@process_info.wait)
+    Process::Status.new(system_exit_status: @process_info.wait)
   ensure
     close
     @process_info.release

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -149,11 +149,11 @@ class Process::Status
 
   {% if flag?(:win32) %}
     # :nodoc:
-    def initialize(@exit_status : UInt32)
+    def initialize(*, system_exit_status @exit_status : UInt32)
     end
   {% else %}
     # :nodoc:
-    def initialize(@exit_status : Int32)
+    def initialize(*, system_exit_status @exit_status : Int32)
     end
   {% end %}
 
@@ -406,7 +406,7 @@ class Process::Status
   # Returns a textual description of this process status.
   #
   # ```
-  # Process::Status.new(0).description # => "Process exited normally"
+  # Process.run("true").description # => "Process exited normally"
   # process = Process.new("sleep", ["10"])
   # process.terminate
   # process.wait.description # => "Process received and didn't handle signal TERM (15)"

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -149,7 +149,7 @@ class Process::Status
 
   {% if flag?(:win32) %}
     # :nodoc:
-    @[Deprecated("Use `Process::Status.new(system_exit_status: ...)` instead.")]
+    @[Deprecated("`Process::Status` does not provide a portable constructor.")]
     def self.new(exit_status : UInt32)
       new(system_exit_status: exit_status)
     end
@@ -159,7 +159,7 @@ class Process::Status
     end
   {% else %}
     # :nodoc:
-    @[Deprecated("Use `Process::Status.new(system_exit_status: ...)` instead.")]
+    @[Deprecated("`Process::Status` does not provide a portable constructor.")]
     def self.new(exit_status : Int32)
       new(system_exit_status: exit_status)
     end

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -137,23 +137,23 @@ class Process::Status
   # The other `Process::Status` methods extract the values from `exit_status`.
   @[Deprecated("Use `#exit_reason`, `#exit_code`, or `#system_exit_status` instead")]
   def exit_status : Int32
-    @exit_status.to_i32!
+    @system_exit_status.to_i32!
   end
 
   # Returns the exit status as indicated by the operating system.
   #
   # It can encode exit codes and termination signals and is platform-specific.
   def system_exit_status : UInt32
-    @exit_status.to_u32!
+    @system_exit_status.to_u32!
   end
 
   {% if flag?(:win32) %}
     # :nodoc:
-    def initialize(*, system_exit_status @exit_status : UInt32)
+    def initialize(*, @system_exit_status : UInt32)
     end
   {% else %}
     # :nodoc:
-    def initialize(*, system_exit_status @exit_status : Int32)
+    def initialize(*, @system_exit_status : Int32)
     end
   {% end %}
 
@@ -162,7 +162,7 @@ class Process::Status
     {% if flag?(:win32) %}
       # TODO: perhaps this should cover everything that SEH can handle?
       # https://learn.microsoft.com/en-us/windows/win32/debug/getexceptioncode
-      case @exit_status
+      case @system_exit_status
       when LibC::STATUS_FATAL_APP_EXIT
         ExitReason::Aborted
       when LibC::STATUS_CONTROL_C_EXIT
@@ -178,7 +178,7 @@ class Process::Status
       when LibC::STATUS_FLOAT_DIVIDE_BY_ZERO, LibC::STATUS_FLOAT_INEXACT_RESULT, LibC::STATUS_FLOAT_INVALID_OPERATION, LibC::STATUS_FLOAT_OVERFLOW, LibC::STATUS_FLOAT_UNDERFLOW
         ExitReason::FloatException
       else
-        @exit_status & 0xC0000000_u32 == 0 ? ExitReason::Normal : ExitReason::Unknown
+        @system_exit_status & 0xC0000000_u32 == 0 ? ExitReason::Normal : ExitReason::Unknown
       end
     {% elsif flag?(:unix) && !flag?(:wasm32) %}
       case exit_signal?
@@ -299,9 +299,9 @@ class Process::Status
 
     {% if flag?(:unix) %}
       # define __WEXITSTATUS(status) (((status) & 0xff00) >> 8)
-      (@exit_status & 0xff00) >> 8
+      (@system_exit_status & 0xff00) >> 8
     {% else %}
-      @exit_status.to_i32!
+      @system_exit_status.to_i32!
     {% end %}
   end
 
@@ -312,10 +312,10 @@ class Process::Status
 
   private def signal_code
     # define __WTERMSIG(status) ((status) & 0x7f)
-    @exit_status & 0x7f
+    @system_exit_status & 0x7f
   end
 
-  def_equals_and_hash @exit_status
+  def_equals_and_hash @system_exit_status
 
   # Prints a textual representation of the process status to *io*.
   #
@@ -342,7 +342,7 @@ class Process::Status
   end
 
   private def name_for_win32_exit_status
-    case @exit_status
+    case @system_exit_status
     # Ignoring LibC::STATUS_SUCCESS here because we prefer its numerical representation `0`
     when LibC::STATUS_FATAL_APP_EXIT          then "STATUS_FATAL_APP_EXIT"
     when LibC::STATUS_DATATYPE_MISALIGNMENT   then "STATUS_DATATYPE_MISALIGNMENT"
@@ -423,11 +423,11 @@ class Process::Status
 
   private def stringify_exit_status_windows(io)
     # On Windows large status codes are typically expressed in hexadecimal
-    if @exit_status >= UInt16::MAX
+    if @system_exit_status >= UInt16::MAX
       io << "0x"
-      @exit_status.to_s(base: 16, upcase: true).rjust(io, 8, '0')
+      @system_exit_status.to_s(base: 16, upcase: true).rjust(io, 8, '0')
     else
-      @exit_status.to_s(io)
+      @system_exit_status.to_s(io)
     end
   end
 end

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -149,9 +149,21 @@ class Process::Status
 
   {% if flag?(:win32) %}
     # :nodoc:
+    @[Deprecated("Use `Process::Status.new(system_exit_status: ...)` instead.")]
+    def self.new(exit_status : UInt32)
+      new(system_exit_status: exit_status)
+    end
+
+    # :nodoc:
     def initialize(*, @system_exit_status : UInt32)
     end
   {% else %}
+    # :nodoc:
+    @[Deprecated("Use `Process::Status.new(system_exit_status: ...)` instead.")]
+    def self.new(exit_status : Int32)
+      new(system_exit_status: exit_status)
+    end
+
     # :nodoc:
     def initialize(*, @system_exit_status : Int32)
     end


### PR DESCRIPTION
`Process::Status.new` is undocumented, but easily reachable. It seems intuitive. But it isn't. It expects a system exit status, which on Unix systems, is not equivalent to the exit code. As a result, it's also not portable. And it's easy to shoot yourself in the foot.

`Process::Status.new(42)` returns `Process::Status[Signal[42]` on Unix, and `Process::Status[42]` on Windows.

This patch makes the platform-specific constructor harder to use accidentally, by requiring the platform-specific parameter as a named argument with `system_` prefix. We're using this approach with other types where we need to provide platform-specific constructors.

I'm keeping the existing signatures as deprecated. This avoids breaking existing calls, even though this API is meant for internal use, it was (and still is) reachable from user code.

Related to #13016
