### PR TITLE
Deprecate `spawn(same_thread:)`

### DIFF
--- a/src/concurrent.cr
+++ b/src/concurrent.cr
@@ -72,7 +72,7 @@ end
 #
 # wg.wait
 # ```
-def spawn(*, name : String? = nil, @[Deprecated("It will have no effect with execution contexts.")]same_thread = false, &block)
+def spawn(*, name : String? = nil, {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated("It will have no effect with execution contexts.")] {% end %} same_thread = false, &block)
   {% if flag?(:execution_context) %}
     Fiber::ExecutionContext::Scheduler.current.spawn(name: name, same_thread: same_thread, &block)
   {% else %}

--- a/src/concurrent.cr
+++ b/src/concurrent.cr
@@ -72,7 +72,7 @@ end
 #
 # wg.wait
 # ```
-def spawn(*, name : String? = nil, same_thread = false, &block)
+def spawn(*, name : String? = nil, @[Deprecated("It will have no effect with execution contexts.")]same_thread = false, &block)
   {% if flag?(:execution_context) %}
     Fiber::ExecutionContext::Scheduler.current.spawn(name: name, same_thread: same_thread, &block)
   {% else %}
@@ -134,7 +134,7 @@ macro spawn(call, *, name = nil, same_thread = false, &block)
         {% end %}
       {% end %}
       ) {
-      spawn(name: {{name}}, same_thread: {{same_thread}}) do
+      spawn(name: {{name}}{% if same_thread %}, same_thread: {{same_thread}}{% end %}) do
         {% if call.receiver %}{{ call.receiver }}.{% end %}{{call.name}}(
           {% for arg, i in call.args %}
             {% if arg.is_a?(Splat) %}*{% end %}__arg{{i}},


### PR DESCRIPTION
It's only used by `preview_mt`.

Without MT the argument is pointless.

With execution contexts, you must start a concurrent context to run fibers that musn't run in parallel, or not resize the default context to keep it concurrent.

**Notes for upgrading**:

If the value for `same_thread` is set to `false` you can safely drop the argument (it's the default).

If set to `true`, you will have to investigate if there is an actual parallelism issue.

If there is an issue, you can either fix the issue (for example by using [Sync](https://crystal-lang.org/api/Sync.html) primitives), or start a concurrent execution context and spawn the fibers that can't run in parallel there, or choose to not resize the default execution context (no parallelism until you opt-in).

In any case, you can drop the argument.