### PR TITLE
Refactor file lock

### DIFF
--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -162,41 +162,39 @@ module Crystal::System::FileDescriptor
     fd unless fd == -1
   end
 
-  private def system_flock_shared(blocking)
-    flock LibC::FlockOp::SH, blocking
-  end
+  private def system_lock(blocking : Bool, exclusive : Bool) : Nil
+    flags = exclusive ? LibC::FlockOp::EX : LibC::FlockOp::SH
 
-  private def system_flock_exclusive(blocking)
-    flock LibC::FlockOp::EX, blocking
-  end
+    # 1st attempt (always non-blocking)
+    ret = LibC.flock(fd, flags | LibC::FlockOp::NB)
+    errno = Errno.value
 
-  private def system_flock_unlock
-    flock LibC::FlockOp::UN
-  end
+    while true
+      return if ret == 0
 
-  private def flock(op : LibC::FlockOp, retry : Bool) : Nil
-    op |= LibC::FlockOp::NB
-
-    if retry
-      until flock(op)
-        sleep 0.1.seconds
-      end
-    else
-      flock(op) || raise IO::Error.from_errno("Error applying file lock: file is already locked", target: self)
-    end
-  end
-
-  private def flock(op) : Bool
-    if 0 == LibC.flock(fd, op)
-      true
-    else
-      errno = Errno.value
-      if errno.in?(Errno::EAGAIN, Errno::EWOULDBLOCK)
-        false
+      case errno
+      when Errno::EINTR
+        # retry
+      when Errno::EWOULDBLOCK, Errno::EAGAIN
+        raise IO::Error.from_os_error("Error applying file lock: file is already locked", errno, target: self) unless blocking
       else
-        raise IO::Error.from_os_error("Error applying or removing file lock", errno, target: self)
+        raise IO::Error.from_os_error("Error applying file lock", errno, target: self)
       end
+
+      ret, errno =
+        {% if !flag?(:without_mt) && !flag?(:preview_mt) || flag?(:execution_context) %}
+          ::Fiber.syscall { {LibC.flock(fd, flags), Errno.value} }
+        {% else %}
+          # poll at regular intervals (no unlock event)
+          sleep 100.milliseconds
+          {LibC.flock(fd, flags | LibC::FlockOp::NB), Errno.value}
+        {% end %}
     end
+  end
+
+  private def system_unlock : Nil
+    ret = LibC.flock(fd, LibC::FlockOp::UN)
+    raise IO::Error.from_errno("Error removing file lock", target: self) unless ret == 0
   end
 
   private def system_fsync(flush_metadata = true) : Nil

--- a/src/crystal/system/wasi/file_descriptor.cr
+++ b/src/crystal/system/wasi/file_descriptor.cr
@@ -30,20 +30,12 @@ module Crystal::System::FileDescriptor
     raise NotImplementedError.new "Crystal::System::FileDescriptor#system_reopen"
   end
 
-  private def system_flock_shared(blocking)
-    raise NotImplementedError.new "Crystal::System::File#system_flock_shared"
+  private def system_lock(blocking, exclusive)
+    raise NotImplementedError.new "Crystal::System::File#system_lock"
   end
 
-  private def system_flock_exclusive(blocking)
-    raise NotImplementedError.new "Crystal::System::File#system_flock_exclusive"
-  end
-
-  private def system_flock_unlock
-    raise NotImplementedError.new "Crystal::System::File#system_flock_unlock"
-  end
-
-  private def flock(op : LibC::FlockOp, blocking : Bool = true)
-    raise NotImplementedError.new "Crystal::System::File#flock"
+  private def system_unlock
+    raise NotImplementedError.new "Crystal::System::File#system_unlock"
   end
 
   private def system_echo(enable : Bool)

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -252,75 +252,52 @@ module Crystal::System::FileDescriptor
     end
   end
 
