### PR TITLE
Fix: `Fiber::ExecutionContext::Monitor` compat with old Crystal releases

### DIFF
--- a/src/fiber/execution_context/monitor.cr
+++ b/src/fiber/execution_context/monitor.cr
@@ -7,10 +7,11 @@ module Fiber::ExecutionContext
 
     @thread : Thread?
 
-    # Annotations are needed for Crystal < 1.4
-    @every : Time::Span
-    @collect_stacks_next : Time::Instant
-    @increase_parallelism_next : Time::Instant
+    {% if compare_versions(CrystaL::VERSION, "1.4.0") < 0 %}
+      @every : Time::Span
+      @collect_stacks_next : Time::Instant
+      @increase_parallelism_next : Time::Instant
+    {% end %}
 
     def initialize(@every = DEFAULT_EVERY)
       @collect_stacks_next = Crystal::System::Time.instant + COLLECT_STACKS_EVERY

--- a/src/fiber/execution_context/monitor.cr
+++ b/src/fiber/execution_context/monitor.cr
@@ -7,7 +7,7 @@ module Fiber::ExecutionContext
 
     @thread : Thread?
 
-    {% if compare_versions(CrystaL::VERSION, "1.4.0") < 0 %}
+    {% if compare_versions(Crystal::VERSION, "1.4.0") < 0 %}
       @every : Time::Span
       @collect_stacks_next : Time::Instant
       @increase_parallelism_next : Time::Instant

--- a/src/fiber/execution_context/monitor.cr
+++ b/src/fiber/execution_context/monitor.cr
@@ -7,6 +7,11 @@ module Fiber::ExecutionContext
 
     @thread : Thread?
 
+    # Annotations are needed for Crystal < 1.4
+    @every : Time::Span
+    @collect_stacks_next : Time::Instant
+    @increase_parallelism_next : Time::Instant
+
     def initialize(@every = DEFAULT_EVERY)
       @collect_stacks_next = Crystal::System::Time.instant + COLLECT_STACKS_EVERY
       @increase_parallelism_next = Crystal::System::Time.instant + INCREASE_PARALLELISM_EVERY


### PR DESCRIPTION
Extracted from #17001 