### PR TITLE
Fix: cross-compile crashes when combined with emit llvm-bc or obj

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -441,15 +441,13 @@ module Crystal
 
     private def cross_compile(program, units, output_filename)
       unit = units.first
-      llvm_mod = unit.llvm_mod
+      emit_targets = @emit_targets | EmitTarget::OBJ
 
       @progress_tracker.stage("Codegen (bc+obj)") do
-        optimize llvm_mod, target_machine unless @optimization_mode.o0?
-
-        unit.emit(@emit_targets, emit_base_filename || output_filename)
-
-        target_machine.emit_obj_to_file llvm_mod, output_filename
+        sequential_codegen(units)
+        unit.emit(emit_targets, emit_base_filename || output_filename)
       end
+
       object_names = [output_filename]
       output_filename = output_filename.rchop(unit.object_extension)
       _, command, args = linker_command(program, object_names, output_filename, nil)


### PR DESCRIPTION
When cross compiling, the compiler used to emit before the actual codegen and bypassed the cache to directly emit the object file to the current folder.

We now call the regular codegen path (sequential one because only one compilation unit), then emit files to the current folder. We still always emit the object file to be consistent with the current behavior and with the `build` command that always generates an executable.

Closes #16857
Closes #17055