### PR TITLE
Add URI::Params::Field ignore options

### DIFF
--- a/spec/std/uri/params/serializable_spec.cr
+++ b/spec/std/uri/params/serializable_spec.cr
@@ -78,6 +78,13 @@ private record IgnoreSerializeType, name : String, token : String do
   @token : String
 end
 
+private record IgnoreSerializeIfType, name : String, token : String, internal : Bool = false do
+  include URI::Params::Serializable
+
+  @[URI::Params::Field(ignore_serialize: internal)]
+  @token : String
+end
+
 class ParentType
   include URI::Params::Serializable
 
@@ -180,6 +187,11 @@ describe URI::Params::Serializable do
 
     it "ignores fields with ignore_serialize" do
       IgnoreSerializeType.new("John", "secret").to_www_form.should eq "name=John"
+    end
+
+    it "evaluates ignore_serialize expression at runtime" do
+      IgnoreSerializeIfType.new("John", "secret", internal: true).to_www_form.should eq "name=John&internal=true"
+      IgnoreSerializeIfType.new("John", "secret", internal: false).to_www_form.should eq "name=John&token=secret&internal=false"
     end
   end
 

--- a/spec/std/uri/params/serializable_spec.cr
+++ b/spec/std/uri/params/serializable_spec.cr
@@ -57,6 +57,27 @@ private record GenericConverterType(T), value : Int32 do
   @value : Int32
 end
 
+private record IgnoreType, name : String, token : String = "generated" do
+  include URI::Params::Serializable
+
+  @[URI::Params::Field(ignore: true)]
+  @token : String = "generated"
+end
+
+private record IgnoreDeserializeType, name : String, token : String = "generated" do
+  include URI::Params::Serializable
+
+  @[URI::Params::Field(ignore_deserialize: true)]
+  @token : String = "generated"
+end
+
+private record IgnoreSerializeType, name : String, token : String do
+  include URI::Params::Serializable
+
+  @[URI::Params::Field(ignore_serialize: true)]
+  @token : String
+end
+
 class ParentType
   include URI::Params::Serializable
 
@@ -102,6 +123,14 @@ describe URI::Params::Serializable do
       ConverterType.from_www_form("value=10").should eq ConverterType.new(100)
     end
 
+    it "ignores fields with ignore" do
+      IgnoreType.from_www_form("name=John&token=from_params").should eq IgnoreType.new("John")
+    end
+
+    it "ignores fields with ignore_deserialize" do
+      IgnoreDeserializeType.from_www_form("name=John&token=from_params").should eq IgnoreDeserializeType.new("John")
+    end
+
     it "child type" do
       ChildType.from_www_form("name=Fred").name.should eq "Fred"
     end
@@ -143,6 +172,14 @@ describe URI::Params::Serializable do
     it "doubly nested" do
       Parent.new(Child.new("active", GrandChild.new("Fred"))).to_www_form
         .should eq "child%5Bstatus%5D=active&child%5Bgrand_child%5D%5Bname%5D=Fred"
+    end
+
+    it "ignores fields with ignore" do
+      IgnoreType.new("John").to_www_form.should eq "name=John"
+    end
+
+    it "ignores fields with ignore_serialize" do
+      IgnoreSerializeType.new("John", "secret").to_www_form.should eq "name=John"
     end
   end
 

--- a/src/uri/params/serializable.cr
+++ b/src/uri/params/serializable.cr
@@ -114,7 +114,7 @@ struct URI::Params
                     raise URI::SerializableError.new "Missing required property: '#{%name{idx}}'."
                   {% end %}
                 end
-              end
+              {% end %}
             {% end %}
           {% end %}
         {% end %}

--- a/src/uri/params/serializable.cr
+++ b/src/uri/params/serializable.cr
@@ -43,9 +43,9 @@ struct URI::Params
   # `URI::Params::Field` properties:
   # * **converter**: specify an alternate type for parsing. The converter must define `.from_www_form(params : URI::Params, name : String)`.
   # An example use case would be customizing the format when parsing `Time` instances, or supporting a type not natively supported.
-  # * **ignore**: if `true`, skip this field in serialization and deserialization.
-  # * **ignore_serialize**: if `true`, skip this field in serialization.
-  # * **ignore_deserialize**: if `true`, skip this field in deserialization.
+  # * **ignore**: if `true`, skip this field in serialization and deserialization (by default `false`).
+  # * **ignore_serialize**: if truthy, skip this field in serialization (default: `false`). The value can be any Crystal expression and is evaluated at runtime.
+  # * **ignore_deserialize**: if `true`, skip this field in deserialization (by default `false`).
   #
   # Deserialization also respects default values of variables:
   # ```
@@ -125,8 +125,14 @@ struct URI::Params
       URI::Params.build(space_to_plus: space_to_plus) do |form|
         {% for ivar in @type.instance_vars %}
           {% ann = ivar.annotation(URI::Params::Field) %}
-          {% unless ann && (ann[:ignore] || ann[:ignore_serialize]) %}
-            @{{ivar.name.id}}.to_www_form form, {{ivar.name.stringify}}
+          {% unless ann && (ann[:ignore] || ann[:ignore_serialize] == true) %}
+            {% if ann && ann[:ignore_serialize] %}
+              unless {{ ann[:ignore_serialize] }}
+                @{{ivar.name.id}}.to_www_form form, {{ivar.name.stringify}}
+              end
+            {% else %}
+              @{{ivar.name.id}}.to_www_form form, {{ivar.name.stringify}}
+            {% end %}
           {% end %}
         {% end %}
       end
