### PR TITLE
OpenBSD now supports EVFILT_USER

### DIFF
--- a/src/crystal/event_loop/kqueue.cr
+++ b/src/crystal/event_loop/kqueue.cr
@@ -6,10 +6,6 @@ class Crystal::EventLoop::Kqueue < Crystal::EventLoop::Polling
   INTERRUPT_IDENTIFIER =  9
   TIMER_IDENTIFIER     = 10
 
-  {% unless LibC.has_constant?(:EVFILT_USER) %}
-    @pipe = uninitialized LibC::Int[2]
-  {% end %}
-
   def initialize(parallelism : Int32)
     # the kqueue instance
     @kqueue = System::Kqueue.new
@@ -17,15 +13,10 @@ class Crystal::EventLoop::Kqueue < Crystal::EventLoop::Polling
     # notification to interrupt a run
     @interrupted = Atomic(Bool).new(false)
 
-    {% if LibC.has_constant?(:EVFILT_USER) %}
-      @kqueue.kevent(
-        INTERRUPT_IDENTIFIER,
-        LibC::EVFILT_USER,
-        LibC::EV_ADD | LibC::EV_ENABLE | LibC::EV_CLEAR)
-    {% else %}
-      @pipe = System::FileDescriptor.system_pipe
-      @kqueue.kevent(@pipe[0], LibC::EVFILT_READ, LibC::EV_ADD)
-    {% end %}
+    @kqueue.kevent(
+      INTERRUPT_IDENTIFIER,
+      LibC::EVFILT_USER,
+      LibC::EV_ADD | LibC::EV_ENABLE | LibC::EV_CLEAR)
   end
 
   {% if flag?(:without_mt) %}
@@ -38,16 +29,10 @@ class Crystal::EventLoop::Kqueue < Crystal::EventLoop::Polling
 
       @interrupted.set(false, :relaxed)
 
-      {% if LibC.has_constant?(:EVFILT_USER) %}
-        @kqueue.kevent(
-          INTERRUPT_IDENTIFIER,
-          LibC::EVFILT_USER,
-          LibC::EV_ADD | LibC::EV_ENABLE | LibC::EV_CLEAR)
-      {% else %}
-        @pipe.each { |fd| LibC.close(fd) }
-        @pipe = System::FileDescriptor.system_pipe
-        @kqueue.kevent(@pipe[0], LibC::EVFILT_READ, LibC::EV_ADD)
-      {% end %}
+      @kqueue.kevent(
+        INTERRUPT_IDENTIFIER,
+        LibC::EVFILT_USER,
+        LibC::EV_ADD | LibC::EV_ENABLE | LibC::EV_CLEAR)
 
       system_set_timer(@timers.next_ready?)
 
@@ -84,20 +69,10 @@ class Crystal::EventLoop::Kqueue < Crystal::EventLoop::Polling
   end
 
   private def process_interrupt?(kevent)
-    {% if LibC.has_constant?(:EVFILT_USER) %}
-      if kevent.value.filter == LibC::EVFILT_USER
-        @interrupted.set(false, :relaxed) if kevent.value.ident == INTERRUPT_IDENTIFIER
-        return true
-      end
-    {% else %}
-      if kevent.value.filter == LibC::EVFILT_READ && kevent.value.ident == @pipe[0]
-        ident = 0
-        ret = LibC.read(@pipe[0], pointerof(ident), sizeof(Int32))
-        raise RuntimeError.from_errno("read") if ret == -1
-        @interrupted.set(false, :relaxed) if ident == INTERRUPT_IDENTIFIER
-        return true
-      end
-    {% end %}
+    if kevent.value.filter == LibC::EVFILT_USER
+      @interrupted.set(false, :relaxed) if kevent.value.ident == INTERRUPT_IDENTIFIER
+      return true
+    end
     false
   end
 
@@ -142,15 +117,9 @@ class Crystal::EventLoop::Kqueue < Crystal::EventLoop::Polling
   end
 
   def interrupt : Nil
-    return if @interrupted.swap(true, :relaxed)
-
-    {% if LibC.has_constant?(:EVFILT_USER) %}
+    unless @interrupted.swap(true, :relaxed)
       @kqueue.kevent(INTERRUPT_IDENTIFIER, LibC::EVFILT_USER, 0, LibC::NOTE_TRIGGER)
-    {% else %}
-      ident = INTERRUPT_IDENTIFIER
-      ret = LibC.write(@pipe[1], pointerof(ident), sizeof(Int32))
-      raise RuntimeError.from_errno("write") if ret == -1
-    {% end %}
+    end
   end
 
   protected def system_add(fd : Int32, index : Polling::Arena::Index) : Nil

--- a/src/lib_c/x86_64-openbsd/c/sys/event.cr
+++ b/src/lib_c/x86_64-openbsd/c/sys/event.cr
@@ -1,18 +1,21 @@
 require "../time"
 
 lib LibC
-  EVFILT_READ  = -1_i16
-  EVFILT_WRITE = -2_i16
-  EVFILT_TIMER = -7_i16
+  EVFILT_READ  =  -1_i16
+  EVFILT_WRITE =  -2_i16
+  EVFILT_TIMER =  -7_i16
+  EVFILT_USER  = -10_i16
 
   EV_ADD     = 0x0001_u16
   EV_DELETE  = 0x0002_u16
+  EV_ENABLE  = 0x0004_u16
   EV_ONESHOT = 0x0010_u16
   EV_CLEAR   = 0x0020_u16
   EV_EOF     = 0x8000_u16
   EV_ERROR   = 0x4000_u16
 
   NOTE_NSECONDS = 0x00000003_u32
+  NOTE_TRIGGER  = 0x01000000_u32
 
   struct Kevent
     ident : SizeT # UintptrT


### PR DESCRIPTION
OpenBSD added support for `EVFILT_USER` in Openbsd 7.8. Not only can we use it, but we can drop the custom pipe fallback to interrupt the kqueue event loop.