### PR TITLE
Add missing_option to OptionParser example

### DIFF
--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -30,6 +30,11 @@
 #     STDERR.puts parser
 #     exit(1)
 #   end
+#   parser.missing_option do |flag|
+#     STDERR.puts "ERROR: #{flag} is missing an argument."
+#     STDERR.puts parser
+#     exit(1)
+#   end
 # end
 #
 # destination = destination.upcase if upcase


### PR DESCRIPTION
This is adds a small detail that I think would be worth adding: handling of options without arguments. Most real applications will use this, so I think adding it into the example would help newbies(We already handle invalid options, why not missing arguments to options?)