### PR TITLE
Fix: add alias vs anchor ratio check to `YAML::PullParser`

### DIFF
--- a/spec/std/yaml/yaml_pull_parser_spec.cr
+++ b/spec/std/yaml/yaml_pull_parser_spec.cr
@@ -138,6 +138,24 @@ module YAML
       end
     end
 
+    it "prevents excessive node expansions (billion-laugh attacks)" do
+      parser = PullParser.new(<<-YAML)
+      a: &a ["lol","lol","lol","lol","lol","lol","lol","lol","lol"]
+      b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]
+      c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]
+      d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]
+      e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]
+      f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]
+      g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]
+      h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]
+      i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]
+      YAML
+      expect_raises(ParseException, "Document contains excessive aliasing") do
+        until parser.read_next == EventKind::NONE
+        end
+      end
+    end
+
     describe "skip" do
       it "scalar" do
         parser = PullParser.new("[1, 2]")

--- a/src/yaml/pull_parser.cr
+++ b/src/yaml/pull_parser.cr
@@ -15,11 +15,35 @@ class YAML::PullParser
   # Maximum structural depth (nested sequences and mappings) allowed.
   property max_nesting = 512
 
+  # :nodoc:
+  #
+  # If true, evaluates the alias/anchor ratio to avoid excessive expansion of
+  # aliases.
+  property enforce_alias_anchor_ratio = true
+
+  # :nodoc:
+  #
+  # Minimum number of aliases required before starting to evaluate the
+  # alias/anchor ratio. This avoids affecting smaller documents.
+  property alias_anchor_min_aliases = 100
+
+  # :nodoc:
+  #
+  # The multiplier for the alias/anchor ratio evaluation. An error will be
+  # raised when `aliases > multiplier * anchors` once `min_aliases` has been
+  # reached.
+  property alias_anchor_multiplier = 10
+
   def initialize(@content : String | IO)
     @parser = Pointer(Void).malloc(LibYAML::PARSER_SIZE).as(LibYAML::Parser*)
     @event = LibYAML::Event.new
     @closed = false
+
     @nesting = 0
+    @anchors = 0
+    @aliases = 0
+    @anchor_scope = Hash(Int32, {String, Int32}).new
+    @anchor_costs = Hash(String, Int32).new
 
     LibYAML.yaml_parser_initialize(@parser)
 
@@ -115,13 +139,16 @@ class YAML::PullParser
       raise msg, *location, context_info
     end
 
-    @anchor = read_anchor
+    read_anchor
+    @anchors += 1 if @anchor
 
     case kind
     when EventKind::SEQUENCE_START, EventKind::MAPPING_START
       increase_nesting
     when EventKind::SEQUENCE_END, EventKind::MAPPING_END
       decrease_nesting
+    when EventKind::ALIAS
+      increase_alias
     end
 
     kind
@@ -348,7 +375,7 @@ class YAML::PullParser
       else
         Pointer(UInt8).null
       end
-    anchor ? String.new(anchor) : nil
+    @anchor = anchor ? String.new(anchor) : nil
   end
 
   def raise(msg : String, line_number = self.start_line, column_number = self.start_column, context_info = nil) : NoReturn
@@ -357,12 +384,33 @@ class YAML::PullParser
 
   private def increase_nesting
     @nesting += 1
+
     if @nesting > @max_nesting
       raise "Nesting of #{@nesting} is too deep"
+    end
+
+    if anchor = @anchor
+      @anchor_scope[@nesting] = {anchor, @aliases}
     end
   end
 
   private def decrease_nesting
+    if scope = @anchor_scope.delete(@nesting)
+      anchor, aliases = scope
+      @anchor_costs[anchor] = @aliases - aliases
+    end
+
     @nesting -= 1
+  end
+
+  private def increase_alias
+    aliases = @anchor_costs[@anchor]? || 0
+    @aliases += aliases + 1
+
+    if @enforce_alias_anchor_ratio &&
+       @aliases > @alias_anchor_min_aliases &&
+       @aliases > @alias_anchor_multiplier * @anchors
+      raise "Document contains excessive aliasing"
+    end
   end
 end


### PR DESCRIPTION
Prevents excessive expansion of aliases.