### PR TITLE
Replace `markdownlint` with `rumdl`

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -48,6 +48,10 @@ no-blanks-blockquote: false
 # FIXME: We're using some legacy inline HTML.
 no-inline-html: false
 
+# MD038 - No space in code
+# FIXME: Bug in rumdl: https://github.com/rvben/rumdl/issues/665
+no-space-in-code: false
+
 # MD049 - Keep italic text formatting consistent
 emphasis-style:
   style: "underscore"

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -27,10 +27,6 @@ ol-prefix:
 ul-style:
   style: "dash"
 
-# MD007 - Keep list indentation consistent
-ul-indent:
-  indent: 2
-
 ## Whitespace Rules
 
 # MD013 - Line length
@@ -78,9 +74,3 @@ no-bare-urls: false
 # MD045 - Add Descriptive Text to Images
 # FIXME: Deferred
 no-alt-text: false
-
-## Table Rules
-
-# MD060 - Table column style
-# FIXME: Deferred
-table-column-style: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,37 +1,82 @@
+# Indicators for comment annotations:
+#
+# * `Disabled`: The rule is disabled because it does not seem useful for this repo (or in general).
+# * `BUG`: A bug prevents using this rule either entirely or for specific files.
+# * `FIXME`: The rule seems useful, but requires some effort to resolve. That's deferred for later.
+# * `TODO`: The rule might be useful, but we need to investigate whether we want to use it or not.
+
 default: true
 
-heading-style: "setext"
+## Heading Rules
 
-no-inline-html: false
-line-length: false
+# MD003 - Heading style should be consistent
+heading-style:
+  style: "atx"
 
+# MD024 - Avoid duplicate heading text
+no-duplicate-heading:
+  siblings_only: true
+
+## List Rules
+
+# MD029 - Use consistent numbers for ordered lists
 ol-prefix:
   style: "ordered"
+
+# MD004 - Unordered list style should be consistent
 ul-style:
   style: "dash"
+
+# MD007 - Keep list indentation consistent
 ul-indent:
   indent: 2
 
+## Whitespace Rules
+
+# MD013 - Line length
+# TODO: We might want to consider automatic wrapping (maybe with https://github.com/razziel89/mdslw ?)
+line-length: false
+
+# MD028 - No blank lines inside blockquote
+# TODO: We're using consecutive blockquotes with no content in between in a few places.
+# This rule is supposed to prevent ambiguity, but there shouldn't be any with our tooling.
 no-blanks-blockquote: false
 
+## Formatting Rules
+
+# MD033 - Inline HTML
+# FIXME: We're using some legacy inline HTML.
+no-inline-html: false
+
+# MD049 - Keep italic text formatting consistent
 emphasis-style:
   style: "underscore"
+
+# MD050 - Keep bold text formatting consistent
 strong-style:
   style: "asterisk"
 
-no-duplicate-heading:
-  siblings_only: true
-no-bare-urls: false
+## Code Block Rules
 
-fenced-code-language: false
+# MD014 - Show command output in documentation
+# TODO: Not sure if this is generally useful.
 commands-show-output: false
 
-first-line-h1:
-  front_matter_title: "^\\s*(page_)?title\\s*[:=]"
-  exclude:
-    .github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+# MD040 - Code blocks should have a language specified
+# FIXME: Deferred
+fenced-code-language: false
 
+## Link and Image Rules
+
+# MD034 - Bare URL used
+no-bare-urls: false
+
+# MD045 - Add Descriptive Text to Images
+# FIXME: Deferred
 no-alt-text: false
 
-hard_tab:
-  code_blocks: false
+## Table Rules
+
+# MD060 - Table column style
+# FIXME: Deferred
+table-column-style: false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -13,10 +13,6 @@ default: true
 heading-style:
   style: "atx"
 
-# MD024 - Avoid duplicate heading text
-no-duplicate-heading:
-  siblings_only: true
-
 ## List Rules
 
 # MD029 - Use consistent numbers for ordered lists
@@ -33,16 +29,7 @@ ul-style:
 # TODO: We might want to consider automatic wrapping (maybe with https://github.com/razziel89/mdslw ?)
 line-length: false
 
-# MD028 - No blank lines inside blockquote
-# TODO: We're using consecutive blockquotes with no content in between in a few places.
-# This rule is supposed to prevent ambiguity, but there shouldn't be any with our tooling.
-no-blanks-blockquote: false
-
 ## Formatting Rules
