### PR TITLE
Fix: memory leak in `XML::Node#each_namespace`

### DIFF
--- a/src/xml.cr
+++ b/src/xml.cr
@@ -187,16 +187,20 @@ module XML
       begin
         String.new(ptr)
       ensure
-        xmlFree = LibXML.xmlFree
-        {% if flag?(:interpreted) %}
-          # FIXME: calling xmlFree directly crashes the interpreter (https://github.com/crystal-lang/crystal/issues/12495)
-          xmlFree = LibXML::FreeFunc.new(xmlFree.pointer, Pointer(Void).null)
-        {% end %}
-        xmlFree.call(ptr.as(Void*))
+        XML.free(ptr.as(Void*))
       end
     else
       ""
     end
+  end
+
+  protected def self.free(pointer : Void*)
+    xmlFree = LibXML.xmlFree
+    {% if flag?(:interpreted) %}
+      # FIXME: calling xmlFree directly crashes the interpreter (https://github.com/crystal-lang/crystal/issues/12495)
+      xmlFree = LibXML::FreeFunc.new(xmlFree.pointer, Pointer(Void).null)
+    {% end %}
+    xmlFree.call(pointer.as(Void*))
   end
 end
 

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -453,7 +453,7 @@ class XML::Node
         ns += 1
       end
     ensure
-      LibXML.xmlFree.call(ns_list.as(Void*))
+      XML.free(ns_list.as(Void*))
     end
   end
 

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -444,12 +444,16 @@ class XML::Node
 
   protected def each_namespace(& : Namespace ->)
     ns_list = LibXML.xmlGetNsList(@node.value.doc, @node)
+    return unless ns_list
 
-    if ns_list
-      while ns_list.value
-        yield Namespace.new(document, ns_list.value)
-        ns_list += 1
+    begin
+      ns = ns_list
+      while ns.value
+        yield Namespace.new(document, ns.value)
+        ns += 1
       end
+    ensure
+      LibXML.xmlFree.call(ns_list.as(Void*))
     end
   end
 


### PR DESCRIPTION
The array allocated by `LibXML.xmlGetNsList` must be manually freed.

closes #17036