### PR TITLE
fix: report a clear error for --emit with --cross-compile

### DIFF
--- a/spec/compiler/compiler_spec.cr
+++ b/spec/compiler/compiler_spec.cr
@@ -38,4 +38,27 @@ describe "Compiler" do
         FILE
     end
   end
+
+  it "rejects emit targets when cross compiling" do
+    emit_targets = [
+      Compiler::EmitTarget::ASM,
+      Compiler::EmitTarget::OBJ,
+      Compiler::EmitTarget::LLVM_BC,
+      Compiler::EmitTarget::LLVM_IR,
+    ]
+
+    emit_targets.each do |emit_target|
+      compiler = create_spec_compiler
+      compiler.cross_compile = true
+      compiler.emit_targets = emit_target
+      compiler.prelude = "empty"
+      compiler.stdout = IO::Memory.new
+
+      with_temp_executable "compiler_spec_output" do |path|
+        expect_raises Crystal::Error, "`--emit` is not supported together with `--cross-compile`" do
+          compiler.compile Compiler::Source.new("compiler_spec_sample", "1"), path
+        end
+      end
+    end
+  end
 end

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -440,6 +440,10 @@ module Crystal
     end
 
     private def cross_compile(program, units, output_filename)
+      unless @emit_targets.none?
+        raise Crystal::Error.new("`--emit` is not supported together with `--cross-compile`")
+      end
+
       unit = units.first
       llvm_mod = unit.llvm_mod
 


### PR DESCRIPTION
## Summary
Combining `--emit` with `--cross-compile` now reports a clear error instead of crashing.

## Why this matters
Reported in #16857: `--emit` together with `--cross-compile` hit an unhandled path and crashed the compiler. The maintainer proposed reporting a clear, actionable error for the unsupported combination.

## Changes
- In `cross_compile`, raise `"--emit is not supported together with --cross-compile"` when emit targets are set.

## Testing
Added a compiler spec asserting the error is raised for the unsupported combination.

Fixes #16857

AI was used for assistance.
