### PR TITLE
Refactor: simplify read console (windows)

### DIFF
--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -500,64 +500,59 @@ private module ConsoleUtils
     @@buffer = appender.to_slice
   end
 
+  class ReadRequest
+    getter handle : LibC::HANDLE
+    getter slice : Slice(UInt16)
+    getter fiber : Fiber
+
+    property units_read = LibC::DWORD.zero
+    property error = WinError::ERROR_SUCCESS
+
+    def initialize(@handle : LibC::HANDLE, @slice : Slice(UInt16), @fiber : Fiber)
+    end
+  end
+
+  @@read_mtx = ::Thread::Mutex.new
+  @@read_cv = ::Thread::ConditionVariable.new
+  @@read_requests = Deque(ReadRequest).new
+  @@read_thread = ::Thread.new { reader_loop }
+
   private def self.read_console(handle : LibC::HANDLE, slice : Slice(UInt16)) : Int32
-    @@mtx.synchronize do
-      @@read_requests << ReadRequest.new(
-        handle: handle,
-        slice: slice,
-        iocp: Crystal::EventLoop.current.iocp_handle,
-        completion_key: Crystal::System::IOCP::CompletionKey.new(:stdin_read, ::Fiber.current),
-      )
+    request = ReadRequest.new(handle, slice, ::Fiber.current)
+
+    @@read_mtx.synchronize do
+      @@read_requests << request
       @@read_cv.signal
     end
 
     ::Fiber.suspend
 
-    @@mtx.synchronize do
-      @@bytes_read.shift
+    unless request.error == WinError::ERROR_SUCCESS
+      raise IO::Error.from_os_error("ReadConsoleW", request.error)
     end
+
+    request.units_read.to_i32!
   end
-
-  private def self.read_console_blocking(handle : LibC::HANDLE, slice : Slice(UInt16)) : Int32
-    if 0 == LibC.ReadConsoleW(handle, slice, slice.size, out units_read, nil)
-      raise IO::Error.from_winerror("ReadConsoleW")
-    end
-    units_read.to_i32
-  end
-
-  record ReadRequest,
-    handle : LibC::HANDLE,
-    slice : Slice(UInt16),
-    iocp : LibC::HANDLE,
-    completion_key : Crystal::System::IOCP::CompletionKey
-
-  @@read_cv = ::Thread::ConditionVariable.new
-  @@read_requests = Deque(ReadRequest).new
-  @@bytes_read = Deque(Int32).new
-  @@mtx = ::Thread::Mutex.new
-
-  # Start a dedicated thread to block on reads from the console. Doesn't need an
-  # isolated execution context because there's no fiber communication (only
-  # thread communication) and only blocking I/O within the thread.
-  @@reader_thread = ::Thread.new { reader_loop }
 
   private def self.reader_loop
     while true
-      request = @@mtx.synchronize do
+      request = @@read_mtx.synchronize do
         loop do
           if entry = @@read_requests.shift?
             break entry
           end
-          @@read_cv.wait(@@mtx)
+          @@read_cv.wait(@@read_mtx)
         end
       end
+      slice = request.slice
 
-      bytes = read_console_blocking(request.handle, request.slice)
-
-      @@mtx.synchronize do
-        @@bytes_read << bytes
-        LibC.PostQueuedCompletionStatus(request.iocp, LibC::JOB_OBJECT_MSG_EXIT_PROCESS, request.completion_key.object_id, nil)
+      if LibC.ReadConsoleW(request.handle, slice, slice.size, out units_read, nil) == 0
+        request.error = WinError.value
+      else
+        request.units_read = units_read
       end
+
+      request.fiber.enqueue
     end
   end
 end

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -500,61 +500,74 @@ private module ConsoleUtils
     @@buffer = appender.to_slice
   end
 
-  class ReadRequest
-    getter handle : LibC::HANDLE
-    getter slice : Slice(UInt16)
-    getter fiber : Fiber
+  {% if !flag?(:without_mt) %}
+    private def self.read_console(handle : LibC::HANDLE, slice : Slice(UInt16)) : Int32
+      units_read = LibC::DWORD.zero
 
