### PR TITLE
Fix short option order in docs help

### DIFF
--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -41,10 +41,10 @@ class Crystal::Command
         project_info.source_url_pattern = value
       end
 
-      opts.on("--output=DIR", "-o DIR", "Set the output directory (default: #{output_directory})") do |value|
+      opts.on("-o DIR", "--output=DIR", "Set the output directory (default: #{output_directory})") do |value|
         output_directory = value
       end
-      opts.on("--format=FORMAT", "-f FORMAT", "Set the output format [#{VALID_OUTPUT_FORMATS.join(", ")}] (default: #{output_format})") do |value|
+      opts.on("-f FORMAT", "--format=FORMAT", "Set the output format [#{VALID_OUTPUT_FORMATS.join(", ")}] (default: #{output_format})") do |value|
         if !VALID_OUTPUT_FORMATS.includes? value
           STDERR.puts "Invalid format '#{value}'"
           abort! opts, :USAGE_ERROR
@@ -64,7 +64,7 @@ class Crystal::Command
         project_info.base_path = value
       end
 
-      opts.on("--sitemap-base-url=URL", "-b URL", "Set the sitemap base URL and generates sitemap") do |value|
+      opts.on("-b URL", "--sitemap-base-url=URL", "Set the sitemap base URL and generates sitemap") do |value|
         sitemap_base_url = value
       end
 


### PR DESCRIPTION
Hi Crystal team!

I’m looking forward to the release of version 1.21.

While testing the changes from #16914, I noticed that some `crystal docs --help` options showed the long option before the short option, unlike the rest of the compiler help output.

This PR updates those option definitions so the short option is listed first.

<img width="893" height="551" alt="screenshot" src="https://github.com/user-attachments/assets/3f48f5fd-6a54-4b1f-863d-cd31591c73b5" />
