### PR TITLE
Fix: `EventLoop::IoUring#open` musn't set `O_NONBLOCK` when blocking

### DIFF
--- a/src/crystal/event_loop/io_uring.cr
+++ b/src/crystal/event_loop/io_uring.cr
@@ -595,7 +595,7 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
     return Errno.new(-fd) if fd < 0
 
     blocking = true if blocking.nil?
-    System::FileDescriptor.set_blocking(fd, false) if blocking
+    System::FileDescriptor.set_blocking(fd, false) if blocking == false
     {fd, blocking}
   end
 


### PR DESCRIPTION
_Facepalm moment when debugging the regular io_uring failures on CI_.