### PR TITLE
Fix: `fdlock#try_close?` must release ref after yielding to the block

### DIFF
--- a/src/crystal/fd_lock.cr
+++ b/src/crystal/fd_lock.cr
@@ -249,12 +249,12 @@ struct Crystal::FdLock
     @readers.consume_each(&.value.enqueue)
     @writers.consume_each(&.value.enqueue)
 
-    # decrement the last ref
-    m = @m.sub(REF, :release)
-
     begin
       yield
     ensure
+      # decrement the last ref
+      m = @m.sub(REF, :release)
+
       # wait for the last ref... unless we're the last ref!
       Fiber.suspend unless (m & MASK) == REF
     end


### PR DESCRIPTION
Otherwise we risk a double enqueue. This was made visible by the io_uring evloop where shutdown now yields the calling fiber, while other event loops block.

Fixes this error on CI:
https://github.com/crystal-lang/crystal/actions/runs/27864964688/job/82467377851?pr=17079