### PR TITLE
Fix: sysctl name is hw.ncpu [fixup #17012]

### DIFF
--- a/spec/std/system_spec.cr
+++ b/spec/std/system_spec.cr
@@ -23,7 +23,7 @@ describe System do
             ["getconf", "_NPROCESSORS_ONLN"],
             ["nproc", "--all"],
             ["grep", "-sc", "^processor", "/proc/cpuinfo"],
-            ["sysctl", "-n", "hw.cpu"],
+            ["sysctl", "-n", "hw.ncpu"],
           ].find_value(0) do |args|
             Process.capture_result?(args).try(&.output.to_i)
           end


### PR DESCRIPTION
Running specs on OpenBSD I realized this spec started failing.