-
-# MD033 - Inline HTML
-# FIXME: We're using some legacy inline HTML.
-no-inline-html: false
 
 # MD038 - No space in code
 # FIXME: Bug in rumdl: https://github.com/rvben/rumdl/issues/665
@@ -56,21 +43,7 @@ emphasis-style:
 strong-style:
   style: "asterisk"
 
-## Code Block Rules
-
-# MD014 - Show command output in documentation
-# TODO: Not sure if this is generally useful.
-commands-show-output: false
-
-# MD040 - Code blocks should have a language specified
-# FIXME: Deferred
-fenced-code-language: false
-
 ## Link and Image Rules
 
 # MD034 - Bare URL used
 no-bare-urls: false
-
-# MD045 - Add Descriptive Text to Images
-# FIXME: Deferred
-no-alt-text: false

--- a/devenv.nix
+++ b/devenv.nix
@@ -35,7 +35,6 @@
       files = "^Makefile(\.win)?$";
       pass_filenames = true;
     };
-    markdownlint.enable = true;
     mbake = {
       enable = true;
       name = "Mbake";
@@ -43,6 +42,7 @@
       files = "Makefile|.*\\.Makefile|Makefile\\..*|.*\\.mk";
       pass_filenames = true;
     };
+    rumdl.enable = true;
     shellcheck = {
       enable = true;
       excludes = [

--- a/doc/changelogs/pre-1.0.md
+++ b/doc/changelogs/pre-1.0.md
@@ -541,7 +541,7 @@
 - **(breaking-change)** Rename `Log::Severity::Warning` to `Warn`. Drop `Verbose`. Add `Trace` and `Notice`. ([#9293](https://github.com/crystal-lang/crystal/pull/9293), [#9107](https://github.com/crystal-lang/crystal/pull/9107), [#9316](https://github.com/crystal-lang/crystal/pull/9316), thanks @bcardiff, @paulcsmith)
 - **(breaking-change)** Allow local data on entries via `Log::Metadata` and redesign `Log::Context`. ([#9118](https://github.com/crystal-lang/crystal/pull/9118), [#9227](https://github.com/crystal-lang/crystal/pull/9227), [#9150](https://github.com/crystal-lang/crystal/pull/9150), [#9157](https://github.com/crystal-lang/crystal/pull/9157), thanks @bcardiff, @waj)
 - **(breaking-change)** Split top-level `Log::Metadata` from `Log::Metadata::Value`, drop immutability via clone, improve performance. ([#9295](https://github.com/crystal-lang/crystal/pull/9295), thanks @bcardiff)
-- **(breaking-change)** Rework `Log.setup_from_env` and defaults. ([#9145](https://github.com/crystal-lang/crystal/pull/9145), [#9240](https://github.com/crystal-lang/crystal/pull/9240),  thanks @bcardiff)
+- **(breaking-change)** Rework `Log.setup_from_env` and defaults. ([#9145](https://github.com/crystal-lang/crystal/pull/9145), [#9240](https://github.com/crystal-lang/crystal/pull/9240), thanks @bcardiff)
 - Add `Log.capture` spec helper. ([#9201](https://github.com/crystal-lang/crystal/pull/9201), thanks @bcardiff)
 - Redesign `Log::Formatter`. ([#9211](https://github.com/crystal-lang/crystal/pull/9211), thanks @waj)
 - Add `to_json` for `Log::Context`. ([#9101](https://github.com/crystal-lang/crystal/pull/9101), thanks @paulcsmith)
@@ -1506,7 +1506,7 @@
 #### Language semantics
 
 - **(breaking-change)** Fix new/initialize lookup regarding modules. ([#7818](https://github.com/crystal-lang/crystal/pull/7818), thanks @asterite)
-- **(breaking-change)**  Don't precompute `sizeof` on abstract structs and modules. ([#7801](https://github.com/crystal-lang/crystal/pull/7801), thanks @asterite)
+- **(breaking-change)** Don't precompute `sizeof` on abstract structs and modules. ([#7801](https://github.com/crystal-lang/crystal/pull/7801), thanks @asterite)
 - Consider macro calls in `@ivar` initializer. ([#7750](https://github.com/crystal-lang/crystal/pull/7750), thanks @asterite)
 - Give precedence to `T.class` over `Class` in method lookup. ([#7759](https://github.com/crystal-lang/crystal/pull/7759), thanks @asterite)
 - Honor enum base type on non-default values. ([#7776](https://github.com/crystal-lang/crystal/pull/7776), thanks @asterite)
@@ -1545,7 +1545,7 @@
 ### Language changes
 
 - **(breaking-change)** Enum declaration members can no longer be separated by a space, only by a newline, `;` or `,`, the latter being deprecated and reformatted to a newline. ([#7607](https://github.com/crystal-lang/crystal/pull/7607), [#7618](https://github.com/crystal-lang/crystal/pull/7618), thanks @asterite, and @j8r)
-- Add begin-less and end-less ranges: `array[5..]`.  ([#7179](https://github.com/crystal-lang/crystal/pull/7179), thanks @asterite)
+- Add begin-less and end-less ranges: `array[5..]`. ([#7179](https://github.com/crystal-lang/crystal/pull/7179), thanks @asterite)
 - Add `offsetof(Type, @ivar)` expression. ([#7589](https://github.com/crystal-lang/crystal/pull/7589), thanks @malte-v)
 
 #### Macros
@@ -1607,7 +1607,7 @@
 
 #### Time
 
-- **(breaking-change)** Rename `Time` constructors. Deprecate `Time.now` to encourage usage  `Time.utc` or `Time.local` ([#5346](https://github.com/crystal-lang/crystal/pull/5346), [#7586](https://github.com/crystal-lang/crystal/pull/7586), thanks @straight-shoota)
+- **(breaking-change)** Rename `Time` constructors. Deprecate `Time.now` to encourage usage `Time.utc` or `Time.local` ([#5346](https://github.com/crystal-lang/crystal/pull/5346), [#7586](https://github.com/crystal-lang/crystal/pull/7586), thanks @straight-shoota)
 - **(breaking-change)** Rename `Time#add_span` to `Time#shift` for changing a time instance by calendar units and handle other units. ([#6598](https://github.com/crystal-lang/crystal/pull/6598), thanks @straight-shoota)
 - **(breaking-change)** Change `Time#date` to return a `Tuple` of `{year, month, day}`. Use `Time#at_beginning_of_day` if a `Time` instance is wanted. ([#5822](https://github.com/crystal-lang/crystal/pull/5822), thanks @straight-shoota)
 - Fix Windows monotonic time bug. ([#7377](https://github.com/crystal-lang/crystal/pull/7377), thanks @domgetter)
@@ -2909,7 +2909,7 @@
 
 - **(breaking change)** Removed `ifdef` from the language
 - **(breaking change)** Removed `PointerIO`
-- **(breaking change)** The `body` property of `HTTP::Request` is now an `IO?` (previously it was `String`). Use `request.body.try(&.gets_to_end)`  if you need the entire body as a String.
+- **(breaking change)** The `body` property of `HTTP::Request` is now an `IO?` (previously it was `String`). Use `request.body.try(&.gets_to_end)` if you need the entire body as a String.
 - **(breaking change)** `MemoryIO` has been renamed to `IO::Memory`. The old name can still be used but will produce a compile-time warning. `MemoryIO` will be removed immediately after 0.20.0.
 - **(breaking change)** `Char#digit?` was split into `Char#ascii_number?` and `Char#number?`. The old name is still available and will produce a compile-time warning, but will be removed immediately after 0.20.0.
 - **(breaking change)** `Char#alpha?` was split into `Char#ascii_letter?` and `Char#letter?`. The old name is still available and will produce a compile-time warning, but will be removed immediately after 0.20.0.
@@ -2939,7 +2939,7 @@
 - Optimized `Array#sort` by using introsort (thanks @c910335)
 - [Several bug fixes](https://github.com/crystal-lang/crystal/issues?q=is%3Aclosed+milestone%3A0.20.0)
 
-### 0.19.4  (2016-10-07)
+### 0.19.4 (2016-10-07)
 
 - Added support for OpenBSD (thanks @wmoxam and @ysbaddaden)
 - More iconv fixes for FreeBSD (thanks @ysbaddaden)
@@ -2950,7 +2950,7 @@
 - Added `Char#+(Int)` and `Char#-(Int)`
 - [A few bug fixes](https://github.com/crystal-lang/crystal/issues?q=is%3Aclosed+milestone%3A0.19.4)
 
-### 0.19.3  (2016-09-30)
+### 0.19.3 (2016-09-30)
 
 - `crystal eval` now accepts some flags like `--stats`, `--release` and `--help`
 - Added `File.chown` and `File.chmod` (thanks @ysbaddaden)
@@ -2958,7 +2958,7 @@
 - Added docs to `OAuth` and `OAuth2`
 - [Several bug fixes](https://github.com/crystal-lang/crystal/issues?q=is%3Aclosed+milestone%3A0.19.3)
 
-### 0.19.2  (2016-09-16)
+### 0.19.2 (2016-09-16)
 
 - Generic type variables no longer need to be single-letter names (for example `class Gen(Foo)` is now possible)
 - Added syntax to denote free variables: `def foo(x : T) forall T`. The old rule of single-letter name still applies but will be removed in the future.
@@ -2973,13 +2973,13 @@
 - Error messages no longer include a type trace by default, pass `--error-trace` to show the full trace (the trace is often useless and makes it harder to understand error messages)
 - [Several bug fixes](https://github.com/crystal-lang/crystal/issues?q=is%3Aclosed+milestone%3A0.19.2)
 
-### 0.19.1  (2016-09-09)
+### 0.19.1 (2016-09-09)
 
 - Types (class, module, etc.) can now be marked as `private`.
-- Added `WeakRef`  (thanks @bcardiff)
+- Added `WeakRef` (thanks @bcardiff)
 - [Several bug fixes](https://github.com/crystal-lang/crystal/issues?q=is%3Aclosed+milestone%3A0.19.1)
 
-### 0.19.0  (2016-09-02)
+### 0.19.0 (2016-09-02)
 
 - **(breaking change)** Added `select` keyword
 - **(breaking change)** Removed $global variables. Use @@class variables instead.
@@ -3106,7 +3106,7 @@
 - The output of the `debug()` macro method now tries to format the code (pass `false` to disable this)
 - Added `JSON` and `YAML` parsing and mapping for unions
 - Added `FileUtils.cp_r` (thanks @Dreauw)
-- Added `Tuple.from` and `NamedTuple.from`  (thanks @jhass)
+- Added `Tuple.from` and `NamedTuple.from` (thanks @jhass)
 - Added `XML.escape` (thanks @juanedi)
 - Added `HTTP::Server::Response#respond_with_error` (thanks @jhass)
 - Added `TCPServer#accept?`

--- a/doc/changelogs/pre-1.0.md
+++ b/doc/changelogs/pre-1.0.md
@@ -1632,7 +1632,6 @@
 - Add support for OAuth 2.0 resource owner password credentials grant type. ([#7424](https://github.com/crystal-lang/crystal/pull/7424), thanks @Blacksmoke16)
 - Add support for IIS date format in cookies. ([#7405](https://github.com/crystal-lang/crystal/pull/7405), thanks @Sija)
 - Allow calls to `IO::Syscall#wait_readable` and `IO::Syscall#wait_writable`. ([#7366](https://github.com/crystal-lang/crystal/pull/7366), thanks @stakach)
-
 - Fix spec of `HTTP::Client` to not write server response after timeout. ([#7402](https://github.com/crystal-lang/crystal/pull/7402), thanks @asterite)
 - Fix spec of `TCP::Server` for musl. ([#7484](https://github.com/crystal-lang/crystal/pull/7484), thanks @straight-shoota)
 
@@ -4079,7 +4078,6 @@
     ```
 
     In the previous example, `b = 2` (and the rest of the file) is considered as being parsed from file `bar.cr` at line 12, column 24.
-
 - Added a special `run` call inside macros. This compiles and executes another Crystal program and pastes its output into the current program.
 
     As an example, consider this program:

--- a/doc/changelogs/pre-1.0.md
+++ b/doc/changelogs/pre-1.0.md
@@ -4029,45 +4029,45 @@
 - The parser generates string literals out of strings with interpolated string literals. For example, `"#{__DIR__}/foo"` is interpolated at compile time and generates a string literal with the full path, since `__DIR__` is just a (special) string literal.
 - **(breaking change)** Now macro nodes are always pasted as is. If you want to generate an id use `{{var.id}}`.
 
-    Previously, a code like this:
+  Previously, a code like this:
 
-    ```ruby
-    macro foo(name)
-      def {{name}}; end
-    end
+  ```ruby
+  macro foo(name)
+    def {{name}}; end
+  end
 
-    foo :hello
-    foo "hello"
-    foo hello
-    ```
+  foo :hello
+  foo "hello"
+  foo hello
+  ```
 
-    generated this:
+  generated this:
 
-    ```ruby
-    def hello; end
-    def hello; end
-    def hello; end
-    ```
+  ```ruby
+  def hello; end
+  def hello; end
+  def hello; end
+  ```
 
-    With this change, it generates this:
+  With this change, it generates this:
 
-    ```ruby
-    def :hello; end
-    def "hello"; end
-    def hello; end
-    ```
+  ```ruby
+  def :hello; end
+  def "hello"; end
+  def hello; end
+  ```
 
-    Now, to get an identifier out of a symbol literal, string literal or a name, use id:
+  Now, to get an identifier out of a symbol literal, string literal or a name, use id:
 
-    ```ruby
-    macro foo(name)
-      def {{name.id}}; end
-    end
-    ```
+  ```ruby
+  macro foo(name)
+    def {{name.id}}; end
+  end
+  ```
 
-    Although it's longer to type, the implicit "id" call was sometimes confusing. Explicit is better than implicit.
+  Although it's longer to type, the implicit "id" call was sometimes confusing. Explicit is better than implicit.
 
-    Invoking `id` on any other kind of node has no effect on the pasted result.
+  Invoking `id` on any other kind of node has no effect on the pasted result.
 - Allow escaping curly braces inside macros with `\{`. This allows defining macros that, when expanded, can contain other macro expressions.
 - Added a special comment-like pragma to change the lexer's filename, line number and column number.
 

--- a/doc/changelogs/v1.1.md
+++ b/doc/changelogs/v1.1.md
@@ -64,14 +64,14 @@
 
 - Add type restriction to private `Process` constructor. ([#7040](https://github.com/crystal-lang/crystal/pull/7040), thanks @z64)
 - Add various return type restrictions (thanks @oprypin, @straight-shoota, and @caspiano):
-    [#10578](https://github.com/crystal-lang/crystal/pull/10578), [#10579](https://github.com/crystal-lang/crystal/pull/10579),
-    [#10580](https://github.com/crystal-lang/crystal/pull/10580), [#10581](https://github.com/crystal-lang/crystal/pull/10581),
-    [#10582](https://github.com/crystal-lang/crystal/pull/10582), [#10583](https://github.com/crystal-lang/crystal/pull/10583),
-    [#10584](https://github.com/crystal-lang/crystal/pull/10584), [#10585](https://github.com/crystal-lang/crystal/pull/10585),
-    [#10586](https://github.com/crystal-lang/crystal/pull/10586), [#10587](https://github.com/crystal-lang/crystal/pull/10587),
-    [#10588](https://github.com/crystal-lang/crystal/pull/10588), [#10849](https://github.com/crystal-lang/crystal/pull/10849),
-    [#10856](https://github.com/crystal-lang/crystal/pull/10856), [#10857](https://github.com/crystal-lang/crystal/pull/10857),
-    [#10858](https://github.com/crystal-lang/crystal/pull/10858), [#10905](https://github.com/crystal-lang/crystal/pull/10905)
+  [#10578](https://github.com/crystal-lang/crystal/pull/10578), [#10579](https://github.com/crystal-lang/crystal/pull/10579),
+  [#10580](https://github.com/crystal-lang/crystal/pull/10580), [#10581](https://github.com/crystal-lang/crystal/pull/10581),
+  [#10582](https://github.com/crystal-lang/crystal/pull/10582), [#10583](https://github.com/crystal-lang/crystal/pull/10583),
+  [#10584](https://github.com/crystal-lang/crystal/pull/10584), [#10585](https://github.com/crystal-lang/crystal/pull/10585),
+  [#10586](https://github.com/crystal-lang/crystal/pull/10586), [#10587](https://github.com/crystal-lang/crystal/pull/10587),
+  [#10588](https://github.com/crystal-lang/crystal/pull/10588), [#10849](https://github.com/crystal-lang/crystal/pull/10849),
+  [#10856](https://github.com/crystal-lang/crystal/pull/10856), [#10857](https://github.com/crystal-lang/crystal/pull/10857),
+  [#10858](https://github.com/crystal-lang/crystal/pull/10858), [#10905](https://github.com/crystal-lang/crystal/pull/10905)
 - Add type restrictions for splat-less overloads of some methods. ([#10594](https://github.com/crystal-lang/crystal/pull/10594), thanks @HertzDevil)
 
 #### Numeric

--- a/doc/changelogs/v1.13.md
+++ b/doc/changelogs/v1.13.md
@@ -280,7 +280,7 @@
 - _(codegen)_ Fix stats and progress issues in codegen ([#14763], thanks @ysbaddaden)
 - _(debugger)_ Fix LLDB `crystal_formatters.py` for Python 3 ([#14665], thanks @zw963)
 - _(parser)_ Disallow assignments to calls with parentheses ([#14527], thanks @HertzDevil)
-- _(parser)_ Fix parser validate UTF-8 on first input byte  ([#14750], thanks @straight-shoota)
+- _(parser)_ Fix parser validate UTF-8 on first input byte ([#14750], thanks @straight-shoota)
 - _(semantic)_ Fix type def reopening type from parent namespace ([#11208], thanks @straight-shoota)
 - _(semantic)_ Fix `Crystal::Path#to_macro_id` for global path ([#14490], thanks @straight-shoota)
 - _(semantic)_ Fix `Class#===` on metaclass ([#11162], thanks @makenowjust)

--- a/doc/changelogs/v1.16.md
+++ b/doc/changelogs/v1.16.md
@@ -8,7 +8,7 @@
 
 #### stdlib
 
-- _(runtime)_ Fix `Crystal::EventLoop::LibEvent` and `FiberExecutionContext`  integration ([#15759], backported from [#15743], thanks @ysbaddaden)
+- _(runtime)_ Fix `Crystal::EventLoop::LibEvent` and `FiberExecutionContext` integration ([#15759], backported from [#15743], thanks @ysbaddaden)
 
 [#15759]: https://github.com/crystal-lang/crystal/pull/15759
 [#15743]: https://github.com/crystal-lang/crystal/pull/15743
@@ -158,7 +158,7 @@
 - _(runtime)_ Add `EventLoop#wait_readable`, `#wait_writable` methods methods ([#15376], thanks @ysbaddaden)
 - _(runtime)_ Initialize `Fiber` with an explicit stack ([#15409], thanks @ysbaddaden)
 - _(runtime)_ Add fiber queues for execution context schedulers ([#15345], thanks @ysbaddaden)
-- _(runtime)_ RFC 2: Skeleton for ExecutionContext  ([#15350], [#15596], thanks @ysbaddaden)
+- _(runtime)_ RFC 2: Skeleton for ExecutionContext ([#15350], [#15596], thanks @ysbaddaden)
 - _(runtime)_ RFC 2: Add `Fiber::ExecutionContext::SingleThreaded` scheduler ([#15511], thanks @ysbaddaden)
 - _(runtime)_ RFC 2: Add `Fiber::ExecutionContext::Isolated` ([#15513], thanks @ysbaddaden)
 - _(runtime)_ RFC 2: Add `Fiber::ExecutionContext::Monitor` ([#15599], thanks @ysbaddaden)

--- a/doc/changelogs/v1.18.md
+++ b/doc/changelogs/v1.18.md
@@ -200,7 +200,7 @@
 - _(parser)_ Fix parsing `ReadInstanceVar` in short block syntax ([#16099], thanks @nobodywasishere)
 - _(semantic)_ Pass through variable types unchanged in a while loop ([#15980], thanks @HertzDevil)
 - _(semantic)_ deprecation warning for (expanded) deprecated def ([#15997], thanks @ysbaddaden)
-- _(semantic)_ Copy annotations in  `Crystal::Arg#copy_without_location` ([#16008], thanks @ysbaddaden)
+- _(semantic)_ Copy annotations in `Crystal::Arg#copy_without_location` ([#16008], thanks @ysbaddaden)
 - _(semantic)_ Copy annotations in `Crystal::Def#expand_default_arguments` ([#16007], thanks @ysbaddaden)
 - _(semantic)_ Copy annotations in `Crystal::Def#expand_new_default_arguments` ([#16013], thanks @ysbaddaden)
 - _(semantic)_ Fix error message for `StaticArray` with non-integer generic argument `N` ([#16037], thanks @straight-shoota)

--- a/doc/changelogs/v1.2.md
+++ b/doc/changelogs/v1.2.md
@@ -257,7 +257,7 @@
 - [CI] Remove obsolete `package_build` workflow ([#11240](https://github.com/crystal-lang/crystal/pull/11240), thanks @straight-shoota)
 - [CI] Add build matrix with 1.0.0 and 1.1.1 ([#11278](https://github.com/crystal-lang/crystal/pull/11278), thanks @straight-shoota)
 - [CI] Update aarch64.yml ([#11160](https://github.com/crystal-lang/crystal/pull/11160), thanks @beta-ziliani)
-- [CI] Update distribution-scripts (universal darwin & demote alpine to 3.12)  ([#11228](https://github.com/crystal-lang/crystal/pull/11228), thanks @bcardiff)
+- [CI] Update distribution-scripts (universal darwin & demote alpine to 3.12) ([#11228](https://github.com/crystal-lang/crystal/pull/11228), thanks @bcardiff)
 - Update shards 0.16.0 ([#11292](https://github.com/crystal-lang/crystal/pull/11292), thanks @straight-shoota)
 - Update previous release Crystal 1.1.0 ([#10955](https://github.com/crystal-lang/crystal/pull/10955), thanks @straight-shoota)
 - Merge changelog entry for 1.1.1 ([#11028](https://github.com/crystal-lang/crystal/pull/11028), thanks @straight-shoota)

--- a/doc/changelogs/v1.3.md
+++ b/doc/changelogs/v1.3.md
@@ -100,7 +100,7 @@
 - Allow metaclass parameters in `Proc` literals and pointers ([#11367](https://github.com/crystal-lang/crystal/pull/11367), thanks @HertzDevil)
 - Fix top-level multi-assign splat variable not working in macros ([#11600](https://github.com/crystal-lang/crystal/pull/11600), thanks @HertzDevil)
 - Replace `semantic` with `assert_no_errors` in compiler specs whenever possible ([#11288](https://github.com/crystal-lang/crystal/pull/11288), thanks @HertzDevil)
-- Make `inject_primitives = false` default for semantic specs  ([#11297](https://github.com/crystal-lang/crystal/pull/11297), thanks @HertzDevil)
+- Make `inject_primitives = false` default for semantic specs ([#11297](https://github.com/crystal-lang/crystal/pull/11297), thanks @HertzDevil)
 - Add spec for #8428 ([#10073](https://github.com/crystal-lang/crystal/pull/10073), thanks @docelic)
 - Remove and resolve spurious cast and its associated FIXME ([#11455](https://github.com/crystal-lang/crystal/pull/11455), thanks @rymiel)
 - Add pending spec for recursive abstract struct ([#11470](https://github.com/crystal-lang/crystal/pull/11470), thanks @HertzDevil)

--- a/doc/changelogs/v1.4.md
+++ b/doc/changelogs/v1.4.md
@@ -158,7 +158,7 @@
 - Remove useless assignments II ([#11843](https://github.com/crystal-lang/crystal/pull/11843), thanks @IgorPolyakov)
 - Limit the number of rendered overloads on signature mismatch ([#10890](https://github.com/crystal-lang/crystal/pull/10890), thanks @caspiano)
 - Support "can't infer type parameter" error for uninstantiated generic modules ([#11904](https://github.com/crystal-lang/crystal/pull/11904), thanks @HertzDevil)
-- Fix: Accept only option flags in `CRYSTAL_OPTS` for build commands ([#11922](https://github.com/crystal-lang/crystal/pull/11922), thanks  @HertzDevil, @beta-ziliani)
+- Fix: Accept only option flags in `CRYSTAL_OPTS` for build commands ([#11922](https://github.com/crystal-lang/crystal/pull/11922), thanks @HertzDevil, @beta-ziliani)
 - Evaluate `LibLLVM::IS_LT_*` during macro expansion time ([#11913](https://github.com/crystal-lang/crystal/pull/11913), thanks @HertzDevil)
 - Fix incorrect var type inside nested exception handler ([#11928](https://github.com/crystal-lang/crystal/pull/11928), thanks @asterite)
 - Fix: Look up return type in defining type ([#11962](https://github.com/crystal-lang/crystal/pull/11962), thanks @asterite)

--- a/doc/changelogs/v1.5.md
+++ b/doc/changelogs/v1.5.md
@@ -77,7 +77,7 @@
 - Windows: Always use `GC_set_stackbottom` on Windows ([#12186](https://github.com/crystal-lang/crystal/pull/12186), thanks @HertzDevil)
 - Windows: Event loop based on IOCP ([#12149](https://github.com/crystal-lang/crystal/pull/12149), thanks @straight-shoota, @wonderix, @yxhuvud, @HertzDevil)
 - Use enum instead of symbol for `Atomic` primitives ([#11583](https://github.com/crystal-lang/crystal/pull/11583), thanks @HertzDevil)
-- Allow `Enumerable(Channel)` parameter for  `Channel.send_first`, `.receive_first` ([#12101](https://github.com/crystal-lang/crystal/pull/12101), thanks @carlhoerberg)
+- Allow `Enumerable(Channel)` parameter for `Channel.send_first`, `.receive_first` ([#12101](https://github.com/crystal-lang/crystal/pull/12101), thanks @carlhoerberg)
 
 #### Crypto
 

--- a/doc/changelogs/v1.7.md
+++ b/doc/changelogs/v1.7.md
@@ -207,7 +207,7 @@
 #### Interpreter
 
 - Interpreter: fix class var initializer that needs an upcast ([#12635](https://github.com/crystal-lang/crystal/pull/12635), thanks @asterite)
-- Reverting #12405 Compiler: don't always use Array for node dependencies and observers  ([#12849](https://github.com/crystal-lang/crystal/pull/12849), thanks @beta-ziliani)
+- Reverting #12405 Compiler: don't always use Array for node dependencies and observers ([#12849](https://github.com/crystal-lang/crystal/pull/12849), thanks @beta-ziliani)
 - Match Nix loader errors in compiler spec ([#12852](https://github.com/crystal-lang/crystal/pull/12852), thanks @bcardiff)
 - Interpreter reply ([#12738](https://github.com/crystal-lang/crystal/pull/12738), thanks @I3oris)
 
@@ -243,7 +243,7 @@
 
 #### Docs-generator
 
-- Fix range literals causing method lookups in docs generator  ([#12680](https://github.com/crystal-lang/crystal/pull/12680), thanks @caspiano)
+- Fix range literals causing method lookups in docs generator ([#12680](https://github.com/crystal-lang/crystal/pull/12680), thanks @caspiano)
 - Fix method lookup for single char class names ([#12683](https://github.com/crystal-lang/crystal/pull/12683), thanks @caspiano)
 
 #### Formatter

--- a/doc/changelogs/v1.8.md
+++ b/doc/changelogs/v1.8.md
@@ -268,7 +268,7 @@
 - Update GH Actions ([#13075](https://github.com/crystal-lang/crystal/pull/13075), [#13132](https://github.com/crystal-lang/crystal/pull/13132), thanks @renovate)
 - CI: Enable testing with `libpcre2` on wasm32 ([#13109](https://github.com/crystal-lang/crystal/pull/13109), thanks @lbguilherme)
 - Build the compiler with PCRE2 ([#13084](https://github.com/crystal-lang/crystal/pull/13084), [#13133](https://github.com/crystal-lang/crystal/pull/13133), thanks @straight-shoota)
-- Prefer matching `llvm-config` in  `find-llvm-config` ([#13087](https://github.com/crystal-lang/crystal/pull/13087), thanks @straight-shoota)
+- Prefer matching `llvm-config` in `find-llvm-config` ([#13087](https://github.com/crystal-lang/crystal/pull/13087), thanks @straight-shoota)
 - **(performance)** Run compiler specs in release mode ([#13122](https://github.com/crystal-lang/crystal/pull/13122), thanks @straight-shoota)
 - [CI] Increase `no_output_timeout` on circleci ([#13151](https://github.com/crystal-lang/crystal/pull/13151), thanks @straight-shoota)
 - Update NOTICE.md ([#13159](https://github.com/crystal-lang/crystal/pull/13159), thanks @HertzDevil)


### PR DESCRIPTION
[rumdl](https://rumdl.dev/) is a Markdown linter similar to [markdownlint](https://github.com/igorshubovych/markdownlint-cli) but with some significant improvements.
It is compatible with markdownlint, supporting the same rules and configuration as before. It's a drop-in replacement with more performance (Rust vs Javascript).
And it brings a bunch of additional rules and features, such as per-file-ignores.
See https://rumdl.dev/markdownlint-comparison/ for a full comparison.


We already applied the same change in https://github.com/crystal-lang/crystal-website/pull/1082