### PR TITLE
Fix: `Fiber::ExecutionContext.current?`

### DIFF
--- a/src/fiber/execution_context.cr
+++ b/src/fiber/execution_context.cr
@@ -172,7 +172,7 @@ module Fiber::ExecutionContext
   end
 
   def self.current? : ExecutionContext?
-    Thread.current.execution_context?
+    Thread.current?.try(&.execution_context?)
   end
 
   # :nodoc:


### PR DESCRIPTION
I noticed that a bare thread on windows (a system IO wait thread) segfaulted while trying to allocate a `Thread.current` in order to enqueue a fiber back into its execution context.

If there's no current thread, there can't be an execution context.