### PR TITLE
Remedy short-flag conflict for `crystal spec -p`

### DIFF
--- a/src/compiler/crystal/command/spec.cr
+++ b/src/compiler/crystal/command/spec.cr
@@ -24,7 +24,7 @@ class Crystal::Command
         puts opts
         puts
 
-        runtime_options = Spec::CLI.new.option_parser(without_p: true)
+        runtime_options = Spec::CLI.new.build_option_parser(without_p: true)
         runtime_options.banner = "Runtime options (passed to spec runner):"
         puts runtime_options
         exit

--- a/src/compiler/crystal/command/spec.cr
+++ b/src/compiler/crystal/command/spec.cr
@@ -24,7 +24,7 @@ class Crystal::Command
         puts opts
         puts
 
-        runtime_options = Spec::CLI.new.option_parser
+        runtime_options = Spec::CLI.new.option_parser(without_p: true)
         runtime_options.banner = "Runtime options (passed to spec runner):"
         puts runtime_options
         exit

--- a/src/compiler/crystal/command/spec.cr
+++ b/src/compiler/crystal/command/spec.cr
@@ -17,7 +17,7 @@ class Crystal::Command
     compiler = new_compiler
     link_flags = [] of String
     parse_with_crystal_opts do |opts|
-      opts.banner = "Usage: crystal spec [options] [files] [runtime_options]\n\nOptions:"
+      opts.banner = "Usage: crystal spec [options] [files] [-- runtime_options]\n\nOptions:"
       setup_simple_compiler_options compiler, opts
 
       opts.on("-h", "--help", "Show this message") do

--- a/src/compiler/crystal/command/spec.cr
+++ b/src/compiler/crystal/command/spec.cr
@@ -24,6 +24,9 @@ class Crystal::Command
         puts opts
         puts
 
+        # Short flag `-p` might collied with the same parser flag (short for `--progress`),
+        # so we don't show it here. It still works when passed as an explicit argument to the
+        # runner process (e.g. `crystal spec -- -p`).
         runtime_options = Spec::CLI.new.build_option_parser(without_p: true)
         runtime_options.banner = "Runtime options (passed to spec runner):"
         puts runtime_options

--- a/src/spec/cli.cr
+++ b/src/spec/cli.cr
@@ -58,7 +58,7 @@ module Spec
       @randomizer = seed ? Random::PCG32.new(seed) : nil
     end
 
-    def option_parser : OptionParser
+    def option_parser(without_p = false) : OptionParser
       @option_parser ||= OptionParser.new do |opts|
         opts.banner = "crystal spec runner"
         opts.on("-e", "--example STRING", "run examples whose full nested names include STRING") do |pattern|
@@ -67,7 +67,7 @@ module Spec
         opts.on("-l", "--line LINE", "run examples whose line matches LINE") do |line|
           @line = line.to_i
         end
-        opts.on("-p", "--profile", "Print the 10 slowest specs") do
+        opts.on((without_p ? "" : "-p"), "--profile", "Print the 10 slowest specs") do
           @slowest = 10
         end
         opts.on("--fail-fast", "abort the run on first failure") do

--- a/src/spec/cli.cr
+++ b/src/spec/cli.cr
@@ -58,8 +58,10 @@ module Spec
       @randomizer = seed ? Random::PCG32.new(seed) : nil
     end
 
-    def option_parser(without_p = false) : OptionParser
-      @option_parser ||= OptionParser.new do |opts|
+    getter option_parser : OptionParser { build_option_parser(without_p: false) }
+
+    def build_option_parser(*, without_p) : OptionParser
+      OptionParser.new do |opts|
         opts.banner = "crystal spec runner"
         opts.on("-e", "--example STRING", "run examples whose full nested names include STRING") do |pattern|
           @pattern = Regex.new(Regex.escape(pattern))


### PR DESCRIPTION
The shorthand flag `-p` for `crystal spec -- --profile` is in conflict with the shorthand flag `-p` for `crystal spec --progress`.

This patch removes the short flag from `crystal spec --help` and suggests passing runner options after `--`.
That solution still is not ideal, but keeps existing commands working compared to removing `-p` from the spec runner entirely.

Closes #17061