### PR TITLE
Revert "Codegen doesn't materialize an unused yield block value in debug builds"

### DIFF
--- a/spec/compiler/codegen/block_spec.cr
+++ b/spec/compiler/codegen/block_spec.cr
@@ -1602,27 +1602,6 @@ describe "Code gen: block" do
       CRYSTAL
   end
 
-  it "doesn't materialize an unused yield block value in debug builds (#12693)" do
-    mod = codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
-      def foo : Nil
-        yield Pointer(Bool).new(0).value
-        nil
-      end
-
-      def bar
-        x = 11111
-        foo do |y|
-          x = 22222 if y
-        end
-        x
-      end
-
-      bar
-      CRYSTAL
-
-    mod.to_s.should_not contain(%(alloca %"(Int32 | Nil)"))
-  end
-
   it "doesn't crash if yield exp has no type (#12670)" do
     codegen(<<-CRYSTAL)
       def foo : String?

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1840,9 +1840,7 @@ module Crystal
 
           set_ensure_exception_handler(block)
 
-          request_value(@needs_value) do
-            accept block.body
-          end
+          request_value(block.body)
         end
 
         phi.add @last, block.body.type?, last: true


### PR DESCRIPTION
Reverts crystal-lang/crystal#17119

This patch appears to be causing codegen error #17125