-    property units_read = LibC::DWORD.zero
-    property error = WinError::ERROR_SUCCESS
+      ret, error = Fiber.syscall do
+        {LibC.ReadConsoleW(handle, slice, slice.size, pointerof(units_read), nil), WinError.value}
+      end
+      raise IO::Error.from_os_error("ReadConsoleW", error) if ret == 0
 
-    def initialize(@handle : LibC::HANDLE, @slice : Slice(UInt16), @fiber : Fiber)
+      units_read.to_i32
     end
-  end
+  {% else %}
+    class ReadRequest
+      getter handle : LibC::HANDLE
+      getter slice : Slice(UInt16)
+      getter fiber : Fiber
 
-  @@read_mtx = ::Thread::Mutex.new
-  @@read_cv = ::Thread::ConditionVariable.new
-  @@read_requests = Deque(ReadRequest).new
-  @@read_thread = ::Thread.new { reader_loop }
+      property units_read = LibC::DWORD.zero
+      property error = WinError::ERROR_SUCCESS
 
-  private def self.read_console(handle : LibC::HANDLE, slice : Slice(UInt16)) : Int32
-    request = ReadRequest.new(handle, slice, ::Fiber.current)
-
-    @@read_mtx.synchronize do
-      @@read_requests << request
-      @@read_cv.signal
-    end
-
-    ::Fiber.suspend
-
-    unless request.error == WinError::ERROR_SUCCESS
-      raise IO::Error.from_os_error("ReadConsoleW", request.error)
+      def initialize(@handle : LibC::HANDLE, @slice : Slice(UInt16), @fiber : Fiber)
+      end
     end
 
-    request.units_read.to_i32!
-  end
+    @@read_mtx = ::Thread::Mutex.new
+    @@read_cv = ::Thread::ConditionVariable.new
+    @@read_requests = Deque(ReadRequest).new
+    @@read_thread = ::Thread.new { reader_loop }
 
-  private def self.reader_loop
-    while true
-      request = @@read_mtx.synchronize do
-        loop do
-          if entry = @@read_requests.shift?
-            break entry
+    private def self.read_console(handle : LibC::HANDLE, slice : Slice(UInt16)) : Int32
+      request = ReadRequest.new(handle, slice, ::Fiber.current)
+
+      @@read_mtx.synchronize do
+        @@read_requests << request
+        @@read_cv.signal
+      end
+
+      ::Fiber.suspend
+
+      unless request.error == WinError::ERROR_SUCCESS
+        raise IO::Error.from_os_error("ReadConsoleW", request.error)
+      end
+
+      request.units_read.to_i32!
+    end
+
+    private def self.reader_loop
+      while true
+        request = @@read_mtx.synchronize do
+          loop do
+            if entry = @@read_requests.shift?
+              break entry
+            end
+            @@read_cv.wait(@@read_mtx)
           end
-          @@read_cv.wait(@@read_mtx)
         end
-      end
-      slice = request.slice
+        slice = request.slice
 
-      if LibC.ReadConsoleW(request.handle, slice, slice.size, out units_read, nil) == 0
-        request.error = WinError.value
-      else
-        request.units_read = units_read
-      end
+        if LibC.ReadConsoleW(request.handle, slice, slice.size, out units_read, nil) == 0
+          request.error = WinError.value
+        else
+          request.units_read = units_read
+        end
 
-      request.fiber.enqueue
+        request.fiber.enqueue
+      end
     end
-  end
+  {% end %}
 end
 
 # Enable UTF-8 console I/O for the duration of program execution

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -517,14 +517,14 @@ private module ConsoleUtils
       getter slice : Slice(UInt16)
 
       getter iocp_handle : LibC::HANDLE
-      getter completion_key : IOCP::CompletionKey
+      getter completion_key : Crystal::System::IOCP::CompletionKey
 
       property units_read = LibC::DWORD.zero
       property error = WinError::ERROR_SUCCESS
 
       def initialize(@handle : LibC::HANDLE, @slice : Slice(UInt16))
-        @iocp_handle = EventLoop.current.iocp_handle
-        @completion_key = IOCP::CompletionKey.new(:read_console, ::Fiber.current)
+        @iocp_handle = Crystal::EventLoop.current.iocp_handle
+        @completion_key = Crystal::System::IOCP::CompletionKey.new(:read_console, ::Fiber.current)
       end
     end
 
