### PR TITLE
Add `URI::Params::Field(ignore:)`, `ignore_serialize`, `ignore_deserialize`

### DIFF
--- a/spec/std/uri/params/serializable_spec.cr
+++ b/spec/std/uri/params/serializable_spec.cr
@@ -66,6 +66,56 @@ end
 class ChildType < ParentType
 end
 
+private struct IgnoreField
+  include URI::Params::Serializable
+
+  property name : String
+  property age : Int32?
+
+  @[URI::Params::Field(ignore: true)]
+  property computed : String?
+
+  def initialize(@name : String, @age : Int32? = nil, @computed : String? = nil)
+  end
+end
+
+private struct IgnoreSerializeField
+  include URI::Params::Serializable
+
+  property name : String
+
+  @[URI::Params::Field(ignore_serialize: true)]
+  property secret : String?
+
+  def initialize(@name : String, @secret : String? = nil)
+  end
+end
+
+private struct IgnoreDeserializeField
+  include URI::Params::Serializable
+
+  property name : String
+
+  @[URI::Params::Field(ignore_deserialize: true)]
+  property derived : String?
+
+  def initialize(@name : String, @derived : String? = nil)
+  end
+end
+
+private struct IgnoreSerializeConditional
+  include URI::Params::Serializable
+
+  property name : String
+  property internal : Bool
+
+  @[URI::Params::Field(ignore_serialize: internal)]
+  property extra : String?
+
+  def initialize(@name : String, @internal : Bool, @extra : String? = nil)
+  end
+end
+
 private record SimpleTypeInitializeOpts, value : Int32 do
   include URI::Params::Serializable
 
@@ -152,5 +202,67 @@ describe URI::Params::Serializable do
 
   it "supports generic type variables in converters" do
     GenericConverterType(MyConverter).from_www_form("value=123").value.should eq(1230)
+  end
+
+  describe "URI::Params::Field ignore options" do
+    describe "ignore: true" do
+      it "skips field in serialization" do
+        obj = IgnoreField.new("Alice", 30, "computed value")
+        obj.to_www_form.should eq "name=Alice&age=30"
+      end
+
+      it "skips field in deserialization" do
+        obj = IgnoreField.from_www_form("name=Alice&age=30&computed=should+be+ignored")
+        obj.name.should eq "Alice"
+        obj.age.should eq 30
+        obj.computed.should be_nil
+      end
+
+      it "round trips without the ignored field" do
+        obj = IgnoreField.new("Alice", 30, "computed")
+        round_tripped = IgnoreField.from_www_form(obj.to_www_form)
+        round_tripped.name.should eq "Alice"
+        round_tripped.age.should eq 30
+        round_tripped.computed.should be_nil
+      end
+    end
+
+    describe "ignore_serialize: true" do
+      it "skips field in serialization" do
+        obj = IgnoreSerializeField.new("Alice", "topsecret")
+        obj.to_www_form.should eq "name=Alice"
+      end
+
+      it "still deserializes the field" do
+        obj = IgnoreSerializeField.from_www_form("name=Alice&secret=topsecret")
+        obj.name.should eq "Alice"
+        obj.secret.should eq "topsecret"
+      end
+    end
+
+    describe "ignore_deserialize: true" do
+      it "still serializes the field" do
+        obj = IgnoreDeserializeField.new("Alice", "derived_value")
+        obj.to_www_form.should eq "name=Alice&derived=derived_value"
+      end
+
+      it "skips field in deserialization" do
+        obj = IgnoreDeserializeField.from_www_form("name=Alice&derived=should+be+ignored")
+        obj.name.should eq "Alice"
+        obj.derived.should be_nil
+      end
+    end
+
+    describe "ignore_serialize with runtime expression" do
+      it "skips field when expression is truthy" do
+        obj = IgnoreSerializeConditional.new("Alice", internal: true, extra: "hidden")
+        obj.to_www_form.should eq "name=Alice&internal=true"
+      end
+
+      it "includes field when expression is falsy" do
+        obj = IgnoreSerializeConditional.new("Alice", internal: false, extra: "visible")
+        obj.to_www_form.should eq "name=Alice&internal=false&extra=visible"
+      end
+    end
   end
 end

