### PR TITLE
Refactor: simplify `Crystal::Scheduler`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -67,13 +67,11 @@ jobs:
           - x86_64
           - aarch64
         opts:
-          - flags: "-Dexecution_context -Dpreview_mt" # execution_context: concurrent
-            workers: 1
-          - flags: "-Dexecution_context -Dpreview_mt" # execution_context: parallel
+          - flags: "-Dwithout_mt"
+          - flags: "" # execution_context: parallel
             workers: 4
+          - flags: "-Devloop=io_uring -Dwithout_mt"
           - flags: "-Devloop=io_uring"
-            workers: 1
-          - flags: "-Dexecution_context -Dpreview_mt -Devloop=io_uring"
             workers: 4
         include:
           - arch: x86_64

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -60,9 +60,9 @@ jobs:
       fail-fast: false
       matrix:
         opts:
-          - flags: "-Dexecution_context -Dpreview_mt" # execution_context: concurrent
+          - flags: "-Dwithout_mt" # execution_context: disable
             workers: 1
-          - flags: "-Dexecution_context -Dpreview_mt" # execution_context: parallel
+          - flags: "" # execution_context: parallel
             workers: 4
     steps:
       - name: Download Crystal source

--- a/.github/workflows/wasm32.yml
+++ b/.github/workflows/wasm32.yml
@@ -45,7 +45,7 @@ jobs:
           rm wasm32-wasi-libs.tar.gz
 
       - name: Build spec/wasm32_std_spec.cr
-        run: bin/crystal build spec/wasm32_std_spec.cr -o wasm32_std_spec.wasm --target wasm32-wasi -Dwithout_iconv -Dwithout_openssl
+        run: bin/crystal build spec/wasm32_std_spec.cr -o wasm32_std_spec.wasm --target wasm32-wasi -Dwithout_iconv -Dwithout_openssl -Dwithout_mt
         env:
           CRYSTAL_LIBRARY_PATH: ${{ github.workspace }}/wasm32-wasi-libs
 

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -271,9 +271,9 @@ jobs:
       fail-fast: false
       matrix:
         opts:
-          - flags: "-Dexecution_context -Dpreview_mt" # execution_context: concurrent
+          - flags: "-Dwithout_mt" # execution_context: disable
             workers: 1
-          - flags: "-Dexecution_context -Dpreview_mt" # execution_context: parallel
+          - flags: "" # execution_context: parallel
             workers: 4
     steps:
       - name: Disable CRLF line ending substitution

--- a/Makefile
+++ b/Makefile
@@ -37,14 +37,14 @@ check              ?= ## Enable only check when running format
 order              ?= random## Enable order for spec execution (values: "default" | "random" | seed number)
 deref_symlinks     ?= ## Dereference symbolic links for `make install`
 docs_sanitizer     ?= ## Enable sanitization for documentation generation
