### PR TITLE
Fix: skip Windows registry MIME entries with an invalid Content Type

### DIFF
--- a/src/crystal/system/win32/mime.cr
+++ b/src/crystal/system/win32/mime.cr
@@ -14,7 +14,7 @@ module Crystal::System::MIME
         if content_type
           begin
             ::MIME.register String.from_utf16(name), content_type
-          rescue
+          rescue ArgumentError
             # skip registry entries with an invalid Content Type value
           end
         end

--- a/src/crystal/system/win32/mime.cr
+++ b/src/crystal/system/win32/mime.cr
@@ -12,7 +12,11 @@ module Crystal::System::MIME
       WindowsRegistry.open?(LibC::HKEY_CLASSES_ROOT, name) do |sub_handle|
         content_type = WindowsRegistry.get_string(sub_handle, CONTENT_TYPE)
         if content_type
-          ::MIME.register String.from_utf16(name), content_type
+          begin
+            ::MIME.register String.from_utf16(name), content_type
+          rescue
+            # skip registry entries with an invalid Content Type value
+          end
         end
       end
     end


### PR DESCRIPTION
On Windows, `Crystal::System::MIME.load` reads MIME types from the registry and calls `MIME.register` for each `.<ext>\Content Type` entry. If any entry holds an empty or malformed value, `MIME.register` raises `ArgumentError` ("Invalid media type: ...") which is unrescued, so a single bad registry entry aborts MIME initialization and crashes the first `MIME.from_extension` call.

The Unix loader already guards each source with a bare `rescue` (`src/crystal/system/unix/mime.cr`). This mirrors that: the per-entry `register` is wrapped so an invalid entry is skipped instead of taking down the whole load.

Fixes #17103.

The failing path is Windows-registry-specific, so I couldn't add a portable spec that exercises `load` directly. I confirmed the behavior of the guarded loop with the same call `load` makes (registering a batch where one entry has an empty Content Type): before the guard the `ArgumentError` aborts the loop, after it the bad entry is skipped and the remaining extensions register.