@@ -136,8 +142,14 @@ struct URI::Params
     def to_www_form(builder : URI::Params::Builder, name : String)
       {% for ivar in @type.instance_vars %}
         {% ann = ivar.annotation(URI::Params::Field) %}
-        {% unless ann && (ann[:ignore] || ann[:ignore_serialize]) %}
-          @{{ivar.name.id}}.to_www_form builder, "#{name}[#{{{ivar.name.stringify}}}]"
+        {% unless ann && (ann[:ignore] || ann[:ignore_serialize] == true) %}
+          {% if ann && ann[:ignore_serialize] %}
+            unless {{ ann[:ignore_serialize] }}
+              @{{ivar.name.id}}.to_www_form builder, "#{name}[#{{{ivar.name.stringify}}}]"
+            end
+          {% else %}
+            @{{ivar.name.id}}.to_www_form builder, "#{name}[#{{{ivar.name.stringify}}}]"
+          {% end %}
         {% end %}
       {% end %}
     end

--- a/src/uri/params/serializable.cr
+++ b/src/uri/params/serializable.cr
@@ -43,6 +43,9 @@ struct URI::Params
   # `URI::Params::Field` properties:
   # * **converter**: specify an alternate type for parsing. The converter must define `.from_www_form(params : URI::Params, name : String)`.
   # An example use case would be customizing the format when parsing `Time` instances, or supporting a type not natively supported.
+  # * **ignore**: if `true`, skip this field in serialization and deserialization.
+  # * **ignore_serialize**: if `true`, skip this field in serialization.
+  # * **ignore_deserialize**: if `true`, skip this field in deserialization.
   #
   # Deserialization also respects default values of variables:
   # ```
@@ -99,15 +102,18 @@ struct URI::Params
         {% verbatim do %}
           {% begin %}
             {% for ivar, idx in @type.instance_vars %}
-              %name{idx} = name.nil? ? {{ivar.name.stringify}} : "#{name}[#{{{ivar.name.stringify}}}]"
-              %value{idx} = {{(ann = ivar.annotation(URI::Params::Field)) && (converter = ann["converter"]) ? converter : ivar.type}}.from_www_form params, %name{idx}
+              {% ann = ivar.annotation(URI::Params::Field) %}
+              {% unless ann && (ann[:ignore] || ann[:ignore_deserialize]) %}
+                %name{idx} = name.nil? ? {{ivar.name.stringify}} : "#{name}[#{{{ivar.name.stringify}}}]"
+                %value{idx} = {{ann && (converter = ann["converter"]) ? converter : ivar.type}}.from_www_form params, %name{idx}
 
-              unless %value{idx}.nil?
-                @{{ivar.name.id}} = %value{idx}
-              else
-                {% unless ivar.type.resolve.nilable? || ivar.has_default_value? %}
-                  raise URI::SerializableError.new "Missing required property: '#{%name{idx}}'."
-                {% end %}
+                unless %value{idx}.nil?
+                  @{{ivar.name.id}} = %value{idx}
+                else
+                  {% unless ivar.type.resolve.nilable? || ivar.has_default_value? %}
+                    raise URI::SerializableError.new "Missing required property: '#{%name{idx}}'."
+                  {% end %}
+                end
               end
             {% end %}
           {% end %}
@@ -118,7 +124,10 @@ struct URI::Params
     def to_www_form(*, space_to_plus : Bool = true) : String
       URI::Params.build(space_to_plus: space_to_plus) do |form|
         {% for ivar in @type.instance_vars %}
-          @{{ivar.name.id}}.to_www_form form, {{ivar.name.stringify}}
+          {% ann = ivar.annotation(URI::Params::Field) %}
+          {% unless ann && (ann[:ignore] || ann[:ignore_serialize]) %}
+            @{{ivar.name.id}}.to_www_form form, {{ivar.name.stringify}}
+          {% end %}
         {% end %}
       end
     end
@@ -126,7 +135,10 @@ struct URI::Params
     # :nodoc:
     def to_www_form(builder : URI::Params::Builder, name : String)
       {% for ivar in @type.instance_vars %}
-        @{{ivar.name.id}}.to_www_form builder, "#{name}[#{{{ivar.name.stringify}}}]"
+        {% ann = ivar.annotation(URI::Params::Field) %}
+        {% unless ann && (ann[:ignore] || ann[:ignore_serialize]) %}
+          @{{ivar.name.id}}.to_www_form builder, "#{name}[#{{{ivar.name.stringify}}}]"
+        {% end %}
       {% end %}
     end
   end


### PR DESCRIPTION
﻿Resolves #16873.

This adds the same basic field-skipping options to `URI::Params::Field` that are already available on `JSON::Field` and `YAML::Field`:

- `ignore: true` skips both serialization and deserialization
- `ignore_serialize: true` skips `#to_www_form`
- `ignore_deserialize: true` skips `.from_www_form`

I also updated the `URI::Params::Serializable` docs and added specs covering each case.

Local check:

- `git diff --check`

I could not run the Crystal specs locally because this Windows environment does not have the Crystal compiler installed.
