### PR TITLE
Set `a_def.raises` recursively, not just on caller

### DIFF
--- a/spec/compiler/codegen/exception_spec.cr
+++ b/spec/compiler/codegen/exception_spec.cr
@@ -1136,6 +1136,33 @@ describe "Code gen: exception" do
       CRYSTAL
   end
 
+  it "propagates raise status back to a caller analyzed before the callee was known to raise" do
+    run(<<-CRYSTAL).to_i.should eq(1)
+      require "prelude"
+
+      def oops(msg : String) : NoReturn
+        check false
+        raise msg
+      end
+
+      def check(should_raise)
+        oops "boom" if should_raise
+      end
+
+      # Since `oops` calls `check false`, this analyzes `check` first, which
+      # will be marked with `a_def.raises = false`.
+      oops "prime" rescue nil
+
+      x = 0
+      begin
+        check true
+      rescue
+        x = 1
+      end
+      x
+      CRYSTAL
+  end
+
   it "doesn't crash on #1988" do
     run(<<-CRYSTAL).to_i.should eq(42)
       require "prelude"

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -66,15 +66,34 @@ module Crystal
   class CleanupTransformer < Transformer
     @transformed : Set(Def)
 
+    # The callers for each method, used to propagate `raises`
+    @callers : Hash(Def, Array(Def))
+
     # The current method we are processing
     @current_def : Def?
 
     def initialize(@program : Program)
       @transformed = Set(Def).new.compare_by_identity
+      @callers = Hash(Def, Array(Def)).new.compare_by_identity
       @exhaustiveness_checker = ExhaustivenessChecker.new(@program)
       @def_nest_count = 0
       @last_is_truthy = false
       @last_is_falsey = false
+    end
+
+    # Recursively mark all methods that call `a_def` as raising when `a_def`
+    # is found to raise.
+    private def propagate_raises(a_def : Def) : Nil
+      return if a_def.raises?
+
+      worklist = [a_def]
+      while current = worklist.pop?
+        next if current.raises?
+        current.raises = true
+        @callers[current]?.try &.each do |caller|
+          worklist << caller unless caller.raises?
+        end
+      end
     end
 
     def inside_def!
@@ -594,6 +613,8 @@ module Crystal
         current_def = @current_def
 
         target_defs.each do |target_def|
+          (@callers[target_def] ||= [] of Def) << current_def if current_def
+
           if @transformed.add?(target_def)
             node.bubbling_exception do
               @current_def = target_def
@@ -605,8 +626,8 @@ module Crystal
           end
 
           # If the current call targets a method that raises, the method
-          # where the call happens also raises.
-          current_def.raises = true if current_def && target_def.raises?
+          # where the call happens also raises, recursively up the chain.
+          propagate_raises(current_def) if current_def && target_def.raises?
         end
 
         if node.target_defs.not_nil!.empty?


### PR DESCRIPTION
Methods that raise behind an `if false` guard clause (including when passing a `false` literal from outside the method) may not be marked as `raises`. Tracking which methods call which recursively, rather than just on direct callers, ensures that `raises` gets set in this case.

This was the cause of some of at least some of the spec failures for https://github.com/crystal-lang/crystal/pull/17124.

Fixes #17127