--- a/spec/std/uri/params/serializable_spec.cr
+++ b/spec/std/uri/params/serializable_spec.cr
@@ -66,54 +66,32 @@ end
 class ChildType < ParentType
 end
 
-private struct IgnoreField
+private record IgnoreField, name : String, age : Int32? = nil, computed : String? = nil do
   include URI::Params::Serializable
-
-  property name : String
-  property age : Int32?
 
   @[URI::Params::Field(ignore: true)]
-  property computed : String?
-
-  def initialize(@name : String, @age : Int32? = nil, @computed : String? = nil)
-  end
+  @computed : String?
 end
 
-private struct IgnoreSerializeField
+private record IgnoreSerializeField, name : String, secret : String? = nil do
   include URI::Params::Serializable
-
-  property name : String
 
   @[URI::Params::Field(ignore_serialize: true)]
-  property secret : String?
-
-  def initialize(@name : String, @secret : String? = nil)
-  end
+  @secret : String?
 end
 
-private struct IgnoreDeserializeField
+private record IgnoreDeserializeField, name : String, derived : String? = nil do
   include URI::Params::Serializable
-
-  property name : String
 
   @[URI::Params::Field(ignore_deserialize: true)]
-  property derived : String?
-
-  def initialize(@name : String, @derived : String? = nil)
-  end
+  @derived : String?
 end
 
-private struct IgnoreSerializeConditional
+private record IgnoreSerializeConditional, name : String, internal : Bool, extra : String? = nil do
   include URI::Params::Serializable
 
-  property name : String
-  property internal : Bool
-
   @[URI::Params::Field(ignore_serialize: internal)]
-  property extra : String?
-
-  def initialize(@name : String, @internal : Bool, @extra : String? = nil)
-  end
+  @extra : String?
 end
 
 private record SimpleTypeInitializeOpts, value : Int32 do

--- a/src/uri/params/serializable.cr
+++ b/src/uri/params/serializable.cr
@@ -41,6 +41,9 @@ struct URI::Params
   # Annotating property, getter and setter macros is also allowed.
   #
   # `URI::Params::Field` properties:
+  # * **ignore**: if `true` skip this field in serialization and deserialization (by default `false`)
+  # * **ignore_serialize**: if truthy, skip this field in serialization (default: `false`). The value can be any Crystal expression and is evaluated at runtime.
+  # * **ignore_deserialize**: if `true` skip this field in deserialization (by default `false`)
   # * **converter**: specify an alternate type for parsing. The converter must define `.from_www_form(params : URI::Params, name : String)`.
   # An example use case would be customizing the format when parsing `Time` instances, or supporting a type not natively supported.
   #
@@ -99,16 +102,19 @@ struct URI::Params
         {% verbatim do %}
           {% begin %}
             {% for ivar, idx in @type.instance_vars %}
-              %name{idx} = name.nil? ? {{ivar.name.stringify}} : "#{name}[#{{{ivar.name.stringify}}}]"
-              %value{idx} = {{(ann = ivar.annotation(URI::Params::Field)) && (converter = ann["converter"]) ? converter : ivar.type}}.from_www_form params, %name{idx}
+              {% ann = ivar.annotation(URI::Params::Field) %}
+              {% unless ann && (ann[:ignore] || ann[:ignore_deserialize]) %}
+                %name{idx} = name.nil? ? {{ivar.name.stringify}} : "#{name}[#{{{ivar.name.stringify}}}]"
+                %value{idx} = {{(ann = ivar.annotation(URI::Params::Field)) && (converter = ann["converter"]) ? converter : ivar.type}}.from_www_form params, %name{idx}
 
