### PR TITLE
Fix: leftover `:execution_context` flag [fixup #17100]

### DIFF
--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -500,7 +500,7 @@ private module ConsoleUtils
     @@buffer = appender.to_slice
   end
 
-  {% if flag?(:execution_context) %}
+  {% if !flag?(:without_mt) && !flag?(:preview_mt) || flag?(:execution_context) %}
     private def self.read_console(handle : LibC::HANDLE, slice : Slice(UInt16)) : Int32
       units_read = LibC::DWORD.zero
 


### PR DESCRIPTION
It slipped after merging #17099 and before merging #17100.