### PR TITLE
Fix: check endianness using `IO::ByteFormat` in `Crystal::System::ELF` [fixup #16939]

### DIFF
--- a/src/crystal/system/unix/elf.cr
+++ b/src/crystal/system/unix/elf.cr
@@ -81,7 +81,7 @@ class Crystal::System::ELF
   def valid? : Bool
     header.value.ei_magic.to_slice == LibELF::MAGIC.to_slice &&
       header.value.ei_class == {% if flag?(:bits64) %} LibELF::CLASS_64 {% else %} LibELF::CLASS_32 {% end %} &&
-      header.value.ei_data == {% if flag?(:endianness) == "big" %} LibELF::ENDIAN_BIG {% else %} LibELF::ENDIAN_LITTLE {% end %} &&
+      header.value.ei_data == {% if IO::ByteFormat::SystemEndian == IO::ByteFormat::BigEndian %} LibELF::ENDIAN_BIG {% else %} LibELF::ENDIAN_LITTLE {% end %} &&
       header.value.ei_version == 1 &&
       header.value.e_version == 1 &&
       header.value.e_ehsize == sizeof(LibELF::Header)


### PR DESCRIPTION
See https://github.com/crystal-lang/crystal/pull/16939#discussion_r3593645637