### PR TITLE
Disable transport read-ahead for Kernel TLS sockets

### DIFF
--- a/spec/std/openssl/ssl/ktls_spec.cr
+++ b/spec/std/openssl/ssl/ktls_spec.cr
@@ -26,15 +26,15 @@ describe "OpenSSL::SSL::Socket (kTLS)" do
       serve = ->(socket : TCPSocket) do
         begin
           ssl = OpenSSL::SSL::Socket::Server.new(socket, server_context, sync_close: true)
-          byte = ssl.read_byte
-          if byte
+          if byte = ssl.read_byte
             ssl.write(Bytes[byte]) # echo so the client's read completes
             ssl.flush
           end
           served.send(byte == 42_u8)
-          ssl.close
         rescue
           served.send(false)
+        ensure
+          ssl.try(&.close)
         end
       end
 
@@ -51,8 +51,10 @@ describe "OpenSSL::SSL::Socket (kTLS)" do
           ssl.write(Bytes[42_u8])
           ssl.flush
           ssl.read_byte
-          ssl.close
         rescue
+          # silence
+        ensure
+          ssl.try(&.close)
         end
       end
 
@@ -66,8 +68,8 @@ describe "OpenSSL::SSL::Socket (kTLS)" do
       select
       when count = collected.receive
         count.should eq n
-      when timeout(15.seconds)
-        fail "kTLS connections deadlocked: data sent immediately after the handshake was not delivered"
+      when timeout(5.seconds)
+        fail "timeout: data sent immediately after the handshake was not delivered"
       end
     end
   end

--- a/spec/std/openssl/ssl/ktls_spec.cr
+++ b/spec/std/openssl/ssl/ktls_spec.cr
@@ -1,7 +1,4 @@
-require "spec"
-require "socket"
 require "../../spec_helper"
-require "../../socket/spec_helper"
 require "../../../support/ssl"
 
 {% skip_file unless OpenSSL.has_constant?(:KTLS) %}

--- a/spec/std/openssl/ssl/ktls_spec.cr
+++ b/spec/std/openssl/ssl/ktls_spec.cr
@@ -1,0 +1,74 @@
+require "spec"
+require "socket"
+require "../../spec_helper"
+require "../../socket/spec_helper"
+require "../../../support/ssl"
+
+{% skip_file unless OpenSSL.has_constant?(:KTLS) %}
+
+# Regression spec for #16881.
+#
+# Since kTLS bypasses the transport, records are read straight from the
+# kernel, we need to ensure there's no data that can get "stuck" in
+# buffers as we switch from userspace to kernel.
+#
+# There's some timing involved thus opening many connections to provoke it.
+describe "OpenSSL::SSL::Socket (kTLS)" do
+  it "delivers data sent immediately after the handshake" do
+    server_context, client_context = ssl_context_pair
+    server_context.add_options(OpenSSL::SSL::Options::ENABLE_KTLS)
+
+    TCPServer.open("127.0.0.1", 0) do |tcp_server|
+      address = tcp_server.local_address
+      n = 100
+      served = Channel(Bool).new(n)
+
+      serve = ->(socket : TCPSocket) do
+        begin
+          ssl = OpenSSL::SSL::Socket::Server.new(socket, server_context, sync_close: true)
+          byte = ssl.read_byte
+          if byte
+            ssl.write(Bytes[byte]) # echo so the client's read completes
+            ssl.flush
+          end
+          served.send(byte == 42_u8)
+          ssl.close
+        rescue
+          served.send(false)
+        end
+      end
+
+      spawn do
+        while client = tcp_server.accept?
+          spawn serve.call(client)
+        end
+      end
+
+      n.times do
+        spawn do
+          tcp = TCPSocket.new(address.address, address.port)
+          ssl = OpenSSL::SSL::Socket::Client.new(tcp, client_context, sync_close: true)
+          ssl.write(Bytes[42_u8])
+          ssl.flush
+          ssl.read_byte
+          ssl.close
+        rescue
+        end
+      end
+
+      collected = Channel(Int32).new(1)
+      spawn do
+        ok = 0
+        n.times { ok += 1 if served.receive }
+        collected.send(ok)
+      end
+
+      select
+      when count = collected.receive
+        count.should eq n
+      when timeout(15.seconds)
+        fail "kTLS connections deadlocked: data sent immediately after the handshake was not delivered"
+      end
+    end
+  end
+end

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -25,7 +25,7 @@ abstract class OpenSSL::SSL::Socket < IO
           end
         end
 
