### PR TITLE
Support nested `root` properties in `JSON::Field`

### DIFF
--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -263,6 +263,7 @@ class JSONAttrWithNestedRoot
   @[JSON::Field(root: {"data", "score"})]
   property bar : Int32
 end
+
 class JSONAttrWithRoot
   include JSON::Serializable
 
@@ -1013,7 +1014,7 @@ describe "JSON::Serializable" do
     json.to_json.should eq(string)
   end
 
-    it "parses nested root properties" do
+  it "parses nested root properties" do
     obj = JSONAttrWithNestedRoot.from_json(%({"foo": {"data": {"value": "bar"}}, "bar": {"data": {"score": 42}}}))
     obj.foo.should eq("bar")
     obj.bar.should eq(42)

--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -254,6 +254,15 @@ class JSONAttrWithRaw
   property value : String
 end
 
+class JSONAttrWithNestedRoot
+  include JSON::Serializable
+
+  @[JSON::Field(root: ["data", "value"])]
+  property foo : String
+
+  @[JSON::Field(root: {"data", "score"})]
+  property bar : Int32
+end
 class JSONAttrWithRoot
   include JSON::Serializable
 
@@ -1004,6 +1013,16 @@ describe "JSON::Serializable" do
     json.to_json.should eq(string)
   end
 
+    it "parses nested root properties" do
+    obj = JSONAttrWithNestedRoot.from_json(%({"foo": {"data": {"value": "bar"}}, "bar": {"data": {"score": 42}}}))
+    obj.foo.should eq("bar")
+    obj.bar.should eq(42)
+  end
+
+  it "serializes nested root properties" do
+    obj = JSONAttrWithNestedRoot.from_json(%({"foo": {"data": {"value": "bar"}}, "bar": {"data": {"score": 42}}}))
+    obj.to_json.should eq(%({"foo":{"data":{"value":"bar"}},"bar":{"data":{"score":42}}}))
+  end
   it "parses with root" do
     json = %({"result":{"heroes":[{"name":"Batman"}]}})
     result = JSONAttrWithRoot.from_json(json)

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -234,13 +234,27 @@ module JSON
                     {% end %}
 
                     %var{name} =
-                      {% if value[:root] %} pull.on_key!({{value[:root]}}) do {% else %} begin {% end %}
+                      {% if value[:root] %}
+                        {% roots = value[:root].is_a?(ArrayLiteral) || value[:root].is_a?(TupleLiteral) ? value[:root] : [value[:root]] %}
+                        {% for root in roots %}
+                          pull.on_key!({{root}}) do
+                        {% end %}
+                      {% else %}
+                        begin
+                      {% end %}
                         {% if value[:converter] %}
                           {{value[:converter]}}.from_json(pull)
                         {% else %}
                           ::Union(typeof(@{{ name }})).new(pull)
                         {% end %}
-                      end
+                      {% if value[:root] %}
+                        {% roots = value[:root].is_a?(ArrayLiteral) || value[:root].is_a?(TupleLiteral) ? value[:root] : [value[:root]] %}
+                        {% for root in roots %}
+                          end
+                        {% end %}
+                      {% else %}
+                        end
+                      {% end %}
                     %found{name} = true
                   rescue exc : ::JSON::ParseException
                     raise ::JSON::SerializableError.new(exc.message, self.class.to_s, {{value[:key]}}, *%key_location, exc)
@@ -322,8 +336,11 @@ module JSON
                       else
                     {% end %}
 
-                    json.object do
-                      json.field({{value[:root]}}) do
+                    {% roots = value[:root].is_a?(ArrayLiteral) || value[:root].is_a?(TupleLiteral) ? value[:root] : [value[:root]] %}
+                    {% for root in roots %}
+                      json.object do
+                        json.field({{root}}) do
+                    {% end %}
                   {% end %}
 
                   {% if value[:converter] %}
@@ -337,11 +354,14 @@ module JSON
                   {% end %}
 
                   {% if value[:root] %}
+                    {% roots = value[:root].is_a?(ArrayLiteral) || value[:root].is_a?(TupleLiteral) ? value[:root] : [value[:root]] %}
+                    {% for root in roots %}
+                        end
+                      end
+                    {% end %}
                     {% if value[:emit_null] %}
                       end
                     {% end %}
-                      end
-                    end
                   {% end %}
                 end
 


### PR DESCRIPTION
This PR allows the `root` property of the `JSON::Field` annotation to support nested keys via `Array` or `Tuple` literals, solving #13894.

For example, a user can now annotate:
```crystal
class RootNestedProperties
  include JSON::Serializable

  @[JSON::Field(root: ["data", "value"])]
  property foo : String
end
```
When `from_json` or `to_json` are called, the parser uses a nested series of `pull.on_key!` or `json.field()` calls to parse/serialize the struct. Because this relies entirely on compile-time macro expansion (`{% for root in roots %}`), there is no runtime overhead added.

Included regression specs to ensure JSON arrays and objects can be correctly traversed.