-  private def system_flock_shared(blocking : Bool) : Nil
-    flock(false, blocking)
-  end
+  private def system_lock(blocking : Bool, exclusive : Bool) : Nil
+    flags = exclusive ? LibC::LOCKFILE_EXCLUSIVE_LOCK : 0_u32
 
-  private def system_flock_exclusive(blocking : Bool) : Nil
-    flock(true, blocking)
-  end
-
-  private def system_flock_unlock : Nil
-    unlock_file(windows_handle)
-  end
-
-  private def flock(exclusive, retry)
-    flags = 0_u32
-    flags |= LibC::LOCKFILE_FAIL_IMMEDIATELY if !retry || system_blocking?
-    flags |= LibC::LOCKFILE_EXCLUSIVE_LOCK if exclusive
-
-    handle = windows_handle
-    if retry && system_blocking?
-      until lock_file(handle, flags)
-        sleep 0.1.seconds
+    if blocking && !system_blocking?
+      IOCP.simple_overlapped_operation(Crystal::EventLoop.current.iocp_handle, self, "LockFileEx") do |operation|
+        LibC.LockFileEx(windows_handle, flags, 0, 0xFFFF_FFFF, 0xFFFF_FFFF, operation)
       end
     else
-      lock_file(handle, flags) || raise IO::Error.from_winerror("Error applying file lock: file is already locked", target: self)
-    end
-  end
+      overlapped = LibC::OVERLAPPED.new
 
-  private def lock_file(handle, flags)
-    IOCP::IOOverlappedOperation.run(Crystal::EventLoop.current.iocp_handle, handle) do |operation|
-      result = LibC.LockFileEx(handle, flags, 0, 0xFFFF_FFFF, 0xFFFF_FFFF, operation)
+      # 1st attempt (always non-blocking)
+      ret = LibC.LockFileEx(windows_handle, flags | LibC::LOCKFILE_FAIL_IMMEDIATELY, 0, 0xFFFF_FFFF, 0xFFFF_FFFF, pointerof(overlapped))
+      error = WinError.value
 
-      if result == 0
-        case error = WinError.value
-        when .error_io_pending?
-          # the operation is running asynchronously; do nothing
-        when .error_lock_violation?
-          # synchronous failure
-          return false
+      while true
+        return unless ret == 0
+
+        if error == WinError::ERROR_LOCK_VIOLATION
+          raise IO::Error.from_os_error("Error applying file lock: file is already locked", error, target: self) unless blocking
         else
-          raise IO::Error.from_os_error("LockFileEx", error, target: self)
+          raise IO::Error.from_os_error("Error applying file lock", error, target: self)
         end
-      else
-        return true
-      end
 
-      operation.wait_for_result(nil) do |error|
-        raise IO::Error.from_os_error("LockFileEx", error, target: self)
+        ret, error =
+          {% if !flag?(:without_mt) && !flag?(:preview_mt) || flag?(:execution_context) %}
+            ::Fiber.syscall do
+              {LibC.LockFileEx(windows_handle, flags, 0, 0xFFFF_FFFF, 0xFFFF_FFFF, pointerof(overlapped)), WinError.value}
+            end
+          {% else %}
+            # poll at regular intervals (no unlock event)
+            sleep 100.milliseconds
+            {LibC.LockFileEx(windows_handle, flags | LibC::LOCKFILE_FAIL_IMMEDIATELY, 0, 0xFFFF_FFFF, 0xFFFF_FFFF, pointerof(overlapped)), WinError.value}
+          {% end %}
       end
-
-      true
     end
   end
 
