### PR TITLE
Fix: add `max_nesting` to `YAML::PullParser`

### DIFF
--- a/spec/std/yaml/yaml_pull_parser_spec.cr
+++ b/spec/std/yaml/yaml_pull_parser_spec.cr
@@ -122,6 +122,22 @@ module YAML
       end
     end
 
+    it "prevents stack overflow for arrays" do
+      parser = YAML::PullParser.new(("[" * 513) + ("]" * 513))
+      expect_raises YAML::ParseException, "Nesting of 513 is too deep" do
+        until parser.read_next == EventKind::NONE
+        end
+      end
+    end
+
+    it "prevents stack overflow for hashes" do
+      parser = YAML::PullParser.new(("{" * 513) + ("}" * 513))
+      expect_raises YAML::ParseException, "Nesting of 513 is too deep" do
+        until parser.read_next == EventKind::NONE
+        end
+      end
+    end
+
     describe "skip" do
       it "scalar" do
         parser = PullParser.new("[1, 2]")

--- a/src/yaml/pull_parser.cr
+++ b/src/yaml/pull_parser.cr
@@ -10,10 +10,16 @@
 class YAML::PullParser
   protected getter content
 
+  # :nodoc:
+  #
+  # Maximum structural depth (nested sequences and mappings) allowed.
+  property max_nesting = 512
+
   def initialize(@content : String | IO)
     @parser = Pointer(Void).malloc(LibYAML::PARSER_SIZE).as(LibYAML::Parser*)
     @event = LibYAML::Event.new
     @closed = false
+    @nesting = 0
 
     LibYAML.yaml_parser_initialize(@parser)
 
@@ -121,6 +127,14 @@ class YAML::PullParser
       end
       raise msg, *location, context_info
     end
+
+    case kind
+    when EventKind::SEQUENCE_START, EventKind::MAPPING_START
+      increase_nesting
+    when EventKind::SEQUENCE_END, EventKind::MAPPING_END
+      decrease_nesting
+    end
+
     kind
   end
 
@@ -337,5 +351,16 @@ class YAML::PullParser
 
   def raise(msg : String, line_number = self.start_line, column_number = self.start_column, context_info = nil) : NoReturn
     ::raise ParseException.new(msg, line_number, column_number, context_info)
+  end
+
+  private def increase_nesting
+    @nesting += 1
+    if @nesting > @max_nesting
+      raise "Nesting of #{@nesting} is too deep"
+    end
+  end
+
+  private def decrease_nesting
+    @nesting -= 1
   end
 end


### PR DESCRIPTION
Prevents stack overflows when parsing a deeply nested YAML file.