### PR TITLE
Preallocate correct size for hash in `Hash.zip`

### DIFF
--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1855,7 +1855,7 @@ class Hash(K, V)
   # # => {"key1" => "value1", "key2" => "value2", "key3" => "value3"}
   # ```
   def self.zip(ary1 : Array(K), ary2 : Array(V))
-    hash = {} of K => V
+    hash = Hash(K, V).new(initial_capacity: ary1.size)
     ary1.each_with_index do |key, i|
       hash[key] = ary2[i]
     end


### PR DESCRIPTION
Use`Hash.new(initial_capacity: size)` to preallocate the correct size for the hash in `Hash.zip`. This can improve performance by reducing the number of resizes needed as elements are added to the hash.