### PR TITLE
Reject 'uninitialized X' when X has a NoReturn instance variable (#12733)

### DIFF
--- a/spec/compiler/semantic/uninitialized_spec.cr
+++ b/spec/compiler/semantic/uninitialized_spec.cr
@@ -154,4 +154,23 @@ describe "Semantic: uninitialized" do
       u
       CRYSTAL
   end
+
+  it "errors when uninitialized type has a NoReturn instance variable (#12733)" do
+    assert_error <<-CRYSTAL, "can't use 'uninitialized Entry' because instance variable '@key' has type NoReturn"
+      struct Entry
+        def initialize(@key : NoReturn)
+        end
+      end
+
+      entry = uninitialized Entry
+      entry.@key
+      CRYSTAL
+  end
+
+  it "allows uninitialized StaticArray(NoReturn, 0) (#12733)" do
+    assert_type(<<-CRYSTAL) { static_array_of(no_return, 0) }
+      ary = uninitialized StaticArray(NoReturn, 0)
+      ary
+      CRYSTAL
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -474,6 +474,7 @@ module Crystal
         # TODO: should we be using a binding here to recompute the type?
         if declared_type = node.declared_type.type?
           var_type = check_declare_var_type node, declared_type, "a variable"
+          check_uninitialized_no_return_ivars(node, var_type.instance_type)
           var_type = var_type.virtual_type
           var.type = var_type
         else
@@ -542,6 +543,34 @@ module Crystal
     def check_not_a_constant(node)
       if node.is_a?(Path) && node.target_const
         node.raise "#{node.target_const} is not a type, it's a constant"
+      end
+    end
+
+    # `uninitialized X` bypasses the constructor, so the resulting value has
+    # ivars in whatever state malloc/stack left them in. That's fine for any
+    # ivar type that has runtime values — the read produces undefined bytes,
+    # interpreted as that type. For a `NoReturn`-typed ivar the type system
+    # says no value of the ivar's type can exist; reading one would type the
+    # result as `NoReturn` and the codegen later produces an ill-typed return
+    # instruction (#12733). The declaration itself is legal (a class with a
+    # `NoReturn` ivar can never be properly constructed, so the lookup paths
+    # that need the read never run), but `uninitialized` is the loophole that
+    # produces an instance without going through `initialize`. Reject it.
+    def check_uninitialized_no_return_ivars(node, type)
+      return unless type.is_a?(InstanceVarContainer)
+
+      # `StaticArray(T, 0)` has a `@buffer` ivar of type `T`, but a size of 0:
+      # there's no actual storage and no possible read. `T = NoReturn` is fine
+      # here (e.g. `StaticArray(Union(*T), 0)` for an empty splat in tuple.cr).
+      if type.is_a?(StaticArrayInstanceType)
+        size = type.size
+        return if size.is_a?(NumberLiteral) && size.value == "0"
+      end
+
+      type.all_instance_vars.each do |name, ivar|
+        if ivar.type?.try &.no_return?
+          node.raise "can't use 'uninitialized #{type}' because instance variable '#{name}' has type NoReturn, which has no values"
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #12733.

## The bug

```crystal
struct Entry
  def initialize(@key : NoReturn)
  end
end

entry = uninitialized Entry
entry.@key
0
```

```
Module validation failed: Function return type does not match operand type of return inst!
  ret i8 %25
 i32
```

The reduced reproducer collapses the original `Set.new(Tuple())`-via-empty-splat chain in the issue down to its essential shape: a struct whose ivar is typed `NoReturn`, instantiated without going through `initialize`. Reading that ivar yields a `NoReturn`-typed value; the cleanup transformer drops the trailing `0` (correctly, as dead-after-NoReturn); but the surrounding function's signature was already derived from the pre-cleanup body and still expects `Int32`, so codegen emits `ret i8 %25` against an `i32` return type.

## Approach

The previous PR for this issue (#16988) tried to fix it in codegen by emitting `unreachable` after the `NoReturn` ivar load. That was rejected, correctly: the load IS reachable at runtime — `uninitialized` actually executed and the bytes really do get read — so marking it `unreachable` would let LLVM optimise the surrounding code under a false assumption and convert a clean compile-time ICE into a silent runtime miscompile.

The reviewer's preference was to stop `NoReturn` from becoming the actual type of a value in the first place. The catch is that `class Foo; def initialize(@x : NoReturn); end; end` on its own is harmless — the class can't be constructed (you'd need to pass a value of `NoReturn`, of which none exist), and an existing spec (`block_spec.cr:676`) relies on that uninstantiability to type a captured-block body where the class is referenced but never instantiated. Rejecting the declaration outright breaks that test (and others) for no gain — the lookup paths that would read the ivar never run on a never-constructed class, so there's no bug.

The actual loophole is `uninitialized`. It's the one mechanism that produces an instance of a type without calling `initialize`. For a class with a `NoReturn` ivar, that's the only way to materialise an instance at all — and the materialised instance has a `NoReturn` slot that, when read, surfaces the codegen mismatch. So the fix is narrow: at the `uninitialized X` site, check whether `X` (or any ancestor) has a `NoReturn`-typed ivar, and reject if so. Existing legitimate uses of `@x : NoReturn` continue to work.

## The fix

`MainVisitor#visit(UninitializedVar)` gains a `check_uninitialized_no_return_ivars` call that walks `all_instance_vars` of the declared type and raises a `TypeException` if any are `NoReturn`. The check is gated on `is_a?(InstanceVarContainer)` so it short-circuits cleanly for primitives, tuples, procs, etc.

Error message:

```
Error: can't use 'uninitialized Entry' because instance variable '@key' has type NoReturn, which has no values
```

### One exemption: `StaticArray(_, 0)`

`StaticArray(T, N)` has a `@buffer` ivar typed `T`. For `T = NoReturn, N = 0` the buffer has zero slots — no actual storage, no possible read — so the codegen mismatch doesn't arise. The stdlib relies on this shape in `tuple.cr`:

```crystal
ary = uninitialized StaticArray(Union(*T), 0)   # T = empty splat → Union() = NoReturn
```

The fix short-circuits the check for `StaticArrayInstanceType` whose `size` is the literal `0`. Both the reduced repro and the std_spec build now compile cleanly.

## Tests

- `spec/compiler/semantic/uninitialized_spec.cr` — `assert_error` regression for the original ICE shape (`uninitialized Entry` with `@key : NoReturn`). Verified to fail on master and pass with the fix.
- `spec/compiler/semantic/uninitialized_spec.cr` — `assert_type` regression confirming `uninitialized StaticArray(NoReturn, 0)` continues to compile.
- Full `make compiler_spec` (13,501 examples) passes.
- `crystal build spec/std_spec.cr` (the CI step that surfaced the `tuple.cr` regression) compiles cleanly.

## Out of scope

`Pointer(X).malloc(1).value` is a structurally similar bypass — it also produces an instance without going through `initialize` — and continues to ICE in the same way for types with `NoReturn` ivars. Catching it requires either a wider semantic-time check (which the existing `block_spec.cr:676` test would not survive) or per-call-site detection in `Pointer#value` codegen. That's a separate, more invasive change; this PR fixes the `uninitialized` path the original issue reports, and the `Pointer` variant remains tracked as a known limitation.
