### PR TITLE
Add .lattice-cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ devenv.local.yaml
 
 # pre-commit
 .pre-commit-config.yaml
+
+# LSPs
+.lattice-cache


### PR DESCRIPTION
Adds .lattice-cache to .gitignore. Lattice + Ameba(or ameba-ls) is currently one of the most used LSPs for Crystal and the one I happen to use; So I think it isn't too far fetched to add its cache to .gitignore. This will make it easier for new contributors to not accidentally contribute .lattice-cache files and more.

I'd understand if this gets closed since it could come off as endorsement for Lattice, but I think it would be positive to the DX of the compiler.