### PR TITLE
Include exit code in `Process::Status#description`

### DIFF
--- a/spec/std/process/status_spec.cr
+++ b/spec/std/process/status_spec.cr
@@ -332,8 +332,9 @@ describe Process::Status do
 
   describe "#description" do
     it "with exit status" do
-      Process::Status[0].description.should eq "Process exited normally"
-      Process::Status[255].description.should eq "Process exited normally"
+      Process::Status[0].description.should eq "Process exited with status 0"
+      Process::Status[1].description.should eq "Process exited with status 1"
+      Process::Status[255].description.should eq "Process exited with status 255"
     end
 
     it "on interrupt" do

--- a/src/process/capture.cr
+++ b/src/process/capture.cr
@@ -5,12 +5,7 @@ class Process
     getter result : Result
 
     def initialize(@args : Enumerable(String), @result : Result)
-      description = if code = result.status.exit_code?
-                      "Process exited with status #{code}"
-                    else
-                      result.status.description
-                    end
-      super("Command #{args.inspect} failed: #{description}")
+      super("Command #{args.inspect} failed: #{result.status.description}")
     end
   end
 

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -434,15 +434,20 @@ class Process::Status
   # Returns a textual description of this process status.
   #
   # ```
-  # Process.run("true").description # => "Process exited normally"
+  # Process.run("true").description  # => "Process exited with status 0"
+  # Process.run("false").description # => "Process exited with status 1"
   # process = Process.new("sleep", ["10"])
   # process.terminate
   # process.wait.description # => "Process received and didn't handle signal TERM (15)"
   # ```
   #
-  # `ExitReason#description` provides the specific messages for non-signal exits.
+  # `ExitReason#description` provides the specific messages for abnormal exits.
   def description : String
-    if exit_reason.signal? && (signal = exit_signal?)
+    if code = exit_code?
+      "Process exited with status #{code}"
+    elsif exit_reason.signal? && (signal = exit_signal?)
+      # `ExitReason::Signal` represents signals that are not covered by more
+      # specific exit reasons, so we explicitly mention the signal.
       "Process received and didn't handle signal #{signal}"
     else
       exit_reason.description


### PR DESCRIPTION
Previously, for normal exits, the description would only state that the process exited normally.
This match makes the most important information, the exit code, visible.
