### PR TITLE
Add `UUID.v6` and `.v8` generators

### DIFF
--- a/spec/std/uuid_spec.cr
+++ b/spec/std/uuid_spec.cr
@@ -271,6 +271,38 @@ describe "UUID" do
     end
   end
 
+  describe "v6" do
+    it "generates a v6 UUID" do
+      uuid = UUID.v6
+      uuid.v6?.should be_true
+      uuid.version.should eq UUID::Version::V6
+      uuid.variant.should eq UUID::Variant::RFC4122
+    end
+
+    it "accepts a custom node_id" do
+      uuid = UUID.v6(node_id: StaticArray(UInt8, 6).new { |i| (i * 10).to_u8 })
+      uuid.v6?.should be_true
+      uuid.to_s[24..36].should eq("000a141e2832")
+    end
+
+    it "accepts a custom clock_seq" do
+      uuid = UUID.v6(clock_seq: 0x1234_u16)
+      uuid.v6?.should be_true
+      # clock_seq occupies the low 14 bits of bytes 8-9 after the 2 variant bits
+      clock_seq = ((uuid.bytes[8].to_u16 & 0x3f) << 8) | uuid.bytes[9].to_u16
+      clock_seq.should eq 0x1234_u16
+    end
+
+    pending_wasm32 "generates UUIDs that are sortable" do
+      uuids = Array.new(10) do
+        sleep 1.millisecond
+        UUID.v6
+      end
+
+      uuids.should eq uuids.sort
+    end
+  end
+
   describe "v7" do
     it "generates a v7 UUID" do
       uuid = UUID.v7
@@ -285,6 +317,42 @@ describe "UUID" do
       end
 
       uuids.should eq uuids.sort
+    end
+  end
+
+  describe "v8" do
+    it "generates a v8 UUID from a StaticArray" do
+      custom = StaticArray(UInt8, 16).new { |i| i.to_u8 }
+      uuid = UUID.v8(custom)
+      uuid.v8?.should be_true
+      uuid.version.should eq UUID::Version::V8
+      uuid.variant.should eq UUID::Variant::RFC4122
+    end
+
+    it "generates a v8 UUID from a Slice" do
+      custom = Bytes.new(16) { |i| i.to_u8 }
+      uuid = UUID.v8(custom)
+      uuid.v8?.should be_true
+      uuid.version.should eq UUID::Version::V8
+      uuid.variant.should eq UUID::Variant::RFC4122
+    end
+
+    it "preserves user payload except version and variant bits" do
+      custom = StaticArray(UInt8, 16).new(0xff_u8)
+      uuid = UUID.v8(custom)
+      bytes = uuid.bytes
+      # All bytes except 6 (version nibble) and 8 (variant bits) should be 0xFF
+      (0..5).each { |i| bytes[i].should eq 0xff_u8 }
+      # byte 6: high nibble = 8 (version), low nibble = 0xf (preserved)
+      bytes[6].should eq 0x8f_u8
+      bytes[7].should eq 0xff_u8
+      # byte 8: high 2 bits = 10 (variant), low 6 bits = 0x3f (preserved)
+      bytes[8].should eq 0xbf_u8
+      (9..15).each { |i| bytes[i].should eq 0xff_u8 }
+    end
+
+    it "raises on a Slice with wrong size" do
+      expect_raises(ArgumentError) { UUID.v8(Bytes.new(10)) }
     end
   end
 end

--- a/spec/std/uuid_spec.cr
+++ b/spec/std/uuid_spec.cr
@@ -340,15 +340,15 @@ describe "UUID" do
     it "preserves user payload except version and variant bits" do
       custom = StaticArray(UInt8, 16).new(0xff_u8)
       uuid = UUID.v8(custom)
-      bytes = uuid.bytes
       # All bytes except 6 (version nibble) and 8 (variant bits) should be 0xFF
-      (0..5).each { |i| bytes[i].should eq 0xff_u8 }
       # byte 6: high nibble = 8 (version), low nibble = 0xf (preserved)
