### PR TITLE
Codegen doesn't materialize an unused yield block value in debug builds, pt. 2

### DIFF
--- a/spec/compiler/codegen/block_spec.cr
+++ b/spec/compiler/codegen/block_spec.cr
@@ -1602,6 +1602,27 @@ describe "Code gen: block" do
       CRYSTAL
   end
 
+  it "doesn't materialize an unused yield block value in debug builds (#12693)" do
+    mod = codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
+      def foo : Nil
+        yield Pointer(Bool).new(0).value
+        nil
+      end
+
+      def bar
+        x = 11111
+        foo do |y|
+          x = 22222 if y
+        end
+        x
+      end
+
+      bar
+      CRYSTAL
+
+    mod.to_s.should_not contain(%(alloca %"(Int32 | Nil)"))
+  end
+
   it "doesn't crash if yield exp has no type (#12670)" do
     codegen(<<-CRYSTAL)
       def foo : String?

--- a/spec/compiler/codegen/block_spec.cr
+++ b/spec/compiler/codegen/block_spec.cr
@@ -1602,6 +1602,28 @@ describe "Code gen: block" do
       CRYSTAL
   end
 
+  it "codegens proc forwarding from an unused yielded block value (#17125)" do
+    run(<<-CRYSTAL).to_i.should eq(1)
+      require "prelude"
+
+      private record Foo,
+        proc : String ->
+
+      def bar(&proc : String ->)
+        baz(&proc)
+      end
+
+      def baz(&proc : String ->)
+      end
+
+      ([] of Foo).each do |foo|
+        bar(&foo.proc)
+      end
+
+      1
+      CRYSTAL
+  end
+
   it "doesn't materialize an unused yield block value in debug builds (#12693)" do
     mod = codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
       def foo : Nil

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -320,7 +320,7 @@ class Crystal::CodeGenVisitor
   end
 
   def codegen_call_with_block_as_fun_literal(node, fun_literal, self_type, call_args)
-    accept fun_literal
+    request_value(fun_literal)
     call_args.push @last
 
     target_def = node.target_def

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1840,7 +1840,9 @@ module Crystal
 
           set_ensure_exception_handler(block)
 
-          request_value(block.body)
+          request_value(@needs_value) do
+            accept block.body
+          end
         end
 
         phi.add @last, block.body.type?, last: true


### PR DESCRIPTION
Follow up to #17119 with a regression fix. Closes #12693 