### PR TITLE
Fix: underperforming unlock conditions in `Sync::MU`

### DIFF
--- a/src/sync/mu.cr
+++ b/src/sync/mu.cr
@@ -194,7 +194,7 @@ module Sync
         raise RuntimeError.new("Can't unlock Sync::MU that isn't held")
       end
 
-      if (word & WAITING) == 0 && (word & DESIGNATED_WAKER) != 0
+      if (word & WAITING) == 0 || (word & DESIGNATED_WAKER) != 0
         # no waiters, or there is a designated waker already (no need to wake
         # another one), try quick unlock
         _, success = @word.compare_and_set(word, word &- WLOCK, :release, :relaxed)
@@ -215,9 +215,9 @@ module Sync
         raise RuntimeError.new("Can't runlock Sync::MU that isn't held")
       end
 
-      if (word & WAITING) == 0 && (word & DESIGNATED_WAKER) != 0 && (word & RMASK) > RLOCK
+      if (word & WAITING) == 0 || (word & DESIGNATED_WAKER) != 0 || (word & RMASK) > RLOCK
         # no waiters, there is a designated waker already (no need to wake
-        # another one), and there are still readers, try quick unlock
+        # another one), or there are still readers, try quick unlock
         _, success = @word.compare_and_set(word, word &- RLOCK, :release, :relaxed)
         return if success
       end


### PR DESCRIPTION
As outlined in https://github.com/crystal-lang/crystal/pull/17063#issuecomment-4685448325 by @stevegeek: the quick-path (between the uncontended fast-path and the slow-path) for unlocking was using an *and* when it should have been using an *or* in the conditions (just like in the slow-path).

Running benchmarks, it seems to have a slight impact in some cases (far more threads than CPU cores + enough contention), but given that the slow path has the correct conditions, the impact is low.