-      bytes[6].should eq 0x8f_u8
-      bytes[7].should eq 0xff_u8
       # byte 8: high 2 bits = 10 (variant), low 6 bits = 0x3f (preserved)
-      bytes[8].should eq 0xbf_u8
-      (9..15).each { |i| bytes[i].should eq 0xff_u8 }
+      uuid.bytes.should eq UInt8.static_array(
+        0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0x8f, 0xff,
+        0xbf, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff,
+      )
     end
 
     it "raises on a Slice with wrong size" do

--- a/src/uuid.cr
+++ b/src/uuid.cr
@@ -45,8 +45,12 @@ struct UUID
     V4 = 4
     # SHA1 hash and namespace.
     V5 = 5
+    # Reordered date-time and NodeID address, for improved DB locality.
+    V6 = 6
     # Prefixed with a UNIX timestamp with millisecond precision, filled in with randomness.
     V7 = 7
+    # Custom format for experimental or vendor-specific use cases.
+    V8 = 8
   end
 
   # A Domain represents a Version 2 domain (DCE security).
@@ -325,6 +329,46 @@ struct UUID
     end
   {% end %}
 
+  # Generates an RFC 9562 v6 UUID.
+  #
+  # UUIDv6 is a field-compatible version of UUIDv1 with the timestamp bits
+  # reordered to be most-significant-first, making the UUID lexicographically
+  # sortable by creation time.
+  #
+  # The sequence number `clock_seq` should be monotonically increasing across
+  # invocations; only 14 bits are used. If not provided, the current
+  # millisecond sub-second value is used. If `node_id` is not provided, a
+  # pseudo-random node ID is generated with the multicast bit set as
+  # recommended by RFC 4122 section 4.5.
+  def self.v6(*, clock_seq : UInt16? = nil, node_id : MAC? = nil) : self
+    tl = Time.local
+    now = (tl.to_unix_ns / 100).to_u64 + 122192928000000000_u64
+    seq = ((clock_seq || (tl.nanosecond / 1000000).to_u16) & 0x3fff_u16) | 0x8000_u16
+
+    # Unlike v1, v6 stores the 60-bit timestamp most-significant-bits first:
+    # bytes 0-3: T[59:28], bytes 4-5: T[27:12], bytes 6-7: ver(4) | T[11:0]
+    time_high = UInt32.new((now >> 28) & 0xffffffff_u64)
+    time_mid = UInt16.new((now >> 12) & 0xffff_u64)
+    time_low_and_version = UInt16.new(0x6000_u16 | (now & 0x0fff_u64).to_u16)
+
+    uuid = uninitialized UInt8[16]
+    IO::ByteFormat::BigEndian.encode(time_high, uuid.to_slice[0..3])
+    IO::ByteFormat::BigEndian.encode(time_mid, uuid.to_slice[4..5])
+    IO::ByteFormat::BigEndian.encode(time_low_and_version, uuid.to_slice[6..7])
+    IO::ByteFormat::BigEndian.encode(seq, uuid.to_slice[8..9])
+
+    if node_id
+      6.times do |i|
+        uuid.to_slice[10 + i] = node_id[i]
+      end
+    else
+      Random::Secure.random_bytes(uuid.to_slice[10..15])
+      uuid[10] |= 0x01_u8
+    end
+
+    new(uuid, version: UUID::Version::V6, variant: UUID::Variant::RFC4122)
+  end
+
   # Generates an RFC9562-compatible v7 UUID, allowing the values to be sorted
   # chronologically (with 1ms precision) by their raw or hexstring
   # representation.
@@ -347,6 +391,38 @@ struct UUID
     value[8] = (value[8] & 0x0F) | 0x80
 
     new(value, variant: :rfc9562, version: :v7)