@@ -534,7 +534,7 @@ private module ConsoleUtils
     @@read_thread = ::Thread.new { reader_loop }
 
     private def self.read_console(handle : LibC::HANDLE, slice : Slice(UInt16)) : Int32
-      request = ReadRequest.new(handle, slice, ::Fiber.current)
+      request = ReadRequest.new(handle, slice)
 
       @@read_mtx.synchronize do
         @@read_requests << request
@@ -574,7 +574,7 @@ private module ConsoleUtils
         ret = LibC.PostQueuedCompletionStatus(request.handle, 0, completion_key, nil)
 
         # can't recover: the fiber will never be resumed
-        Crystal.panic("PostQueuedCompletionStatus", WinError.value) if ret == 0
+        Crystal::System.panic("PostQueuedCompletionStatus", WinError.value) if ret == 0
       end
     end
   {% end %}

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -515,12 +515,16 @@ private module ConsoleUtils
     class ReadRequest
       getter handle : LibC::HANDLE
       getter slice : Slice(UInt16)
-      getter fiber : Fiber
+
+      getter iocp_handle : LibC::HANDLE
+      getter completion_key : IOCP::CompletionKey
 
       property units_read = LibC::DWORD.zero
       property error = WinError::ERROR_SUCCESS
 
-      def initialize(@handle : LibC::HANDLE, @slice : Slice(UInt16), @fiber : Fiber)
+      def initialize(@handle : LibC::HANDLE, @slice : Slice(UInt16))
+        @iocp_handle = EventLoop.current.iocp_handle
+        @completion_key = IOCP::CompletionKey.new(:read_console, ::Fiber.current)
       end
     end
 
@@ -564,7 +568,13 @@ private module ConsoleUtils
           request.units_read = units_read
         end
 
-        request.fiber.enqueue
+        # OPTIMIZE: after #17091 we can merely `request.fiber.enqueue` and drop
+        # the IOCP handle and CompletionKey
+        completion_key = request.completion_key.as(Void*).address
+        ret = LibC.PostQueuedCompletionStatus(request.handle, 0, completion_key, nil)
+
+        # can't recover: the fiber will never be resumed
+        Crystal.panic("PostQueuedCompletionStatus", WinError.value) if ret == 0
       end
     end
   {% end %}

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -500,7 +500,7 @@ private module ConsoleUtils
     @@buffer = appender.to_slice
   end
 
-  {% if !flag?(:without_mt) %}
+  {% if flag?(:execution_context) %}
     private def self.read_console(handle : LibC::HANDLE, slice : Slice(UInt16)) : Int32
       units_read = LibC::DWORD.zero
 

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -37,7 +37,6 @@ struct Crystal::System::IOCP
   class CompletionKey
     enum Tag
       ProcessRun
-      StdinRead
       Interrupt
       Timer
     end
@@ -85,7 +84,7 @@ struct Crystal::System::IOCP
       case tag
       in .process_run?
         number_of_bytes_transferred.in?(LibC::JOB_OBJECT_MSG_EXIT_PROCESS, LibC::JOB_OBJECT_MSG_ABNORMAL_EXIT_PROCESS)
-      in .stdin_read?, .interrupt?, .timer?
+      in .interrupt?, .timer?
         true
       end
     end

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -37,6 +37,7 @@ struct Crystal::System::IOCP
   class CompletionKey
     enum Tag
       ProcessRun
+      ReadConsole
       Interrupt
       Timer
     end
@@ -84,7 +85,7 @@ struct Crystal::System::IOCP
       case tag
       in .process_run?
         number_of_bytes_transferred.in?(LibC::JOB_OBJECT_MSG_EXIT_PROCESS, LibC::JOB_OBJECT_MSG_ABNORMAL_EXIT_PROCESS)
-      in .interrupt?, .timer?
+      in .read_console?, .interrupt?, .timer?
         true
       end
     end


### PR DESCRIPTION
With execution contexts, we can leverage `Fiber.syscall` to detach the blocking fiber during `ReadConsoleW` (if it blocks for too long).

Without MT (and with preview MT), we can directly pass the result through the request object.

We could drop the IOCP completion event and merely suspend and resume the fiber (mere thread sync), with the caveat that until #17091 it would lazily instantiate a `Crystal::Scheduler` on the thread...