### PR TITLE
Fix swapped atomic orderings in `Sync::MU` fast paths

### DIFF
--- a/src/sync/mu.cr
+++ b/src/sync/mu.cr
@@ -68,7 +68,7 @@ module Sync
 
     def try_rlock? : Bool
       # uncontended
-      word, success = @word.compare_and_set(UNLOCKED, RLOCK, :release, :relaxed)
+      word, success = @word.compare_and_set(UNLOCKED, RLOCK, :acquire, :relaxed)
       return true if success
 
       if (word & (WLOCK | WRITER_WAITING | LONG_WAIT)) == 0
@@ -186,8 +186,8 @@ module Sync
 
     def unlock : Nil
       # uncontended
-      word, success = @word.compare_and_set(WLOCK, UNLOCKED, :acquire, :relaxed)
-      return true if success
+      word, success = @word.compare_and_set(WLOCK, UNLOCKED, :release, :relaxed)
+      return if success
 
       # sanity check
       if (word & WLOCK) == 0


### PR DESCRIPTION
Hey all, and thanks for Crystal, its lovely to work with. 

I was working with some code using Mutex and with `preview_mt` enabled on ARM  (Apple silicon) and ran into fibers intermittently stalling on the mutex until a watchdog fired.

On trying to find the root cause, I used Fable and it found two swapped atomic orderings.

I mentioned this in Discord and @HertzDevil confirmed that `google/nsync` seems to corroborate the findings:
 
[`nsync_mu_rtrylock` uses `ATM_CAS_ACQ`](https://github.com/google/nsync/blob/5b420ef6b16532a4fad4be1fde8e483b6b7bd8f4/internal/mu.c#L171) and [`nsync_mu_unlock` uses `ATM_CAS_REL`](https://github.com/google/nsync/blob/5b420ef6b16532a4fad4be1fde8e483b6b7bd8f4/internal/mu.c#L465).

I did not include a rgerssion test since the issue only affects `ARM` + `--release` and seems to be a form of typo.


The following is `Claude` (`Fable`)'s analysis for reference / transparency:

> ## Fix swapped atomic orderings in `Sync::MU` fast paths
> 
> Two memory orderings in `Sync::MU` (introduced with `Sync::Mutex`/`Sync::RWLock` in #16399) appear to have been transposed between methods:
> 
> - `MU#unlock`'s uncontended fast path released the write lock with `:acquire` — releasing requires `:release` (compare `#runlock`, which is correct).
> - `MU#try_rlock?` acquired the read lock with `:release` — acquiring requires `:acquire` (compare `#try_lock?`, which is correct).
> 
> On weakly-ordered targets (AArch64), the missing release on `unlock` allows stores made inside the critical section to be reordered past the unlock, so the next lock holder can observe stale state — an actual mutual-exclusion violation. x86's stronger memory model masks both issues, which is likely why CI never caught them.
> 
> In practice (Apple M-series, `--release -Dpreview_mt`, `CRYSTAL_WORKERS=4`) this loses roughly 1 in ~2000 contended lock handoffs. Depending on what the critical section protects, that surfaces as wrong results, or — when the protected state gates further progress, e.g. fibers in lockstep — as an intermittent silent hang, which is how it was originally noticed. In principle this also affects execution contexts (same Sync::MU codegen), though it reproduces far more readily under the legacy -Dpreview_mt scheduler's pinned cross-thread handoffs.
> 
> A variant where the barrier state itself is mutex-protected converts the symptom into a silent hang (a lost increment means the round target is never reached): 10/12 runs stalled before the fix, 0/12 after.
>

### Reproduction

Built with `crystal build -Dpreview_mt --release`, run with `CRYSTAL_WORKERS=4` on an Apple M-series Mac:

```crystal
FIBERS = 8
ROUNDS = 20_000

mutex = Mutex.new
counter = 0
arrived = Atomic(Int32).new(0)
release = Array(Channel(Nil)).new(FIBERS) { Channel(Nil).new(1) }
done = Channel(Nil).new

FIBERS.times do |i|
  spawn do
    ROUNDS.times do
      mutex.synchronize { counter += 1 }

      # barrier: keep all fibers in lockstep to maximize contended handoffs
      if arrived.add(1) == FIBERS - 1
        arrived.set(0)
        FIBERS.times { |j| release[j].send(nil) unless j == i }
      else
        release[i].receive
      end
    end
    done.send(nil)
  end
end

FIBERS.times { done.receive }
if counter == FIBERS * ROUNDS
  puts "OK"
else
  puts "LOST #{FIBERS * ROUNDS - counter} updates (#{counter}/#{FIBERS * ROUNDS})"
  exit 1
end
```