-        ret = LibSSL.ssl_connect(@ssl)
+        ret = ktls_safe_handshake { LibSSL.ssl_connect(@ssl) }
         unless ret == 1
           raise OpenSSL::SSL::Error.new(@ssl, ret, "SSL_connect")
         end
@@ -67,7 +67,7 @@ abstract class OpenSSL::SSL::Socket < IO
     end
 
     def accept : Nil
-      ret = LibSSL.ssl_accept(@ssl)
+      ret = ktls_safe_handshake { LibSSL.ssl_accept(@ssl) }
       unless ret == 1
         bio.io.close if @sync_close
         raise OpenSSL::SSL::Error.new(@ssl, ret, "SSL_accept")
@@ -99,7 +99,7 @@ abstract class OpenSSL::SSL::Socket < IO
     @bio = uninitialized BIO
   {% end %}
 
-  protected def initialize(io, context : Context, @sync_close : Bool = false)
+  protected def initialize(io, @context : Context, @sync_close : Bool = false)
     @closed = false
 
     @ssl = LibSSL.ssl_new(context)
@@ -116,15 +116,6 @@ abstract class OpenSSL::SSL::Socket < IO
       {% end %}
 
     LibSSL.ssl_set_bio(@ssl, bio, bio)
-
-    {% if OpenSSL.has_constant?(:KTLS) %}
-      # Must not use buffered transport that can read ahead during handshake, may
-      # cause bytes to be "stranded" in userspace and never delivered
-      if io.responds_to?(:read_buffering=) &&
-         context.options.includes?(OpenSSL::SSL::Options::ENABLE_KTLS)
-        io.read_buffering = false
-      end
-    {% end %}
   end
 
   def finalize
@@ -295,5 +286,26 @@ abstract class OpenSSL::SSL::Socket < IO
         LibCrypto.x509_free(raw_cert)
       end
     end
+  end
+
+  # When kernel TLS is enabled, we must disable the IO read buffer during the
+  # handshake so we don't over-read in the user-space buffer and leave the
+  # kernel with missing data (desync).
+  private def ktls_safe_handshake(&)
+    {% if OpenSSL.has_constant?(:KTLS) %}
+      io = bio.io
+
+      if @context.options.includes?(OpenSSL::SSL::Options::ENABLE_KTLS) && io.is_a?(IO::Buffered)
+        enabled = io.read_buffering?
+        io.read_buffering = false
+        begin
+          return yield
+        ensure
+          io.read_buffering = enabled
+        end
+      end
+    {% end %}
+
+    yield
   end
 end

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -295,13 +295,18 @@ abstract class OpenSSL::SSL::Socket < IO
     {% if OpenSSL.has_constant?(:KTLS) %}
       io = bio.io
 
-      if @context.options.includes?(OpenSSL::SSL::Options::ENABLE_KTLS) && io.is_a?(IO::Buffered)
-        enabled = io.read_buffering?
-        io.read_buffering = false
-        begin
-          return yield
-        ensure
-          io.read_buffering = enabled
+      if @context.options.includes?(OpenSSL::SSL::Options::ENABLE_KTLS) && io.is_a?(::Socket)
+        if io.read_buffering?
+          unless io.@in_buffer_rem.empty?
+            raise Error.new("TLS handshake with KTLS enabled requires the read buffer to be empty")
+          end
+
+          io.read_buffering = false
+          begin
+            return yield
+          ensure
+            io.read_buffering = true
+          end
         end
       end
     {% end %}

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -116,6 +116,15 @@ abstract class OpenSSL::SSL::Socket < IO
       {% end %}
 
     LibSSL.ssl_set_bio(@ssl, bio, bio)
+
+    {% if OpenSSL.has_constant?(:KTLS) %}
+      # Must not use buffered transport that can read ahead during handshake, may
+      # cause bytes to be "stranded" in userspace and never delivered
+      if io.responds_to?(:read_buffering=) &&
+         context.options.includes?(OpenSSL::SSL::Options::ENABLE_KTLS)
+        io.read_buffering = false
+      end
+    {% end %}
   end
 
   def finalize


### PR DESCRIPTION
Disable read-ahead on the transport when the context enables kTLS, so OpenSSL sees every byte and kTLS-RX engages cleanly.

Since kTLS bypasses the transport, records are read straight from the kernel, we need to ensure there's no data that can get "stuck" in buffers as we switch from userspace to kernel.

Fixes #16881