### PR TITLE
crystal spec: fix short flag conflict between --profile and --progress

### DIFF
--- a/src/spec/cli.cr
+++ b/src/spec/cli.cr
@@ -67,7 +67,7 @@ module Spec
         opts.on("-l", "--line LINE", "run examples whose line matches LINE") do |line|
           @line = line.to_i
         end
-        opts.on("-p", "--profile", "Print the 10 slowest specs") do
+        opts.on("--profile", "Print the 10 slowest specs") do
           @slowest = 10
         end
         opts.on("--fail-fast", "abort the run on first failure") do


### PR DESCRIPTION
The shorthand flag `-p` for `crystal spec --profile` is in conflict with the shorthand flag `-p` for `crystal spec --progress`. This removes the short flag for `--profile` to resolve the conflict.