### PR TITLE
Enable OpenSSL Kernel TLS support by default

### DIFF
--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -10,11 +10,7 @@ describe OpenSSL::SSL::Context do
   it "new for client" do
     context = OpenSSL::SSL::Context::Client.new
 
-    {% if OpenSSL.has_constant?(:KTLS) %}
-      (context.options & OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL & ~OpenSSL::SSL::Options::ENABLE_KTLS)
-    {% else %}
-      (context.options & OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL)
-    {% end %}
+    (context.options & OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL)
     (context.options & OpenSSL::SSL::Options::NO_SESSION_RESUMPTION_ON_RENEGOTIATION).should eq(OpenSSL::SSL::Options::NO_SESSION_RESUMPTION_ON_RENEGOTIATION)
 
     context.modes.should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
@@ -24,11 +20,7 @@ describe OpenSSL::SSL::Context do
   it "new for server" do
     context = OpenSSL::SSL::Context::Server.new
 
-    {% if OpenSSL.has_constant?(:KTLS) %}
-      (context.options & OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL & ~OpenSSL::SSL::Options::ENABLE_KTLS)
-    {% else %}
-      (context.options & OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL)
-    {% end %}
+    (context.options & OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL)
     (context.options & OpenSSL::SSL::Options::NO_SESSION_RESUMPTION_ON_RENEGOTIATION).should eq(OpenSSL::SSL::Options::NO_SESSION_RESUMPTION_ON_RENEGOTIATION)
     (context.options & OpenSSL::SSL::Options::NO_RENEGOTIATION).should eq(OpenSSL::SSL::Options::NO_RENEGOTIATION)
 

--- a/src/openssl/bio.cr
+++ b/src/openssl/bio.cr
@@ -100,11 +100,16 @@ class OpenSSL::BIO
                 socket = bio.socket
                 is_tx = num != 0
 
-                KTLS.enable(socket)
+                # can't start Kernel TLS on RX with leftover data in the read buffer
+                if is_tx || !socket.read_buffering? || socket.@in_buffer_rem.empty?
+                  KTLS.enable(socket)
 
-                if KTLS.start(socket, ptr, is_tx)
-                  LibCrypto.BIO_set_flags(b, is_tx ? LibCrypto::BIO_FLAGS_KTLS_TX : LibCrypto::BIO_FLAGS_KTLS_RX)
-                  1
+                  if KTLS.start(socket, ptr, is_tx)
+                    LibCrypto.BIO_set_flags(b, is_tx ? LibCrypto::BIO_FLAGS_KTLS_TX : LibCrypto::BIO_FLAGS_KTLS_RX)
+                    1
+                  else
+                    0
+                  end
                 else
                   0
                 end

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -259,9 +259,6 @@ abstract class OpenSSL::SSL::Context
       NO_SESSION_RESUMPTION_ON_RENEGOTIATION,
       NO_RENEGOTIATION,
     ))
-    {% if OpenSSL.has_constant?(:KTLS) %}
-      remove_options(OpenSSL::SSL::Options::ENABLE_KTLS)
-    {% end %}
     add_modes(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
 
     # OpenSSL does not support reading from the system root certificate store on

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -295,12 +295,8 @@ abstract class OpenSSL::SSL::Socket < IO
     {% if OpenSSL.has_constant?(:KTLS) %}
       io = bio.io
 
-      if @context.options.includes?(OpenSSL::SSL::Options::ENABLE_KTLS) && io.is_a?(::Socket)
+      if @context.options.includes?(OpenSSL::SSL::Options::ENABLE_KTLS) && io.is_a?(IO::Buffered)
         if io.read_buffering?
-          unless io.@in_buffer_rem.empty?
-            raise Error.new("TLS handshake with KTLS enabled requires the read buffer to be empty")
-          end
-
           io.read_buffering = false
           begin
             return yield


### PR DESCRIPTION
This reverts commit f6319c243bffe21e2a68998057e5045c701beb27 to reenable kernel TLS by default.

Changes the behavior from raising when the read buffer isn't empty to skip kernel TLS and fallback to user space TLS instead.

Depends on:
- #17053