### PR TITLE
feat: add IO::ClosedError to identify closed-stream errors

### DIFF
--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -975,6 +975,46 @@ describe IO do
   {% end %}
 
   describe "#close" do
+    it "raises IO::ClosedError when reading from a closed IO::Memory" do
+      io = IO::Memory.new("hello")
+      io.close
+
+      expect_raises(IO::ClosedError, "Closed stream") do
+        io.read(Bytes.new(1))
+      end
+    end
+
+    it "raises IO::ClosedError when writing to a closed IO::Memory" do
+      io = IO::Memory.new
+      io.close
+
+      expect_raises(IO::ClosedError, "Closed stream") do
+        io.write(Bytes[1])
+      end
+    end
+
+    it "can still be rescued as IO::Error" do
+      io = IO::Memory.new("hello")
+      io.close
+
+      error = expect_raises(IO::Error, "Closed stream") do
+        io.read(Bytes.new(1))
+      end
+      error.should be_a(IO::ClosedError)
+    end
+
+    it "doesn't rescue closed streams as EOF" do
+      io = IO::Memory.new("hello")
+      io.close
+
+      expect_raises(IO::ClosedError, "Closed stream") do
+        begin
+          io.read(Bytes.new(1))
+        rescue IO::EOFError
+        end
+      end
+    end
+
     it "aborts 'read' in a different fiber" do
       ch = Channel(SpecChannelStatus).new(1)
 
@@ -1016,6 +1056,14 @@ describe IO do
 
         write.close
         ch.receive.should eq SpecChannelStatus::End
+      end
+    end
+  end
+
+  describe IO::ClosedError do
+    describe ".new" do
+      it "defaults to a closed stream message" do
+        IO::ClosedError.new.message.should eq("Closed stream")
       end
     end
   end

--- a/src/io.cr
+++ b/src/io.cr
@@ -118,7 +118,7 @@ abstract class IO
   end
 
   protected def check_open
-    raise IO::Error.new "Closed stream" if closed?
+    raise IO::ClosedError.new if closed?
   end
 
   # Flushes buffered data, if any.

--- a/src/io/error.cr
+++ b/src/io/error.cr
@@ -32,6 +32,13 @@ class IO
   class TimeoutError < Error
   end
 
+  # Raised when an `IO` operation is attempted on a closed stream.
+  class ClosedError < Error
+    def initialize(message = "Closed stream", cause : Exception? = nil, *, target = nil)
+      super(message, cause: cause, target: target)
+    end
+  end
+
   class EOFError < Error
     def initialize(message = "End of file reached")
       super(message)


### PR DESCRIPTION
## Summary
Adds `IO::ClosedError`, a dedicated `IO::Error` subclass for operations on a closed stream, so callers can rescue closed-stream errors specifically.

## Why this matters
Requested in #16976: operations on a closed `IO` raise a generic `IO::Error("Closed stream")`, which can only be distinguished by message. A dedicated subclass lets callers rescue the closed-stream case directly. `ClosedError < IO::Error`, so existing `rescue IO::Error` handlers keep working.

## Changes
- Add `IO::ClosedError < IO::Error` with the existing `"Closed stream"` default message.
- Raise it from `IO#check_open`.

## Scope
This covers the central `check_open` path. Mapping every OS-level errno (EBADF / ECONNRESET / EPIPE) to `ClosedError` is left out: it needs a maintainer decision per the design discussion. Hence `Refs` rather than `Fixes`.

Refs #16976

AI was used for assistance.