-  private def unlock_file(handle)
-    IOCP::IOOverlappedOperation.run(Crystal::EventLoop.current.iocp_handle, handle) do |operation|
-      result = LibC.UnlockFileEx(handle, 0, 0xFFFF_FFFF, 0xFFFF_FFFF, operation)
-
-      if result == 0
-        error = WinError.value
-        unless error.error_io_pending?
-          raise IO::Error.from_os_error("UnlockFileEx", error, target: self)
-        end
-      else
-        return
+  private def system_unlock : Nil
+    if !system_blocking?
+      IOCP.simple_overlapped_operation(Crystal::EventLoop.current.iocp_handle, self, "UnlockFileEx") do |operation|
+        LibC.UnlockFileEx(windows_handle, 0, 0xFFFF_FFFF, 0xFFFF_FFFF, operation)
       end
-
-      operation.wait_for_result(nil) do |error|
-        raise IO::Error.from_os_error("UnlockFileEx", error, target: self)
-      end
+    else
+      overlapped = LibC::OVERLAPPED.new
+      ret = LibC.UnlockFileEx(windows_handle, 0, 0xFFFF_FFFF, 0xFFFF_FFFF, pointerof(overlapped))
+      raise IO::Error.from_winerror("UnlockFileEx", target: self) if ret == 0
     end
   end
 

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -336,6 +336,27 @@ struct Crystal::System::IOCP
     end
   end
 
+  def self.simple_overlapped_operation(iocp_handle, file_descriptor, method, &)
+    IOOverlappedOperation.run(iocp_handle, file_descriptor.windows_handle) do |operation|
+      result = yield operation
+
+      if result == 0
+        case error = WinError.value
+        when WinError::ERROR_IO_PENDING
+          # the operation is running asynchronously; do nothing
+        else
+          raise IO::Error.from_os_error(method, error, target: file_descriptor)
+        end
+      else
+        return
+      end
+
+      operation.wait_for_result(nil) do |error|
+        raise IO::Error.from_os_error(method, error, target: file_descriptor)
+      end
+    end
+  end
+
   def self.overlapped_operation(iocp_handle, file_descriptor, method, timeout, *, offset = nil, writing = false, &)
     handle = file_descriptor.windows_handle
     seekable = LibC.SetFilePointerEx(handle, 0, out original_offset, IO::Seek::Current) != 0

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -244,8 +244,6 @@ class IO::FileDescriptor < IO
     @fd_lock.reference { system_fsync(flush_metadata) }
   end
 
-  # TODO: use fcntl/lockf instead of flock (which doesn't lock over NFS)
-
   def flock_shared(blocking = true, &)
     flock_shared blocking
     begin
@@ -258,7 +256,7 @@ class IO::FileDescriptor < IO
   # Places a shared advisory lock. More than one process may hold a shared lock for a given file descriptor at a given time.
   # `IO::Error` is raised if *blocking* is set to `false` and an existing exclusive lock is set.
   def flock_shared(blocking : Bool = true) : Nil
-    system_flock_shared(blocking)
+    system_lock(blocking, exclusive: false)
   end
 
   def flock_exclusive(blocking = true, &)
@@ -273,12 +271,12 @@ class IO::FileDescriptor < IO
   # Places an exclusive advisory lock. Only one process may hold an exclusive lock for a given file descriptor at a given time.
   # `IO::Error` is raised if *blocking* is set to `false` and any existing lock is set.
   def flock_exclusive(blocking : Bool = true) : Nil
-    system_flock_exclusive(blocking)
+    system_lock(blocking, exclusive: true)
   end
 
   # Removes an existing advisory lock held by this process.
   def flock_unlock : Nil
-    system_flock_unlock
+    system_unlock
   end
 
   # Finalizes the file descriptor resource.


### PR DESCRIPTION
Simplifies the system interface:

- `#system_lock(blocking, exclusive)`
- `#system_unlock`

Refactors the algorithm to leverage `Fiber.syscall` when available instead of polling.

The first attempt is always non-blocking, then further attempts will be blocking with execution contexts or non-blocking with regular polling for the legacy runtimes (without_mt, preview_mt).

On Windows, when the file handle has been opened with the OVERLAPPED flag, we use an overlapped operations when blocking, and otherwise fallback to the algorithm described above.