### PR TITLE
Add `Crystal::EventLoop::FileDescriptor#pread`

### DIFF
--- a/src/crystal/event_loop/file_descriptor.cr
+++ b/src/crystal/event_loop/file_descriptor.cr
@@ -27,6 +27,10 @@ abstract class Crystal::EventLoop
     # Returns 0 when EOF is reached.
     abstract def read(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
 
+    # Identical to `#read` but takes an *offset* into the file to read at,
+    # instead of the current position. Doesn't affect the current position.
+    abstract def pread(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes, offset : Int64) : Int32
+
     # Blocks the current fiber until the file descriptor is ready for read.
     abstract def wait_readable(file_descriptor : Crystal::System::FileDescriptor) : Nil
 

--- a/src/crystal/event_loop/io_uring.cr
+++ b/src/crystal/event_loop/io_uring.cr
@@ -600,6 +600,10 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
   end
 
   def read(file_descriptor : System::FileDescriptor, slice : Bytes) : Int32
+    pread(file_descriptor, slice, offset: -1)
+  end
+
+  def pread(file_descriptor : System::FileDescriptor, slice : Bytes, offset : Int64) : Int32
     before_suspend =
       {% if flag?(:preview_mt) %}
         file_descriptor.__evloop_reader = ring
@@ -612,7 +616,7 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
         nil
       {% end %}
 
-    async_rw(LibC::IORING_OP_READ, file_descriptor, slice, file_descriptor.@read_timeout, before_suspend) do |errno|
+    async_rw(LibC::IORING_OP_READ, file_descriptor, slice, file_descriptor.@read_timeout, before_suspend, offset) do |errno|
       case errno
       when Errno::ECANCELED
         raise IO::TimeoutError.new("Read timed out")
@@ -941,11 +945,11 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
     end
   end
 
-  private def async_rw(opcode, io, slice, timeout, before_suspend = nil, &)
+  private def async_rw(opcode, io, slice, timeout, before_suspend = nil, offset = -1, &)
     loop do
       res = async(opcode, timeout, before_suspend) do |sqe|
         sqe.value.fd = io.fd
-        sqe.value.off = -1
+        sqe.value.off = offset
         sqe.value.addr = slice.to_unsafe.address.to_u64!
         sqe.value.len = slice.size
       end

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -315,6 +315,13 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
     raise NotImplementedError.new("Crystal::System::IOCP#wait_readable(FileDescriptor)")
   end
 
+  def pread(file_descriptor : System::FileDescriptor, slice : Bytes, offset : Int64) : Int32
+    System::IOCP.overlapped_operation(file_descriptor, "ReadFile", file_descriptor.read_timeout, offset: offset) do |overlapped|
+      ret = LibC.ReadFile(file_descriptor.windows_handle, slice, slice.size, out byte_count, overlapped)
+      {ret, byte_count}
+    end.to_i32
+  end
+
   def write(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
     bytes_written = System::IOCP.overlapped_operation(file_descriptor, "WriteFile", file_descriptor.write_timeout, writing: true) do |overlapped|
       overlapped.offset = UInt64::MAX if file_descriptor.system_append?

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -161,6 +161,12 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
     end
   end
 
+  def pread(file_descriptor : System::FileDescriptor, slice : Bytes, offset : Int64) : Int32
+    evented_read(file_descriptor, "Error reading file descriptor") do
+      LibC.pread(file_descriptor.fd, slice, slice.size, offset)
+    end
+  end
+
   def wait_readable(file_descriptor : Crystal::System::FileDescriptor) : Nil
     file_descriptor.evented_wait_readable(raise_if_closed: false) do
       raise IO::TimeoutError.new("Read timed out")

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -204,6 +204,20 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     end
   end
 
+  def pread(file_descriptor : System::FileDescriptor, slice : Bytes, offset : Int64) : Int32
+    loop do
+      size = LibC.pread(file_descriptor.fd, slice, slice.size, offset)
+      return size.to_i32 unless size == -1
+
+      if Errno.value == Errno::EAGAIN
+        wait_readable(file_descriptor, file_descriptor.@read_timeout)
+        check_open(file_descriptor)
+      else
+        raise IO::Error.from_errno("pread", target: file_descriptor)
+      end
+    end
+  end
+
   def wait_readable(file_descriptor : System::FileDescriptor) : Nil
     wait_readable(file_descriptor, file_descriptor.@read_timeout) do
       raise IO::TimeoutError.new

--- a/src/crystal/event_loop/wasi.cr
+++ b/src/crystal/event_loop/wasi.cr
@@ -48,6 +48,12 @@ class Crystal::EventLoop::Wasi < Crystal::EventLoop
     end
   end
 
+  def pread(file_descriptor : System::FileDescriptor, slice : Bytes, offset : Int64) : Int32
+    evented_read(file_descriptor, "Error reading file_descriptor") do
+      LibC.pread(file_descriptor.fd, slice, slice.size, offset)
+    end
+  end
+
   def wait_readable(file_descriptor : Crystal::System::FileDescriptor) : Nil
     evented_wait_readable(file_descriptor) do
       raise IO::TimeoutError.new("Read timed out")

--- a/src/crystal/system/file_descriptor.cr
+++ b/src/crystal/system/file_descriptor.cr
@@ -35,6 +35,11 @@ module Crystal::System::FileDescriptor
     event_loop.read(self, slice)
   end
 
+  # :nodoc:
+  def system_pread(slice : Bytes, offset : Int64) : Int32
+    event_loop.pread(self, slice, offset)
+  end
+
   private def system_write(slice : Bytes) : Int32
     event_loop.write(self, slice)
   end

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -236,16 +236,6 @@ module Crystal::System::FileDescriptor
     pipe_fds
   end
 
-  def self.pread(file, buffer, offset)
-    bytes_read = LibC.pread(file.fd, buffer, buffer.size, offset).to_i64
-
-    if bytes_read == -1
-      raise IO::Error.from_errno("Error reading file", target: file)
-    end
-
-    bytes_read
-  end
-
   def self.from_stdio(fd)
     # If we have a TTY for stdin/out/err, it is possibly a shared terminal.
     # We need to reopen it to use O_NONBLOCK without causing other programs to break

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -49,6 +49,27 @@ module Crystal::System::FileDescriptor
     bytes_read.to_i32
   end
 
+  def system_pread(slice : Bytes, offset : Int64) : Int32
+    if system_blocking?
+      pread_blocking(slice, offset)
+    else
+      event_loop.pread(self, slice, offset)
+    end
+  end
+
+  private def pread_blocking(slice, offset)
+    overlapped = LibC::OVERLAPPED.new
+    overlapped.union.offset.offset = LibC::DWORD.new!(offset)
+    overlapped.union.offset.offsetHigh = LibC::DWORD.new!(offset >> 32)
+
+    if LibC.ReadFile(windows_handle, slice, slice.size, out bytes_read, pointerof(overlapped)) == 0
+      error = WinError.value
+      return 0_i32 if error == WinError::ERROR_HANDLE_EOF
+      raise IO::Error.from_os_error "Error reading file", error, target: self
+    end
+    bytes_read.to_i32
+  end
+
   private def system_write(slice : Bytes) : Int32
     handle = windows_handle
     if system_blocking?
@@ -326,28 +347,6 @@ module Crystal::System::FileDescriptor
     raise IO::Error.from_winerror("CreateFileW") if r_pipe == LibC::INVALID_HANDLE_VALUE
 
     {r_pipe.address, w_pipe.address}
-  end
-
-  def self.pread(file, buffer, offset)
-    handle = file.windows_handle
-
-    if file.system_blocking?
-      overlapped = LibC::OVERLAPPED.new
-      overlapped.union.offset.offset = LibC::DWORD.new!(offset)
-      overlapped.union.offset.offsetHigh = LibC::DWORD.new!(offset >> 32)
-      if LibC.ReadFile(handle, buffer, buffer.size, out bytes_read, pointerof(overlapped)) == 0
-        error = WinError.value
-        return 0_i64 if error == WinError::ERROR_HANDLE_EOF
-        raise IO::Error.from_os_error "Error reading file", error, target: file
-      end
-
-      bytes_read.to_i64
-    else
-      IOCP.overlapped_operation(file, "ReadFile", file.read_timeout, offset: offset) do |overlapped|
-        ret = LibC.ReadFile(handle, buffer, buffer.size, out byte_count, overlapped)
-        {ret, byte_count}
-      end.to_i64
-    end
   end
 
   def self.from_stdio(fd)

--- a/src/file/preader.cr
+++ b/src/file/preader.cr
@@ -21,7 +21,7 @@ class File::PReader < IO
     count = Math.min(count, @bytesize - @pos)
 
     bytes_read = @file.@fd_lock.reference do
-      Crystal::System::FileDescriptor.pread(@file, slice[0, count], @offset + @pos)
+      @file.system_pread(slice[0, count], @offset + @pos)
     end
 
     @pos += bytes_read


### PR DESCRIPTION
The operation was already using overlapped on Windows/IOCP but outside of the evloop. The operation can also run async on Linux/IoUring.

The polling event loops now consider that `pread` can return EAGAIN in an edge case: disk files are always ready, and a fifo/pipe isn't seekable, but a character device can.

Also enables pread on WASI.