-sequential_codegen ?= $(if $(filter 0,$(supports_preview_mt)),true,)## Enforce sequential codegen in compiler builds. Base compiler before Crystal 1.8 cannot build with `-Dpreview_mt -Dexecution_context`
+sequential_codegen ?= $(if $(filter 0,$(supports_mt)),true,)## Enforce sequential codegen in compiler builds. Base compiler before Crystal 1.8 doesn't support MT
 
 O            := .build
 SOURCES      := $(shell find src -name '*.cr')
 SPEC_SOURCES := $(shell find spec -name '*.cr')
 MAN1PAGES    := $(patsubst doc/man/%.adoc,man/%.1,$(wildcard doc/man/*.adoc))
 override FLAGS += -D strict_multi_assign -D preview_overload_order $(if $(release),--release )$(if $(stats),--stats )$(if $(progress),--progress )$(if $(threads),--threads $(threads) )$(if $(debug),-d )$(if $(static),--static )$(if $(LDFLAGS),--link-flags="$(LDFLAGS)" )$(if $(target),--cross-compile --target $(target) )
-override COMPILER_FLAGS += $(if $(interpreter),,-Dwithout_interpreter )$(if $(docs_sanitizer),,-Dwithout_libxml2 ) -Dwithout_openssl -Dwithout_zlib$(if $(sequential_codegen),, -Dpreview_mt -Dexecution_context )
+override COMPILER_FLAGS += $(if $(interpreter),,-Dwithout_interpreter )$(if $(docs_sanitizer),,-Dwithout_libxml2 ) -Dwithout_openssl -Dwithout_zlib$(if $(sequential_codegen), -Dwithout_mt,)
 SPEC_WARNINGS_OFF := --exclude-warnings spec/std --exclude-warnings spec/compiler --exclude-warnings spec/primitives --exclude-warnings src/float/printer --exclude-warnings src/random.cr
 override SPEC_FLAGS += $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )$(if $(order),--order=$(order) )
 CRYSTAL_CONFIG_LIBRARY_PATH := '$$ORIGIN/../lib/crystal'
@@ -81,8 +81,8 @@ ifeq ($(LLVM_VERSION),)
 	LLVM_VERSION := $(if $(LLVM_CONFIG),$(shell "$(LLVM_CONFIG)" --version 2> /dev/null))
 endif
 
-# Crystal versions before 1.8 cannot build a functional compiler with `-Dpreview_mt` (https://github.com/crystal-lang/crystal/pull/16380)
-supports_preview_mt := $(if $(filter 1.8.0,$(shell printf "%s\n%s" "1.8.0" "$(BASE_CRYSTAL_VERSION)" | sort -V | tail -n1)),0,1)
+# Crystal versions before 1.8 cannot build a functional compiler with MT (https://github.com/crystal-lang/crystal/pull/16380)
+supports_mt := $(if $(filter 1.8.0,$(shell printf "%s\n%s" "1.8.0" "$(BASE_CRYSTAL_VERSION)" | sort -V | tail -n1)),0,1)
 
 LLVM_EXT_DIR = src/llvm/ext
 LLVM_EXT_OBJ = $(LLVM_EXT_DIR)/llvm_ext.o

--- a/Makefile.win
+++ b/Makefile.win
@@ -36,7 +36,7 @@ interpreter        ?= ## Enable interpreter feature
 check              ?= ## Enable only check when running format
 order              ?= random## Enable order for spec execution (values: "default" | "random" | seed number)
 docs_sanitizer     ?= ## Enable sanitization for documentation generation
-sequential_codegen ?= ## Enforce sequential codegen in compiler builds. Base compiler before Crystal 1.8 cannot build with `-Dpreview_mt`
+sequential_codegen ?= ## Enforce sequential codegen in compiler builds. Base compiler before Crystal 1.8 doesn't support MT
 
 MAKEFLAGS += --no-builtin-rules
 .SUFFIXES:
@@ -59,7 +59,7 @@ O            := .build
 SOURCES      := $(call GLOB,src\\*.cr)
 SPEC_SOURCES := $(call GLOB,spec\\*.cr)
 override FLAGS += -D strict_multi_assign -D preview_overload_order $(if $(release),--release )$(if $(stats),--stats )$(if $(progress),--progress )$(if $(threads),--threads $(threads) )$(if $(debug),-d )$(if $(static),--static )$(if $(LDFLAGS),--link-flags="$(LDFLAGS)" )$(if $(target),--cross-compile --target $(target) )
-override COMPILER_FLAGS += $(if $(interpreter),,-Dwithout_interpreter )$(if $(docs_sanitizer),,-Dwithout_libxml2 ) -Dwithout_openssl -Dwithout_zlib$(if $(sequential_codegen),, -Dpreview_mt -Dexecution_context )
+override COMPILER_FLAGS += $(if $(interpreter),,-Dwithout_interpreter )$(if $(docs_sanitizer),,-Dwithout_libxml2 ) -Dwithout_openssl -Dwithout_zlib$(if $(sequential_codegen), -Dwithout_mt,)
 SPEC_WARNINGS_OFF           := --exclude-warnings spec\std --exclude-warnings spec\compiler --exclude-warnings spec\primitives --exclude-warnings src\float\printer
 SPEC_FLAGS                  := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )$(if $(order),--order=$(order) )
 CRYSTAL_CONFIG_LIBRARY_PATH := $$ORIGIN\lib

--- a/spec/std/fiber/execution_context/parallel_spec.cr
+++ b/spec/std/fiber/execution_context/parallel_spec.cr
@@ -1,4 +1,4 @@
-{% skip_file unless flag?(:execution_context) %}
+{% skip_file if flag?(:without_mt) %}
 require "spec"
 require "wait_group"
 

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -59,7 +59,7 @@ describe "File" do
       wbuf = Bytes.new(5120)
       Random::Secure.random_bytes(wbuf)
 
-      {% if flag?(:execution_context) %}
+      {% if !flag?(:without_mt) %}
         WaitGroup.wait do |wg|
           # one fiber may block on open(2) (depends on the event loop) but the
           # monitor thread will notice and move the scheduler to another thread,

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -59,11 +59,13 @@ describe "File" do
       wbuf = Bytes.new(5120)
       Random::Secure.random_bytes(wbuf)
 
-      {% if !flag?(:without_mt) %}
+      {% if !flag?(:without_mt) || flag?(:"evloop=io_uring") %}
         WaitGroup.wait do |wg|
-          # one fiber may block on open(2) (depends on the event loop) but the
-          # monitor thread will notice and move the scheduler to another thread,
-          # unblocking the other fiber
+          # MT: one fiber may block on open(2) (depends on the event loop) but
+          # the monitor thread will notice and move the scheduler to another
+          # thread, unblocking the other fiber.
+          #
+          # io_uring: open is always async (never blocks).
           wg.spawn(name: "fifo:write") do
             File.open(path, "w") do |writer|
               64.times { |i| writer.write(wbuf) }

--- a/spec/std/http/spec_helper.cr
+++ b/spec/std/http/spec_helper.cr
@@ -46,7 +46,7 @@ def run_server(server, &)
     wait_for { server.listening? }
     wait_until_blocked f
 
-    {% if flag?(:preview_mt) %}
+    {% unless flag?(:without_mt) %}
       # avoids fiber synchronization issues in specs, like closing the server
       # before we properly listen, ...
       sleep 1.millisecond
@@ -85,7 +85,7 @@ def run_handler(handler, &)
     ensure
       processor.close
 
-      {% if flag?(:execution_context) && Crystal::EventLoop.has_constant?(:IoUring) %}
+      {% if !flag?(:without_mt) && Crystal::EventLoop.has_constant?(:IoUring) %}
         # FIXME: flaky workaround to avoid OAuth2::Client specs to fail:
         #
         # Error while flushing data to the client (HTTP::Server::ClientError)

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -1169,7 +1169,7 @@ describe Process do
     end
   {% end %}
 
-  {% unless flag?(:preview_mt) || flag?(:win32) %}
+  {% if flag?(:without_mt) && !flag?(:win32) %}
     describe ".fork" do
       it "executes the new process with exec" do
         with_tempfile("crystal-spec-exec") do |path|

--- a/spec/std/spec_helper.cr
+++ b/spec/std/spec_helper.cr
@@ -43,7 +43,7 @@ def spawn_and_check(before : Proc(_), file = __FILE__, line = __LINE__, &block :
 
     # This is a workaround to ensure the "before" fiber
     # is unscheduled. Otherwise it might stay alive running the event loop
-    spawn(same_thread: !{{flag?(:execution_context)}}) do
+    spawn do
       while x.get != 2
         Fiber.yield
       end

--- a/spec/std/sync/exclusive_spec.cr
+++ b/spec/std/sync/exclusive_spec.cr
@@ -113,7 +113,7 @@ describe Sync::Exclusive do
     counter.get(:relaxed).should be > 0
   end
 
-  {% if flag?(:execution_context) %}
+  {% unless flag?(:without_mt) %}
     # see https://github.com/crystal-lang/crystal/issues/15085
     it "synchronizes reads/writes of mixed unions" do
       ready = WaitGroup.new(1)

--- a/spec/std/sync/shared_spec.cr
+++ b/spec/std/sync/shared_spec.cr
@@ -121,7 +121,7 @@ describe Sync::Shared do
     counter.get(:relaxed).should be > 0
   end
 
-  {% if flag?(:execution_context) %}
+  {% unless flag?(:without_mt) %}
     # see https://github.com/crystal-lang/crystal/issues/15085
     it "synchronizes reads/writes of mixed unions" do
       ready = WaitGroup.new(1)

--- a/spec/std/sync/spec_helper.cr
+++ b/spec/std/sync/spec_helper.cr
@@ -44,7 +44,7 @@ module Sync
   end
 
   CONCURRENT =
-    {% if flag?(:execution_context) %}
+    {% if !flag?(:without_mt) %}
       ctx = Fiber::ExecutionContext.current
       if ctx.is_a?(Fiber::ExecutionContext::Parallel) && ctx.capacity > 1
         ctx = Fiber::ExecutionContext::Concurrent.new("CONCURRENT")

--- a/spec/std/thread_spec.cr
+++ b/spec/std/thread_spec.cr
@@ -45,7 +45,7 @@ pending_interpreted describe: Thread do
   end
 
   it "names the thread" do
-    {% if flag?(:execution_context) %}
+    {% if !flag?(:without_mt) %}
       Thread.current.name.should match(/DEFAULT-\d+/)
     {% else %}
       Thread.current.name.should be_nil

--- a/spec/support/mt_abort_timeout.cr
+++ b/spec/support/mt_abort_timeout.cr
@@ -1,11 +1,11 @@
-{% skip_file unless flag?(:preview_mt) %}
+{% skip_file if flag?(:without_mt) %}
 
 private SPEC_TIMEOUT = 15.seconds
 
 Spec.around_each do |example|
   done = Channel(Exception?).new
 
-  spawn(same_thread: !{{flag?(:execution_context)}}) do
+  spawn do
     example.run
   rescue e
     done.send(e)

--- a/spec/support/thread.cr
+++ b/spec/support/thread.cr
@@ -1,6 +1,6 @@
 {% begin %}
   def new_thread(name = nil, &block)
-    {% if flag?(:execution_context) %}
+    {% if !flag?(:without_mt) %}
       Fiber::ExecutionContext::Isolated.new(name: name || "SPEC") { block.call }
     {% else %}
       Thread.new(name) { block.call }

--- a/src/compiler/crystal.cr
+++ b/src/compiler/crystal.cr
@@ -8,7 +8,7 @@ require "./requires"
 
 Log.setup_from_env(default_level: :warn, default_sources: "crystal.*")
 
-{% if flag?(:execution_context) %}
+{% unless flag?(:without_mt) %}
   Fiber::ExecutionContext.default.resize(Fiber::ExecutionContext.default_workers_count)
 {% end %}
 

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -5,7 +5,7 @@ require "crystal/digest/md5"
 {% if flag?(:msvc) %}
   require "./loader"
 {% end %}
-{% if flag?(:preview_mt) %}
+{% unless flag?(:without_mt) %}
   require "wait_group"
 {% end %}
 
@@ -97,10 +97,8 @@ module Crystal
     property? no_codegen = false
 
     # Maximum number of LLVM modules that are compiled in parallel
-    property n_threads : Int32 = {% if flag?(:execution_context) %}
+    property n_threads : Int32 = {% if !flag?(:without_mt) %}
       Fiber::ExecutionContext.default_workers_count
-    {% elsif flag?(:preview_mt) %}
-      ENV["CRYSTAL_WORKERS"]?.try(&.to_i?) || 4
     {% elsif flag?(:win32) %}
       1
     {% else %}
@@ -635,7 +633,7 @@ module Crystal
     end
 
     private def parallel_codegen(units, n_threads)
-      {% if flag?(:preview_mt) %}
+      {% if !flag?(:without_mt) %}
         raise "LLVM isn't multithreaded and cannot fork compiler in multithread mode." unless LLVM.multithreaded?
         mt_codegen(units, n_threads)
       {% elsif LibC.has_method?("fork") %}

--- a/src/compiler/crystal/interpreter/context.cr
+++ b/src/compiler/crystal/interpreter/context.cr
@@ -67,6 +67,9 @@ class Crystal::Repl::Context
   def initialize(@program : Program)
     @program.flags << "interpreted"
 
+    # TODO: interpreter should be capable to start threads (eventually)
+    @program.flags << "without_mt"
+
     @gc_references = [] of Void*
 
     @defs = {} of Def => CompiledDef

--- a/src/concurrent.cr
+++ b/src/concurrent.cr
@@ -2,7 +2,7 @@ require "fiber"
 require "channel"
 require "crystal/tracing"
 
-{% if flag?(:execution_context) %}
+{% if !flag?(:without_mt) %}
   require "fiber/execution_context"
 {% else %}
   require "crystal/scheduler"
@@ -73,12 +73,12 @@ end
 # wg.wait
 # ```
 def spawn(*, name : String? = nil, same_thread = false, &block)
-  {% if flag?(:execution_context) %}
+  {% if !flag?(:without_mt) %}
     Fiber::ExecutionContext::Scheduler.current.spawn(name: name, same_thread: same_thread, &block)
   {% else %}
     fiber = Fiber.new(name, &block)
     Crystal.trace :sched, "spawn", fiber: fiber
-    {% if flag?(:preview_mt) %} fiber.set_current_thread if same_thread {% end %}
+    {% unless flag?(:without_mt) %} fiber.set_current_thread if same_thread {% end %}
     fiber.enqueue
     fiber
   {% end %}

--- a/src/crystal/event_loop.cr
+++ b/src/crystal/event_loop.cr
@@ -46,7 +46,7 @@ abstract class Crystal::EventLoop
 
   @[AlwaysInline]
   def self.current : self
-    {% if flag?(:execution_context) %}
+    {% if !flag?(:without_mt) %}
       Fiber::ExecutionContext.current.event_loop
     {% else %}
       Crystal::Scheduler.event_loop
@@ -55,7 +55,7 @@ abstract class Crystal::EventLoop
 
   @[AlwaysInline]
   def self.current? : self | Nil
-    {% if flag?(:execution_context) %}
+    {% if !flag?(:without_mt) %}
       Fiber::ExecutionContext.current?.try(&.event_loop)
     {% else %}
       Crystal::Scheduler.event_loop?
@@ -73,7 +73,7 @@ abstract class Crystal::EventLoop
   # events.
   abstract def run(blocking : Bool) : Bool
 
-  {% if flag?(:execution_context) %}
+  {% unless flag?(:without_mt) %}
     # Same as `#run` but collects runnable fibers into *queue* instead of
     # enqueueing in parallel, so the caller is responsible and in control for
     # when and how the fibers will be enqueued.

--- a/src/crystal/event_loop/epoll.cr
+++ b/src/crystal/event_loop/epoll.cr
@@ -19,7 +19,7 @@ class Crystal::EventLoop::Epoll < Crystal::EventLoop::Polling
     @epoll.add(@timerfd.fd, LibC::EPOLLIN, u64: @timerfd.fd.to_u64!)
   end
 
-  {% unless flag?(:preview_mt) %}
+  {% if flag?(:without_mt) %}
     def after_fork : Nil
       super
 

--- a/src/crystal/event_loop/io_uring.cr
+++ b/src/crystal/event_loop/io_uring.cr
@@ -54,7 +54,7 @@ require "c/sys/socket"
 require "./io_uring/*"
 require "./timers"
 
-{% if flag?(:execution_context) %}
+{% unless flag?(:without_mt) %}
   # Each scheduler has its own ring, so we can avoid mutexes around the
   # submission queue for example (Linux 6.13+) and otherwise try to make sure
   # the lock is only slightly contented.
@@ -84,7 +84,7 @@ require "./timers"
   end
 {% end %}
 
-{% if flag?(:preview_mt) %}
+{% unless flag?(:without_mt) %}
   # We must cancel pending R/W operations before we close the fd:
   #
   # 1. Closing a fd doesn't interrupt pending reads and writes in the linux
@@ -195,7 +195,7 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
   @main_ring : Ring
   @tick = Atomic(UInt32).new(0_u32)
 
-  {% if flag?(:execution_context) %}
+  {% unless flag?(:without_mt) %}
     # compiler can't type the ivar and fails to notice that it's always
     # initialized properly because of the compile time flag
     @rings = uninitialized Array(Ring?)
@@ -205,7 +205,7 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
     @main_ring = self.class.create_ring
     @timers = Timers(Event).new
 
-    {% if flag?(:execution_context) %}
+    {% unless flag?(:without_mt) %}
       @rings = Array(Ring?).new(parallelism) { nil }
       @rings[0] = @main_ring
     {% end %}
@@ -214,13 +214,13 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
     @mutex = Thread::Mutex.new
   end
 
-  {% unless flag?(:preview_mt) %}
+  {% if flag?(:without_mt) %}
     def after_fork : Nil
     end
   {% end %}
 
   private def ring : Ring
-    {% if flag?(:execution_context) %}
+    {% if !flag?(:without_mt) %}
       Fiber::ExecutionContext::Scheduler.current.__evloop_ring
     {% else %}
       @main_ring
@@ -228,7 +228,7 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
   end
 
   private def ring? : Ring?
-    {% if flag?(:execution_context) %}
+    {% if !flag?(:without_mt) %}
       Fiber::ExecutionContext::Scheduler.current?.try(&.__evloop_ring?)
     {% else %}
       @main_ring
@@ -246,7 +246,7 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
     enqueued
   end
 
-  {% if flag?(:execution_context) %}
+  {% unless flag?(:without_mt) %}
     def run(queue : Fiber::List*, blocking : Bool) : Nil
       system_run(blocking) { |fiber| queue.value.push(fiber) }
     end
@@ -322,7 +322,7 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
     Crystal.trace :evloop, "run", blocking: blocking
     enqueued = 0
 
-    {% if flag?(:execution_context) %}
+    {% unless flag?(:without_mt) %}
       # dereference @rings once (it may be replaced in parallel)
       rings = @rings
 
@@ -474,7 +474,7 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
   private def interrupt_impl : Bool
     # search a waiting ring to wakeup
     waiting_ring =
-      {% if flag?(:execution_context) %}
+      {% if !flag?(:without_mt) %}
         @rings.find(&.try(&.waiting?))
       {% else %}
         @main_ring
@@ -605,7 +605,7 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
 
   def pread(file_descriptor : System::FileDescriptor, slice : Bytes, offset : Int64) : Int32
     before_suspend =
-      {% if flag?(:preview_mt) %}
+      {% if !flag?(:without_mt) %}
         file_descriptor.__evloop_reader = ring
         -> {
           if file_descriptor.closed? && file_descriptor.__evloop_reader?
@@ -627,7 +627,7 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
       end
     end
   ensure
-    {% if flag?(:preview_mt) %}
+    {% unless flag?(:without_mt) %}
       file_descriptor.__evloop_reader = nil
     {% end %}
   end
@@ -638,7 +638,7 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
 
   def write(file_descriptor : System::FileDescriptor, slice : Bytes) : Int32
     before_suspend =
-      {% if flag?(:preview_mt) %}
+      {% if !flag?(:without_mt) %}
         file_descriptor.__evloop_writer = ring
         -> {
           if file_descriptor.closed? && file_descriptor.__evloop_writer?
@@ -660,7 +660,7 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
       end
     end
   ensure
-    {% if flag?(:preview_mt) %}
+    {% unless flag?(:without_mt) %}
       file_descriptor.__evloop_writer = nil
     {% end %}
   end
@@ -674,7 +674,7 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
   end
 
   def shutdown(file_descriptor : System::FileDescriptor) : Nil
-    {% if flag?(:preview_mt) %}
+    {% if !flag?(:without_mt) %}
       if reader_ring = file_descriptor.__evloop_reader?
         cancel(file_descriptor.fd, ring: reader_ring)
       end

--- a/src/crystal/event_loop/io_uring/ring.cr
+++ b/src/crystal/event_loop/io_uring/ring.cr
@@ -6,20 +6,15 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
   class Ring < System::IoUring
     getter? waiting : Bool = false
 
-    {% if flag?(:preview_mt) %}
+    {% unless flag?(:without_mt) %}
       @sq_lock : Thread::Mutex?
-    {% end %}
-
-    {% if flag?(:execution_context) %}
-      # uninitialized-safety: compiler fails to notice the actual initialization
-      # because of comptime flags
-      @cq_lock = uninitialized Thread::Mutex
+      @cq_lock = Thread::Mutex.new
     {% end %}
 
     def initialize(*args, **kwargs)
       super(*args, **kwargs)
 
-      {% if flag?(:preview_mt) %}
+      {% unless flag?(:without_mt) %}
         # unless IORING_REGISTER_SYNC_CANCEL (Linux 6.0) and
         # IORING_REGISTER_SEND_MSG_RING (Linux 6.13) are supported we may have
         # multiple threads trying to submit to the ring (on evloop interrupt and
@@ -27,10 +22,6 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
         unless System::IoUring.supports_register_sync_cancel? && System::IoUring.supports_register_send_msg_ring?
           @sq_lock = Thread::Mutex.new
         end
-      {% end %}
-
-      {% if flag?(:execution_context) %}
-        @cq_lock = Thread::Mutex.new
       {% end %}
     end
 
@@ -43,7 +34,7 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
 
     # Acquires the SQ lock for the duration of the block if required.
     def sq_lock(&)
-      {% if flag?(:preview_mt) %}
+      {% unless flag?(:without_mt) %}
         if sq_lock = @sq_lock
           return sq_lock.synchronize { yield }
         end
@@ -54,7 +45,7 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
 
     # Acquires the CQ lock for the duration of the block.
     def cq_lock(&)
-      {% if flag?(:execution_context) %}
+      {% if !flag?(:without_mt) %}
         @cq_lock.synchronize { yield }
       {% else %}
         yield
@@ -64,7 +55,7 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
     # Tries to acquire the CQ lock for the duration of the block. Returns
     # immediately if the CQ lock couldn't be acquired.
     def cq_trylock?(&)
-      {% if flag?(:execution_context) %}
+      {% if !flag?(:without_mt) %}
         if @cq_lock.try_lock
           begin
             yield

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -80,7 +80,7 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
     enqueued
   end
 
-  {% if flag?(:execution_context) %}
+  {% unless flag?(:without_mt) %}
     # thread unsafe
     def run(queue : Fiber::List*, blocking : Bool) : Nil
       run_impl(blocking) { |fiber| queue.value.push(fiber) }

--- a/src/crystal/event_loop/kqueue.cr
+++ b/src/crystal/event_loop/kqueue.cr
@@ -28,7 +28,7 @@ class Crystal::EventLoop::Kqueue < Crystal::EventLoop::Polling
     {% end %}
   end
 
-  {% unless flag?(:preview_mt) %}
+  {% if flag?(:without_mt) %}
     def after_fork : Nil
       super
 

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -17,7 +17,7 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
   def initialize(parallelism : Int32)
   end
 
-  {% unless flag?(:preview_mt) %}
+  {% if flag?(:without_mt) %}
     # Reinitializes the event loop after a fork.
     def after_fork : Nil
       event_base.reinit
@@ -30,7 +30,7 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
     event_base.loop(flags)
   end
 
-  {% if flag?(:execution_context) %}
+  {% unless flag?(:without_mt) %}
     # the evloop has a single poll instance for the context and only one
     # scheduler must wait on the evloop at any time
     include Lock
@@ -65,7 +65,7 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
   def create_resume_event(fiber : Fiber) : Crystal::EventLoop::LibEvent::Event
     event_base.new_event(-1, LibEvent2::EventFlags::None, fiber) do |s, flags, data|
       f = data.as(Fiber)
-      {% if flag?(:execution_context) %}
+      {% if !flag?(:without_mt) %}
         event_loop = Crystal::EventLoop.current.as(Crystal::EventLoop::LibEvent)
         event_loop.callback_enqueue(f)
       {% else %}
@@ -81,7 +81,7 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
       if select_action = f.timeout_select_action
         f.timeout_select_action = nil
         if select_action.time_expired?
-          {% if flag?(:execution_context) %}
+          {% if !flag?(:without_mt) %}
             event_loop = Crystal::EventLoop.current.as(Crystal::EventLoop::LibEvent)
             event_loop.callback_enqueue(f)
           {% else %}

--- a/src/crystal/event_loop/libevent/event.cr
+++ b/src/crystal/event_loop/libevent/event.cr
@@ -1,6 +1,6 @@
 require "./lib_event2"
 
-{% if flag?(:preview_mt) %}
+{% unless flag?(:without_mt) %}
   LibEvent2.evthread_use_pthreads
 {% end %}
 

--- a/src/crystal/event_loop/libevent/lib_event2.cr
+++ b/src/crystal/event_loop/libevent/lib_event2.cr
@@ -18,7 +18,7 @@ require "c/netdb"
 {% else %}
   @[Link("event", pkg_config: "libevent")]
 {% end %}
-{% if flag?(:preview_mt) %}
+{% unless flag?(:without_mt) %}
   @[Link("event_pthreads", pkg_config: "libevent_pthreads")]
 {% end %}
 lib LibEvent2
@@ -75,7 +75,7 @@ lib LibEvent2
   fun evdns_getaddrinfo_cancel(DnsGetAddrinfoRequest)
   fun evutil_freeaddrinfo(ai : LibC::Addrinfo*)
 
-  {% if flag?(:preview_mt) %}
+  {% unless flag?(:without_mt) %}
     fun evthread_use_pthreads : Int
   {% end %}
 end

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -108,7 +108,7 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
   @timers_lock = SpinLock.new
   @timers = Timers(Event).new
 
-  {% unless flag?(:preview_mt) %}
+  {% if flag?(:without_mt) %}
     # no parallelism issues, but let's clean-up anyway
     def after_fork : Nil
       @timers_lock = SpinLock.new
@@ -118,7 +118,7 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
   # thread unsafe
   def run(blocking : Bool) : Bool
     system_run(blocking) do |fiber|
-      {% if flag?(:execution_context) %}
+      {% if !flag?(:without_mt) %}
         fiber.execution_context.enqueue(fiber)
       {% else %}
         Crystal::Scheduler.enqueue(fiber)
@@ -127,7 +127,7 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     true
   end
 
-  {% if flag?(:execution_context) %}
+  {% unless flag?(:without_mt) %}
     # the evloop has a single poll instance for the context and only one
     # scheduler must wait on the evloop at any time
     include EventLoop::Lock
@@ -480,7 +480,7 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     Polling.arena.free(index) do |pd|
       pd.value.@readers.ready_all do |event|
         pd.value.@event_loop.try(&.unsafe_resume_io(event) do |fiber|
-          {% if flag?(:execution_context) %}
+          {% if !flag?(:without_mt) %}
             fiber.execution_context.enqueue(fiber)
           {% else %}
             Crystal::Scheduler.enqueue(fiber)
@@ -490,7 +490,7 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
 
       pd.value.@writers.ready_all do |event|
         pd.value.@event_loop.try(&.unsafe_resume_io(event) do |fiber|
-          {% if flag?(:execution_context) %}
+          {% if !flag?(:without_mt) %}
             fiber.execution_context.enqueue(fiber)
           {% else %}
             Crystal::Scheduler.enqueue(fiber)

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -60,7 +60,7 @@ class Crystal::Scheduler
   end
 
   @main : Fiber
-  @lock = Crystal::SpinLock.new
+  @lock = Thread::Mutex.new
 
   # :nodoc:
   def initialize(@thread : Thread)
@@ -72,11 +72,11 @@ class Crystal::Scheduler
   end
 
   protected def enqueue(fiber : Fiber) : Nil
-    @lock.sync { @runnables << fiber }
+    @lock.synchronize { @runnables << fiber }
   end
 
   protected def enqueue(fibers : Enumerable(Fiber)) : Nil
-    @lock.sync { @runnables.concat fibers }
+    @lock.synchronize { @runnables.concat fibers }
   end
 
   protected def resume(fiber : Fiber) : Nil
@@ -111,7 +111,7 @@ class Crystal::Scheduler
 
   protected def reschedule : Nil
     loop do
-      if runnable = @lock.sync { @runnables.shift? }
+      if runnable = @lock.synchronize { @runnables.shift? }
         resume(runnable) unless runnable == @thread.current_fiber
         break
       else

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -1,4 +1,4 @@
-{% skip_file if flag?(:execution_context) %}
+{% skip_file unless flag?(:without_mt) %}
 
 require "crystal/event_loop"
 require "crystal/system/print_error"
@@ -33,21 +33,7 @@ class Crystal::Scheduler
 
   def self.enqueue(fiber : Fiber) : Nil
     Crystal.trace :sched, "enqueue", fiber: fiber do
-      thread = Thread.current
-      scheduler = thread.scheduler
-
-      {% if flag?(:preview_mt) %}
-        th = fiber.get_current_thread
-        th ||= fiber.set_current_thread(scheduler.find_target_thread)
-
-        if th == thread
-          scheduler.enqueue(fiber)
-        else
-          th.scheduler.send_fiber(fiber)
-        end
-      {% else %}
-        scheduler.enqueue(fiber)
-      {% end %}
+      Thread.current.scheduler.enqueue(fiber)
     end
   end
 
@@ -63,30 +49,15 @@ class Crystal::Scheduler
   end
 
   def self.resume(fiber : Fiber) : Nil
-    validate_running_thread(fiber)
     Thread.current.scheduler.resume(fiber)
-  end
-
-  private def self.validate_running_thread(fiber : Fiber) : Nil
-    {% if flag?(:preview_mt) %}
-      if th = fiber.get_current_thread
-        unless th == Thread.current
-          raise "BUG: tried to manually resume #{fiber} on #{Thread.current} instead of #{th}"
-        end
-      else
-        fiber.set_current_thread
-      end
-    {% end %}
   end
 
   @main : Fiber
   @lock = Crystal::SpinLock.new
-  @sleeping = false
 
   # :nodoc:
   def initialize(@thread : Thread)
     @main = thread.main_fiber
-    {% if flag?(:preview_mt) %} @main.set_current_thread(thread) {% end %}
     @runnables = Deque(Fiber).new
   end
 
@@ -105,9 +76,7 @@ class Crystal::Scheduler
     Crystal.trace :sched, "resume", fiber: fiber
     validate_resumable(fiber)
 
-    {% if flag?(:preview_mt) %}
-      GC.lock_read
-    {% elsif flag?(:interpreted) %}
+    {% if flag?(:interpreted) %}
       # No need to change the stack bottom!
     {% else %}
       GC.set_stackbottom(fiber.@stack.bottom)
@@ -115,10 +84,6 @@ class Crystal::Scheduler
 
     current, @thread.current_fiber = @thread.current_fiber, fiber
     Fiber.swapcontext(pointerof(current.@context), pointerof(fiber.@context))
-
-    {% if flag?(:preview_mt) %}
-      GC.unlock_read
-    {% end %}
   end
 
   private def validate_resumable(fiber)
@@ -150,106 +115,15 @@ class Crystal::Scheduler
     end
   end
 
-  {% if flag?(:preview_mt) %}
-    private getter! worker_fiber : Fiber
-    @rr_target = 0
-
-    protected def find_target_thread
-      if workers = @@workers
-        @rr_target &+= 1
-        workers[@rr_target % workers.size]
-      else
-        Thread.current
-      end
-    end
-
-    def run_loop
-      @worker_fiber = Fiber.current
-
-      spawn_stack_pool_collector
-
-      loop do
-        @lock.lock
-
-        if runnable = @runnables.shift?
-          @runnables << worker_fiber
-          @lock.unlock
-          resume(runnable)
-        else
-          @sleeping = true
-          @lock.unlock
-          Crystal.trace :sched, "mt:sleeping"
-          Crystal.trace(:sched, "mt:slept") { ::Fiber.suspend }
-        end
-      end
-    end
-
-    def send_fiber(fiber : Fiber)
-      @lock.lock
-      @runnables << fiber
-
-      if @sleeping
-        @sleeping = false
-        @runnables << worker_fiber
-        @event_loop.interrupt
-      end
-      @lock.unlock
-    end
-
-    def self.init : Nil
-      count = worker_count
-      pending = Atomic(Int32).new(count - 1)
-      @@workers = Array(Thread).new(count) do |i|
-        if i == 0
-          worker_loop = Fiber.new(name: "worker-loop") { Thread.current.scheduler.run_loop }
-          worker_loop.set_current_thread
-          Thread.current.scheduler.enqueue worker_loop
-          Thread.current
-        else
-          Thread.new(name: "CRYSTAL-MT-#{i}") do
-            scheduler = Thread.current.scheduler
-            pending.sub(1)
-            scheduler.run_loop
-          end
-        end
-      end
-
-      # Wait for all worker threads to be fully ready to be used
-      while pending.get > 0
-        Fiber.yield
-      end
-    end
-
-    private def self.worker_count
-      env_workers = ENV["CRYSTAL_WORKERS"]?
-
-      if env_workers && !env_workers.empty?
-        workers = env_workers.to_i?
-        if !workers || workers < 1
-          Crystal::System.print_error "FATAL: Invalid value for CRYSTAL_WORKERS: %s\n", env_workers
-          exit 1
-        end
-
-        workers
-      else
-        # TODO: default worker count, currently hardcoded to 4 that seems to be something
-        # that is beneficial for many scenarios without adding too much contention.
-        # In the future we could use the number of cores or something associated to it.
-        4
-      end
-    end
-  {% else %}
-    def self.init : Nil
-      {% unless flag?(:interpreted) %}
-        Thread.current.scheduler.spawn_stack_pool_collector
-      {% end %}
-    end
-  {% end %}
+  def self.init : Nil
+    {% unless flag?(:interpreted) %}
+      Thread.current.scheduler.spawn_stack_pool_collector
+    {% end %}
+  end
 
   # Background loop to cleanup unused fiber stacks.
   def spawn_stack_pool_collector
     fiber = Fiber.new(name: "stack-pool-collector", &->@stack_pool.collect_loop)
-    {% if flag?(:preview_mt) %} fiber.set_current_thread {% end %}
     enqueue(fiber)
   end
 end

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -14,9 +14,9 @@ require "crystal/system/thread"
 # Only the class methods are public and safe to use. Instance methods are
 # protected and must never be called directly.
 class Crystal::Scheduler
-  class_property! scheduler : Scheduler
-  @@event_loop = EventLoop.create
-  @@stack_pool = Fiber::StackPool.new
+  private class_getter! scheduler : Scheduler
+  class_getter event_loop = EventLoop.create
+  class_getter stack_pool = Fiber::StackPool.new
 
   def self.init : Nil
     @@scheduler = new(Thread.current)
@@ -24,14 +24,6 @@ class Crystal::Scheduler
     {% unless flag?(:interpreted) %}
       scheduler.spawn_stack_pool_collector
     {% end %}
-  end
-
-  def self.stack_pool : Fiber::StackPool
-    @@stack_pool
-  end
-
-  def self.event_loop
-    @@event_loop
   end
 
   def self.event_loop?

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -14,26 +14,33 @@ require "crystal/system/thread"
 # Only the class methods are public and safe to use. Instance methods are
 # protected and must never be called directly.
 class Crystal::Scheduler
-  @event_loop = Crystal::EventLoop.create
-  @stack_pool = Fiber::StackPool.new
+  class_property! scheduler : Scheduler
+  @@event_loop = EventLoop.create
+  @@stack_pool = Fiber::StackPool.new
+
+  def self.init : Nil
+    @@scheduler = new(Thread.current)
+
+    {% unless flag?(:interpreted) %}
+      scheduler.spawn_stack_pool_collector
+    {% end %}
+  end
 
   def self.stack_pool : Fiber::StackPool
-    Thread.current.scheduler.@stack_pool
+    @@stack_pool
   end
 
   def self.event_loop
-    Thread.current.scheduler.@event_loop
+    @@event_loop
   end
 
   def self.event_loop?
-    if scheduler = Thread.current?.try(&.scheduler?)
-      scheduler.@event_loop
-    end
+    @@event_loop
   end
 
   def self.enqueue(fiber : Fiber) : Nil
     Crystal.trace :sched, "enqueue", fiber: fiber do
-      Thread.current.scheduler.enqueue(fiber)
+      scheduler.enqueue(fiber)
     end
   end
 
@@ -45,11 +52,11 @@ class Crystal::Scheduler
 
   def self.reschedule : Nil
     Crystal.trace :sched, "reschedule"
-    Thread.current.scheduler.reschedule
+    scheduler.reschedule
   end
 
   def self.resume(fiber : Fiber) : Nil
-    Thread.current.scheduler.resume(fiber)
+    scheduler.resume(fiber)
   end
 
   @main : Fiber
@@ -109,21 +116,15 @@ class Crystal::Scheduler
         break
       else
         Crystal.trace :sched, "event_loop" do
-          @event_loop.run(blocking: true)
+          @@event_loop.run(blocking: true)
         end
       end
     end
   end
 
-  def self.init : Nil
-    {% unless flag?(:interpreted) %}
-      Thread.current.scheduler.spawn_stack_pool_collector
-    {% end %}
-  end
-
   # Background loop to cleanup unused fiber stacks.
   def spawn_stack_pool_collector
-    fiber = Fiber.new(name: "stack-pool-collector", &->@stack_pool.collect_loop)
+    fiber = Fiber.new(name: "stack-pool-collector", &->@@stack_pool.collect_loop)
     enqueue(fiber)
   end
 end

--- a/src/crystal/spin_lock.cr
+++ b/src/crystal/spin_lock.cr
@@ -3,12 +3,12 @@ struct Crystal::SpinLock
   private UNLOCKED = 0
   private LOCKED   = 1
 
-  {% if flag?(:preview_mt) || flag?(:win32) %}
+  {% if !flag?(:without_mt) || flag?(:win32) %}
     @m = Atomic(Int32).new(UNLOCKED)
   {% end %}
 
   def lock
-    {% if flag?(:preview_mt) || flag?(:win32) %}
+    {% if !flag?(:without_mt) || flag?(:win32) %}
       while @m.swap(LOCKED, :acquire) == LOCKED
         while @m.get(:relaxed) == LOCKED
           Intrinsics.pause
@@ -18,7 +18,7 @@ struct Crystal::SpinLock
   end
 
   def unlock
-    {% if flag?(:preview_mt) || flag?(:win32) %}
+    {% if !flag?(:without_mt) || flag?(:win32) %}
       @m.set(UNLOCKED, :release)
     {% end %}
   end

--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -79,7 +79,7 @@ class Thread
 
   getter name : String?
 
-  {% if flag?(:execution_context) %}
+  {% if !flag?(:without_mt) %}
     # :nodoc:
     getter! execution_context : Fiber::ExecutionContext
 

--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -113,14 +113,6 @@ class Thread
         stack
       end
     end
-  {% else %}
-    # :nodoc:
-    getter scheduler : Crystal::Scheduler { Crystal::Scheduler.new(self) }
-
-    # :nodoc:
-    def scheduler? : ::Crystal::Scheduler?
-      @scheduler
-    end
   {% end %}
 
   def self.unsafe_each(&)

--- a/src/crystal/system/unix/io_uring.cr
+++ b/src/crystal/system/unix/io_uring.cr
@@ -191,7 +191,7 @@ class Crystal::System::IoUring
       raise RuntimeError.from_os_error("mmap", errno)
     end
 
-    {% if flag?(:preview_mt) %}
+    {% unless flag?(:without_mt) %}
       # don't bother inheriting mmap on fork: we don't support fork, only
       # fork/exec and we musn't use the evloop after fork before exec
       LibC.madvise(ptr, size, LibC::MADV_DONTFORK)

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -206,7 +206,7 @@ struct Crystal::System::Process
 
   # Only used by deprecated `::Process.fork`
   def self.fork
-    {% raise("Process fork is unsupported with multithreaded mode") if flag?(:preview_mt) %}
+    {% raise("Process fork is unsupported with multithreaded mode") unless flag?(:without_mt) %}
 
     pid, errno = lock_write do
       pthread_disable_cancelstate do

--- a/src/crystal/system/unix/signal.cr
+++ b/src/crystal/system/unix/signal.cr
@@ -148,7 +148,7 @@ module Crystal::System::Signal
       {% end %}
     end
   ensure
-    {% unless flag?(:preview_mt) %}
+    {% if flag?(:without_mt) %}
       @@pipe.each(&.file_descriptor_close)
     {% end %}
   end

--- a/src/crystal/tracing.cr
+++ b/src/crystal/tracing.cr
@@ -90,7 +90,7 @@ module Crystal
           {% end %}
         end
 
-        {% if flag?(:execution_context) %}
+        {% unless flag?(:without_mt) %}
           def write(value : Fiber::ExecutionContext) : Nil
             write value.name
           end

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -68,17 +68,13 @@ class Fiber
 
   @alive = true
 
-  {% if flag?(:preview_mt) && !flag?(:execution_context) %}
-    @current_thread = Atomic(Thread?).new(nil)
-  {% end %}
-
   # :nodoc:
   property next : Fiber?
 
   # :nodoc:
   property previous : Fiber?
 
-  {% if flag?(:execution_context) %}
+  {% if !flag?(:without_mt) %}
     property! execution_context : ExecutionContext
   {% end %}
 
@@ -108,21 +104,21 @@ class Fiber
   # When the fiber is executed, it runs *proc* in its context.
   #
   # *name* is an optional and used only as an internal reference.
-  def self.new(name : String? = nil, {% if flag?(:execution_context) %}execution_context : ExecutionContext = ExecutionContext.current,{% end %} &proc : ->) : self
+  def self.new(name : String? = nil, {% unless flag?(:without_mt) %}execution_context : ExecutionContext = ExecutionContext.current,{% end %} &proc : ->) : self
     stack =
       {% if flag?(:interpreted) %}
         # the interpreter is managing the stacks
         Stack.new(Pointer(Void).null, Pointer(Void).null)
-      {% elsif flag?(:execution_context) %}
+      {% elsif !flag?(:without_mt) %}
         execution_context.stack_pool.checkout
       {% else %}
         Crystal::Scheduler.stack_pool.checkout
       {% end %}
-    new(name, stack, {% if flag?(:execution_context) %}execution_context,{% end %} &proc)
+    new(name, stack, {% unless flag?(:without_mt) %}execution_context,{% end %} &proc)
   end
 
   # :nodoc:
-  def initialize(@name : String?, @stack : Stack, {% if flag?(:execution_context) %}@execution_context : ExecutionContext = ExecutionContext.current,{% end %} &@proc : ->)
+  def initialize(@name : String?, @stack : Stack, {% unless flag?(:without_mt) %}@execution_context : ExecutionContext = ExecutionContext.current,{% end %} &@proc : ->)
     @context = Context.new
 
     fiber_main = ->(f : Fiber) { f.run }
@@ -151,10 +147,6 @@ class Fiber
     @stack = Stack.new(stack, stack_bottom)
 
     @name = "main"
-
-    {% if flag?(:preview_mt) && !flag?(:execution_context) %}
-      @current_thread.set(thread)
-    {% end %}
 
     Fiber.fibers.push(self)
 
@@ -191,7 +183,7 @@ class Fiber
 
     # the interpreter is managing the stacks
     {% unless flag?(:interpreted) %}
-      {% if flag?(:execution_context) %}
+      {% if !flag?(:without_mt) %}
         # do not prematurely release the stack before we switch to another fiber
         if stack = Thread.current.dying_fiber(self)
           # we can however release the stack of a previously dying fiber (we
@@ -249,7 +241,7 @@ class Fiber
   # puts "never reached"
   # ```
   def resume : Nil
-    {% if flag?(:execution_context) %}
+    {% if !flag?(:without_mt) %}
       ExecutionContext.resume(self)
     {% else %}
       Crystal::Scheduler.resume(self)
@@ -262,7 +254,7 @@ class Fiber
   # the next time it has the opportunity to reschedule to another fiber. There
   # are no guarantees when that will happen.
   def enqueue : Nil
-    {% if flag?(:execution_context) %}
+    {% if !flag?(:without_mt) %}
       execution_context.enqueue(self)
     {% else %}
       Crystal::Scheduler.enqueue(self)
@@ -353,7 +345,7 @@ class Fiber
   # useful if the fiber needs to wait  for something to happen (for example an IO
   # event, a message is ready in a channel, etc.) which triggers a re-enqueue.
   def self.suspend : Nil
-    {% if flag?(:execution_context) %}
+    {% if !flag?(:without_mt) %}
       ExecutionContext.reschedule
     {% else %}
       Crystal::Scheduler.reschedule
@@ -362,7 +354,7 @@ class Fiber
 
   # :nodoc:
   def self.syscall(&)
-    {% if flag?(:execution_context) %}
+    {% if !flag?(:without_mt) %}
       ExecutionContext::Scheduler.current.syscall { yield }
     {% else %}
       yield
@@ -387,18 +379,6 @@ class Fiber
     # Push the used section of the stack
     GC.push_stack @context.stack_top, @stack.bottom
   end
-
-  {% if flag?(:preview_mt) && !flag?(:execution_context) %}
-    # :nodoc:
-    def set_current_thread(thread = Thread.current) : Thread
-      @current_thread.set(thread)
-    end
-
-    # :nodoc:
-    def get_current_thread : Thread?
-      @current_thread.lazy_get
-    end
-  {% end %}
 
   # :nodoc:
   #

--- a/src/fiber/context/aarch64-generic.cr
+++ b/src/fiber/context/aarch64-generic.cr
@@ -54,7 +54,7 @@ class Fiber
 
       mov     x19, sp               // current_context.stack_top = sp
       str     x19, [x0, #0]
-      {% if flag?(:execution_context) %}
+      {% unless flag?(:without_mt) %}
       dmb     ish                   // barrier: ensure registers are stored
       {% end %}
       mov     x19, #1               // current_context.resumable = 1
@@ -100,7 +100,7 @@ class Fiber
 
       mov     x19, sp               // current_context.stack_top = sp
       str     x19, [$0, #0]
-      {% if flag?(:execution_context) %}
+      {% unless flag?(:without_mt) %}
       dmb     ish                   // barrier: ensure registers are stored
       {% end %}
       mov     x19, #1               // current_context.resumable = 1

--- a/src/fiber/context/aarch64-microsoft.cr
+++ b/src/fiber/context/aarch64-microsoft.cr
@@ -55,7 +55,7 @@ class Fiber
 
       mov     x19, sp               // current_context.stack_top = sp
       str     x19, [x0, #0]
-      {% if flag?(:execution_context) %}
+      {% unless flag?(:without_mt) %}
       dmb     ish                   // barrier: ensure registers are stored
       {% end %}
       mov     x19, #1               // current_context.resumable = 1
@@ -115,7 +115,7 @@ class Fiber
 
       mov     x19, sp               // current_context.stack_top = sp
       str     x19, [$0, #0]
-      {% if flag?(:execution_context) %}
+      {% unless flag?(:without_mt) %}
       dmb     ish                   // barrier: ensure registers are stored
       {% end %}
       mov     x19, #1               // current_context.resumable = 1

--- a/src/fiber/context/arm.cr
+++ b/src/fiber/context/arm.cr
@@ -53,7 +53,7 @@ class Fiber
         vstmdb sp!, {d8-d15}          // push FPU registers
         {% end %}
         str    sp, [r0, #0]           // current_context.stack_top = sp
-        {% if flag?(:execution_context) %}
+        {% unless flag?(:without_mt) %}
         mov    r4, #0                 // barrier: ensure registers are stored
         mcr    p15, #0, r4, c7, c10, #5
         {% end %}
@@ -87,7 +87,7 @@ class Fiber
         vstmdb sp!, {d8-d15}          // push FPU registers
         {% end %}
         str    sp, [$0, #0]           // current_context.stack_top = sp
-        {% if flag?(:execution_context) %}
+        {% unless flag?(:without_mt) %}
         mov    r4, #0                 // barrier: ensure registers are stored
         mcr    p15, #0, r4, c7, c10, #5
         {% end %}

--- a/src/fiber/execution_context.cr
+++ b/src/fiber/execution_context.cr
@@ -5,16 +5,11 @@ require "../fiber"
 require "./stack_pool"
 require "./execution_context/*"
 
-{% raise "ERROR: execution contexts require the `preview_mt` compilation flag" unless flag?(:preview_mt) || flag?(:docs) %}
-{% raise "ERROR: execution contexts require the `execution_context` compilation flag" unless flag?(:execution_context) || flag?(:docs) %}
+{% raise "ERROR: the interpreter cannot start threads (yet)" if flag?(:interpreted) %}
 
 # An execution context creates and manages a dedicated pool of one or more
 # schedulers where fibers will be running in. Each context manages the rules to
 # run, suspend and swap fibers internally.
-#
-# EXPERIMENTAL: Execution contexts are an experimental feature, implementing
-# [RFC 2](https://github.com/crystal-lang/rfcs/pull/2). It's opt-in and requires
-# the compiler flags `-Dpreview_mt -Dexecution_context`.
 #
 # An execution context groups fibers together. Instead of associating a fiber to
 # a specific system thread, we associate a fiber to an execution context,
@@ -102,7 +97,6 @@ require "./execution_context/*"
 # detached from any context at any time. Threads can be detached from a context
 # and reattached to the same execution context or to another one (`Concurrent`,
 # `Parallel` or `Isolated`).
-@[Experimental]
 module Fiber::ExecutionContext
   @@thread_pool : ThreadPool?
   @@default : ExecutionContext::Parallel?
@@ -126,7 +120,14 @@ module Fiber::ExecutionContext
   # :nodoc:
   def self.init_default_context : Nil
     @@thread_pool = ThreadPool.new
-    @@default = Parallel.default(1)
+    size =
+      {% if flag?(:preview_mt) %}
+        {% nil.warning "Warning: the 'preview_mt' compilation flag is deprecated. Resize the default execution context or start additional contexts instead." %}
+        ENV["CRYSTAL_WORKERS"]?.try(&.to_i?) || 4
+      {% else %}
+        1
+      {% end %}
+    @@default = Parallel.default(size)
     @@monitor = Monitor.new
   end
 

--- a/src/fiber/stack_pool.cr
+++ b/src/fiber/stack_pool.cr
@@ -5,7 +5,7 @@ class Fiber
   class StackPool
     STACK_SIZE = 8 * 1024 * 1024
 
-    {% if flag?(:execution_context) %}
+    {% unless flag?(:without_mt) %}
       # must explicitly declare the variable because of the macro in #initialize
       @lock = uninitialized Crystal::SpinLock
     {% end %}
@@ -23,7 +23,7 @@ class Fiber
     def initialize(@protect : Bool = true, @reuse_dead_fiber_stack : Bool = true)
       @deque = Deque(Stack).new
 
-      {% if flag?(:execution_context) %}
+      {% unless flag?(:without_mt) %}
         @lock = Crystal::SpinLock.new
       {% end %}
     end
@@ -68,7 +68,7 @@ class Fiber
     def release(stack : Stack) : Nil
       return unless stack.reusable?
 
-      {% if flag?(:execution_context) %}
+      {% if !flag?(:without_mt) %}
         @lock.sync { @deque.push(stack) }
       {% else %}
         @deque.push(stack)
@@ -82,7 +82,7 @@ class Fiber
     end
 
     private def shift?
-      {% if flag?(:execution_context) %}
+      {% if !flag?(:without_mt) %}
         @lock.sync { @deque.shift? } unless @deque.empty?
       {% else %}
         @deque.shift?
@@ -90,7 +90,7 @@ class Fiber
     end
 
     private def pop?
-      {% if flag?(:execution_context) %}
+      {% if !flag?(:without_mt) %}
         if @reuse_dead_fiber_stack && (stack = Thread.current.dead_fiber_stack?) && stack.reusable?
           stack
         else

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -1,4 +1,4 @@
-{% if flag?(:preview_mt) %}
+{% unless flag?(:without_mt) %}
   require "crystal/rw_lock"
 {% end %}
 require "crystal/tracing"
@@ -121,7 +121,7 @@ lib LibGC
 
   fun push_all_eager = GC_push_all_eager(bottom : Void*, top : Void*)
 
-  {% if flag?(:preview_mt) || flag?(:win32) || compare_versions(VERSION, "8.2.0") >= 0 %}
+  {% if !flag?(:without_mt) || flag?(:win32) || compare_versions(VERSION, "8.2.0") >= 0 %}
     fun get_my_stackbottom = GC_get_my_stackbottom(sb : StackBase*) : ThreadHandle
     fun set_stackbottom = GC_set_stackbottom(th : ThreadHandle, sb : StackBase*) : ThreadHandle
   {% else %}
@@ -183,7 +183,7 @@ lib LibGC
 end
 
 module GC
-  {% if flag?(:preview_mt) %}
+  {% unless flag?(:without_mt) %}
     @@lock = uninitialized Crystal::RWLock
   {% end %}
 
@@ -214,7 +214,7 @@ module GC
     {% end %}
     LibGC.init
 
-    {% if flag?(:preview_mt) %}
+    {% unless flag?(:without_mt) %}
       @@lock = Crystal::RWLock.new
     {% end %}
 
@@ -229,7 +229,7 @@ module GC
           fiber.push_gc_roots unless fiber.running?
         end
 
-        {% if flag?(:preview_mt) %}
+        {% unless flag?(:without_mt) %}
           Thread.unsafe_each do |thread|
             if fiber = thread.current_fiber?
               GC.set_stackbottom(thread.gc_thread_handler, fiber.@stack.bottom)
@@ -426,7 +426,7 @@ module GC
   end
 
   # :nodoc:
-  {% if flag?(:preview_mt) %}
+  {% if !flag?(:without_mt) %}
     def self.set_stackbottom(thread_handle : Void*, stack_bottom : Void*)
       sb = LibGC::StackBase.new
       sb.mem_base = stack_bottom
@@ -452,28 +452,28 @@ module GC
 
   # :nodoc:
   def self.lock_read
-    {% if flag?(:preview_mt) %}
+    {% unless flag?(:without_mt) %}
       @@lock.read_lock
     {% end %}
   end
 
   # :nodoc:
   def self.unlock_read
-    {% if flag?(:preview_mt) %}
+    {% unless flag?(:without_mt) %}
       @@lock.read_unlock
     {% end %}
   end
 
   # :nodoc:
   def self.lock_write
-    {% if flag?(:preview_mt) %}
+    {% unless flag?(:without_mt) %}
       @@lock.write_lock
     {% end %}
   end
 
   # :nodoc:
   def self.unlock_write
-    {% if flag?(:preview_mt) %}
+    {% unless flag?(:without_mt) %}
       @@lock.write_unlock
     {% end %}
   end

--- a/src/gc/none.cr
+++ b/src/gc/none.cr
@@ -136,7 +136,7 @@ module GC
   end
 
   # :nodoc:
-  {% if flag?(:preview_mt) %}
+  {% if !flag?(:without_mt) %}
     def self.set_stackbottom(thread : Thread, stack_bottom : Void*)
       # NOTE we could store stack_bottom per thread,
       #      and return it in `#current_thread_stack_bottom`,

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -599,13 +599,14 @@ end
   end
 {% end %}
 
-{% unless flag?(:interpreted) || flag?(:wasm32) %}
-  {% if !flag?(:without_mt) %}
-    Fiber::ExecutionContext.init_default_context
-  {% else %}
-    Crystal::Scheduler.init
-  {% end %}
+# initialize the fiber scheduler(s)
+{% if !flag?(:without_mt) %}
+  Fiber::ExecutionContext.init_default_context
+{% else %}
+  Crystal::Scheduler.init
+{% end %}
 
+{% unless flag?(:interpreted) || flag?(:wasm32) %}
   # load debug info on start up of the program is executed with CRYSTAL_LOAD_DEBUG_INFO=1
   # this will make debug info available on print_frame that is used by Crystal's segfault handler
   #

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -577,7 +577,7 @@ def abort(message = nil, status = 1) : NoReturn
   exit status
 end
 
-{% if !flag?(:preview_mt) && flag?(:unix) %}
+{% if flag?(:without_mt) && flag?(:unix) %}
   class Process
     # :nodoc:
     #
@@ -600,7 +600,7 @@ end
 {% end %}
 
 {% unless flag?(:interpreted) || flag?(:wasm32) %}
-  {% if flag?(:execution_context) %}
+  {% if !flag?(:without_mt) %}
     Fiber::ExecutionContext.init_default_context
   {% else %}
     Crystal::Scheduler.init

--- a/src/process.cr
+++ b/src/process.cr
@@ -152,7 +152,7 @@ class Process
   # Available only on Unix-like operating systems.
   @[Deprecated("Fork is no longer supported.")]
   def self.fork : Process?
-    {% raise("Process fork is unsupported with multithread mode") if flag?(:preview_mt) %}
+    {% raise("Process fork is unsupported with multithread mode") unless flag?(:without_mt) %}
 
     if pid = Crystal::System::Process.fork
       new Crystal::System::Process.new(pid)

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -130,7 +130,7 @@ module Spec
         Process.on_terminate { abort! }
       {% end %}
 
-      {% if flag?(:execution_context) %}
+      {% unless flag?(:without_mt) %}
         if count = ENV["CRYSTAL_WORKERS"]?.try(&.to_i?)
           Fiber::ExecutionContext.default.resize(count)
         end


### PR DESCRIPTION
A quick refactor to simplify `Crystal::Scheduler` for `:without_mt`. It allows safe `fiber.enqueue` from any thread, which will help to simplify a couple cases on Windows where IOCP doesn't quite fit (e.g. `ReadConsoleW` for reading from stdin and `RegisterWaitSingleObject` to wait for processes).

Follow up to #17001.