### PR TITLE
Allow chaining `#should`, `#should_not` expectations

### DIFF
--- a/spec/std/spec/expectations_spec.cr
+++ b/spec/std/spec/expectations_spec.cr
@@ -23,6 +23,16 @@ private class ExceptionWithOverriddenToS < Exception
 end
 
 describe "expectations" do
+  describe "chaining" do
+    it "#should returns self" do
+      1.should(be < 3).should(be > 0)
+    end
+
+    it "#should_not returns self" do
+      1.should_not(be > 3).should_not(be < 0)
+    end
+  end
+
   describe "accept a custom failure message" do
     it { 1.should be < 3, "custom message!" }
     it do

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -496,7 +496,10 @@ module Spec
     #
     # See `Spec::Expectations` for available expectations.
     def should(expectation, failure_message : String? = nil, *, file = __FILE__, line = __LINE__)
-      unless expectation.match self
+      # FIXME: Cannot add `self` type restriction due to https://github.com/crystal-lang/crystal/issues/17009
+      if expectation.match self
+        self
+      else
         failure_message ||= expectation.failure_message(self)
         fail(failure_message, file, line)
       end
@@ -516,6 +519,7 @@ module Spec
     #
     # See `Spec::Expectations` for available expectations.
     def should_not(expectation : BeAExpectation(T), failure_message : String? = nil, *, file = __FILE__, line = __LINE__) forall T
+      # FIXME: Cannot add `self` type restriction due to https://github.com/crystal-lang/crystal/issues/17009
       if expectation.match self
         failure_message ||= expectation.negative_failure_message(self)
         fail(failure_message, file, line)
@@ -552,6 +556,8 @@ module Spec
       if expectation.match self
         failure_message ||= expectation.negative_failure_message(self)
         fail(failure_message, file, line)
+      else
+        self
       end
     end
   end


### PR DESCRIPTION
Resolves #17009