+  end
+
+  # Generates an RFC 9562 v8 UUID from *custom_bytes*.
+  #
+  # UUIDv8 is an RFC-compatible format for experimental or vendor-specific
+  # use cases where the caller defines the meaning of all 128 bits. Exactly
+  # **6 bits** of *custom_bytes* are unconditionally overwritten:
+  #
+  # * **Bits 48–51** (high nibble of byte 6) get set to `0x8` (version 8)
+  # * **Bits 64–65** (two high bits of byte 8) get set to `0b10` (RFC 9562 variant)
+  #
+  # All remaining 122 bits are preserved exactly as supplied. Callers must
+  # account for this when designing their custom layout; avoid placing
+  # meaningful data in those 6 bit positions.
+  #
+  # Example: embedding a 16-bit shard ID and a 32-bit sequence number.
+  # ```
+  # require "uuid"
+  #
+  # buf = StaticArray(UInt8, 16).new(0_u8)
+  # IO::ByteFormat::BigEndian.encode(shard_id, buf.to_slice[0, 2])
+  # IO::ByteFormat::BigEndian.encode(seq, buf.to_slice[2, 4])
+  # # bytes 6 and 8 will have 6 bits overwritten; leave them as padding
+  # uuid = UUID.v8(buf)
+  # ```
+  def self.v8(custom_bytes : StaticArray(UInt8, 16)) : self
+    new(custom_bytes, version: UUID::Version::V8, variant: UUID::Variant::RFC4122)
+  end
+
+  # :ditto:
+  def self.v8(custom_bytes : Slice(UInt8)) : self
+    new(custom_bytes, version: UUID::Version::V8, variant: UUID::Variant::RFC4122)
   end
 
   # Generates an empty UUID.
@@ -403,7 +479,9 @@ struct UUID
     when 3 then Version::V3
     when 4 then Version::V4
     when 5 then Version::V5
+    when 6 then Version::V6
     when 7 then Version::V7
+    when 8 then Version::V8
     else        Version::Unknown
     end
   end
@@ -471,7 +549,7 @@ struct UUID
   class Error < Exception
   end
 
-  {% for v in %w(1 2 3 4 5 7) %}
+  {% for v in %w(1 2 3 4 5 6 7 8) %}
     # Returns `true` if UUID is a V{{ v.id }}, `false` otherwise.
     def v{{ v.id }}?
       variant == Variant::RFC4122 && version == Version::V{{ v.id }}

--- a/src/uuid.cr
+++ b/src/uuid.cr
@@ -335,9 +335,9 @@ struct UUID
   # reordered to be most-significant-first, making the UUID lexicographically
   # sortable by creation time.
   #
-  # The sequence number `clock_seq` should be monotonically increasing across
+  # The sequence number *clock_seq* should be monotonically increasing across
   # invocations; only 14 bits are used. If not provided, the current
-  # millisecond sub-second value is used. If `node_id` is not provided, a
+  # millisecond sub-second value is used. If *node_id* is not provided, a
   # pseudo-random node ID is generated with the multicast bit set as
   # recommended by RFC 4122 section 4.5.
   def self.v6(*, clock_seq : UInt16? = nil, node_id : MAC? = nil) : self


### PR DESCRIPTION
Closes #14288. Follows the same approach as #14732 (v7).

## Changes

**`UUID::Version`:**
Added `V6 = 6` and `V8 = 8` to the enum, updated the `#version` reader to return them, and added them to the `v?`/`v!` predicate macro.

**`UUID.v6`:**
Field-compatible with `UUID.v1`, sharing the same `clock_seq` and `node_id` parameters and the same 60-bit Gregorian timestamp. The only difference is field ordering: v6 puts the most significant timestamp bits first (bytes 0-5 carry T[59:12], bytes 6-7 carry version + T[11:0]), which makes the raw UUID string lexicographically sortable by creation time.

**`UUID.v8`:**
Accepts a 16-byte caller-supplied payload and stamps the RFC 9562 version and variant bits onto it. Two overloads: `StaticArray(UInt8, 16)` and `Slice(UInt8)`. Docs call out exactly which 6 bits are overwritten (bits 48-51 and bits 64-65) so callers can design their custom layout to avoid those positions.

## Testing

- v6: checks version/variant, custom `node_id`, custom `clock_seq` extraction, and a `pending_wasm32` sortability test matching the v7 pattern
- v8: checks both overloads, verifies all 122 non-stamped bits survive unchanged, and confirms the size-check `ArgumentError` on a short slice