### PR TITLE
Fix formatter strip empty lines in heredoc

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1989,10 +1989,10 @@ describe Crystal::Formatter do
   assert_format "<<-HTML\n  hello \n  HTML"
   assert_format "<<-HTML\n  hello \n  world   \n  HTML"
   assert_format "  <<-HTML   \n    hello \n    world   \n    HTML", "<<-HTML\n  hello \n  world   \n  HTML"
-  assert_format "<<-HTML\n  hello\n  \n  HTML"
+  assert_format "<<-HTML\n  hello\n  \n  HTML", "<<-HTML\n  hello\n\n  HTML"
   assert_format "<<-HTML\n  hello\n   \n  HTML"
-  assert_format "<<-HTML\n   hello\n  \n   HTML"
-  assert_format "<<-HTML\n   hello\n   \n   HTML"
+  assert_format "<<-HTML\n   hello\n  \n   HTML", "<<-HTML\n   hello\n\n   HTML"
+  assert_format "<<-HTML\n   hello\n   \n   HTML", "<<-HTML\n   hello\n\n   HTML"
   assert_format "<<-HTML\n   hello\n    \n   HTML"
   assert_format "  <<-HTML\n    hello \n    world   \n    HTML", "<<-HTML\n  hello \n  world   \n  HTML"
 

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1989,6 +1989,12 @@ describe Crystal::Formatter do
   assert_format "<<-HTML\n  hello \n  HTML"
   assert_format "<<-HTML\n  hello \n  world   \n  HTML"
   assert_format "  <<-HTML   \n    hello \n    world   \n    HTML", "<<-HTML\n  hello \n  world   \n  HTML"
+  assert_format "<<-HTML\n  hello\n  \n  HTML"
+  assert_format "<<-HTML\n  hello\n   \n  HTML"
+  assert_format "<<-HTML\n   hello\n  \n   HTML"
+  assert_format "<<-HTML\n   hello\n   \n   HTML"
+  assert_format "<<-HTML\n   hello\n    \n   HTML"
+  assert_format "  <<-HTML\n    hello \n    world   \n    HTML", "<<-HTML\n  hello \n  world   \n  HTML"
 
   assert_format "x, y = <<-FOO, <<-BAR\n  hello\n  FOO\n  world\n  BAR"
   assert_format "x, y, z = <<-FOO, <<-BAR, <<-BAZ\n  hello\n  FOO\n  world\n  BAR\n  qux\nBAZ"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -579,9 +579,7 @@ module Crystal
       write @token.raw
 
       if is_heredoc
-        if indent_difference > 0
-          @heredoc_fixes << HeredocFix.new(heredoc_line, @line, indent_difference)
-        end
+        @heredoc_fixes << HeredocFix.new(heredoc_line, @line, indent_difference)
         write_line
       end
 
@@ -4844,9 +4842,16 @@ module Crystal
         indent_before_start = leading_space_count(lines[fix.start_line - 1], fix.difference)
         min_difference = Math.max(min_difference - indent_before_start, 0)
 
+        heredoc_indent = leading_space_count(lines[fix.end_line], Int32::MAX)
         fix.start_line.upto(fix.end_line) do |line_number|
           line = lines[line_number]
-          lines[line_number] = line[min_difference..]
+          if line.size <= heredoc_indent
+            # If the line is shorter than the heredoc indent it contains only
+            # whitespace and can be trimmed entirely.
+            lines[line_number] = ""
+          else
+            lines[line_number] = line[min_difference..]
+          end
         end
       end
     end


### PR DESCRIPTION
The formatter should remove lines in heredoc which consist only of whitespaces less or equal to the heredoc indent. These lines are considered empty by the heredoc syntax and just contain trailing whitespace which the formatter usually removes.

Fixes part of #15836