### PR TITLE
Revert "Fix: cross-compile crashes when combined with emit llvm-bc or obj (#17060)"

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -441,13 +441,15 @@ module Crystal
 
     private def cross_compile(program, units, output_filename)
       unit = units.first
-      emit_targets = @emit_targets | EmitTarget::OBJ
+      llvm_mod = unit.llvm_mod
 
       @progress_tracker.stage("Codegen (bc+obj)") do
-        sequential_codegen(units)
-        unit.emit(emit_targets, emit_base_filename || output_filename)
-      end
+        optimize llvm_mod, target_machine unless @optimization_mode.o0?
 
+        unit.emit(@emit_targets, emit_base_filename || output_filename)
+
+        target_machine.emit_obj_to_file llvm_mod, output_filename
+      end
       object_names = [output_filename]
       output_filename = output_filename.rchop(unit.object_extension)
       _, command, args = linker_command(program, object_names, output_filename, nil)


### PR DESCRIPTION
This reverts commit f38c6d949faaab055cf9bf2ee176b7acaac2d91c.

It causes some yet unidentified codegen failure: #17077