-              unless %value{idx}.nil?
-                @{{ivar.name.id}} = %value{idx}
-              else
-                {% unless ivar.type.resolve.nilable? || ivar.has_default_value? %}
-                  raise URI::SerializableError.new "Missing required property: '#{%name{idx}}'."
-                {% end %}
-              end
+                unless %value{idx}.nil?
+                  @{{ivar.name.id}} = %value{idx}
+                else
+                  {% unless ivar.type.resolve.nilable? || ivar.has_default_value? %}
+                    raise URI::SerializableError.new "Missing required property: '#{%name{idx}}'."
+                  {% end %}
+                end
+              {% end %}
             {% end %}
           {% end %}
         {% end %}
@@ -118,7 +124,16 @@ struct URI::Params
     def to_www_form(*, space_to_plus : Bool = true) : String
       URI::Params.build(space_to_plus: space_to_plus) do |form|
         {% for ivar in @type.instance_vars %}
-          @{{ivar.name.id}}.to_www_form form, {{ivar.name.stringify}}
+          {% ann = ivar.annotation(URI::Params::Field) %}
+          {% unless ann && ann[:ignore] %}
+            {% if ann && ann[:ignore_serialize] %}
+              unless {{ann[:ignore_serialize]}}
+                @{{ivar.name.id}}.to_www_form form, {{ivar.name.stringify}}
+              end
+            {% else %}
+              @{{ivar.name.id}}.to_www_form form, {{ivar.name.stringify}}
+            {% end %}
+          {% end %}
         {% end %}
       end
     end
@@ -126,7 +141,16 @@ struct URI::Params
     # :nodoc:
     def to_www_form(builder : URI::Params::Builder, name : String)
       {% for ivar in @type.instance_vars %}
-        @{{ivar.name.id}}.to_www_form builder, "#{name}[#{{{ivar.name.stringify}}}]"
+        {% ann = ivar.annotation(URI::Params::Field) %}
+        {% unless ann && ann[:ignore] %}
+          {% if ann && ann[:ignore_serialize] %}
+            unless {{ann[:ignore_serialize]}}
+              @{{ivar.name.id}}.to_www_form builder, "#{name}[#{{{ivar.name.stringify}}}]"
+            end
+          {% else %}
+            @{{ivar.name.id}}.to_www_form builder, "#{name}[#{{{ivar.name.stringify}}}]"
+          {% end %}
+        {% end %}
       {% end %}
     end
   end

--- a/src/uri/params/serializable.cr
+++ b/src/uri/params/serializable.cr
@@ -103,9 +103,13 @@ struct URI::Params
           {% begin %}
             {% for ivar, idx in @type.instance_vars %}
               {% ann = ivar.annotation(URI::Params::Field) %}
-              {% unless ann && (ann[:ignore] || ann[:ignore_deserialize]) %}
+              {% if ann && (ann[:ignore] || ann[:ignore_deserialize]) %}
+                {% unless ivar.type.resolve.nilable? || ivar.has_default_value? %}
+                  {% raise "Can't ignore property @#{ivar.name} of #{@type} that is neither nilable nor has a default value" %}
+                {% end %}
+              {% else %}
                 %name{idx} = name.nil? ? {{ivar.name.stringify}} : "#{name}[#{{{ivar.name.stringify}}}]"
-                %value{idx} = {{(ann = ivar.annotation(URI::Params::Field)) && (converter = ann["converter"]) ? converter : ivar.type}}.from_www_form params, %name{idx}
+                %value{idx} = {{ann && ann["converter"] || ivar.type}}.from_www_form params, %name{idx}
 
                 unless %value{idx}.nil?
                   @{{ivar.name.id}} = %value{idx}


### PR DESCRIPTION
Mirrors the same options available on `JSON::Field` and `YAML::Field`.
