### PR TITLE
Reject unrecognized HTTP `Transfer-Encoding` header

### DIFF
--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -172,6 +172,27 @@ class HTTP::Client::Response
           Response.from_io?(IO::Memory.new("HTTP/1.0 42\n\nNot an HTTP response"))
         end
       end
+
+      it "rejects unhandled Transfer-Encoding" do
+        Response.from_io?(IO::Memory.new(<<-HTTP)).should be_nil
+          HTTP/1.1 200
+          Transfer-Encoding: deflate
+
+          Hello
+
+          HTTP
+      end
+
+      it "rejects unknown Transfer-Encoding" do
+        Response.from_io?(IO::Memory.new(<<-HTTP)).should be_nil
+          HTTP/1.1 200
+          Transfer-Encoding: foobar
+
+          Hello
+
+
+          HTTP
+      end
     end
 
     it "doesn't sets content length for 1xx, 204 or 304" do

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -289,6 +289,26 @@ module HTTP
           request.should eq HTTP::Status::REQUEST_HEADER_FIELDS_TOO_LARGE
         end
       end
+
+      it "rejects unhandled Transfer-Encoding" do
+        request = Request.from_io(IO::Memory.new(<<-HTTP)).should eq HTTP::Status::BAD_REQUEST
+          GET / HTTP/1.1
+          Transfer-Encoding: deflate
+
+          Hello
+
+          HTTP
+      end
+
+      it "rejects unknown Transfer-Encoding" do
+        request = Request.from_io(IO::Memory.new(<<-HTTP)).should eq HTTP::Status::BAD_REQUEST
+          GET / HTTP/1.1
+          Transfer-Encoding: foobar
+
+          Hello
+
+          HTTP
+      end
     end
 
     describe "keep-alive" do

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -291,7 +291,7 @@ module HTTP
       end
 
       it "rejects unhandled Transfer-Encoding" do
-        request = Request.from_io(IO::Memory.new(<<-HTTP)).should eq HTTP::Status::BAD_REQUEST
+        request = Request.from_io(IO::Memory.new(<<-HTTP)).should eq HTTP::Status::NOT_IMPLEMENTED
           GET / HTTP/1.1
           Transfer-Encoding: deflate
 
@@ -301,7 +301,7 @@ module HTTP
       end
 
       it "rejects unknown Transfer-Encoding" do
-        request = Request.from_io(IO::Memory.new(<<-HTTP)).should eq HTTP::Status::BAD_REQUEST
+        request = Request.from_io(IO::Memory.new(<<-HTTP)).should eq HTTP::Status::NOT_IMPLEMENTED
           GET / HTTP/1.1
           Transfer-Encoding: foobar
 

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -45,7 +45,7 @@ module HTTP
             body = ChunkedContent.new(io)
           else
             # Reject unrecognized transfer encodings
-            return nil
+            return HTTP::Status::NOT_IMPLEMENTED
           end
         elsif content_length = content_length(headers)
           body = FixedLengthContent.new(io, content_length)

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -35,15 +35,19 @@ module HTTP
       when EndOfRequest
         body = nil
 
-        # RFC 9112, Section 6.1: Transfer-Encoding is defined as overriding the
-        # Content-Length header that must be ignored.
-        transfer_encoding = headers["Transfer-Encoding"]?
-
         if body_type.prohibited?
           body = nil
-        elsif transfer_encoding == "chunked"
-          body = ChunkedContent.new(io)
-        elsif !transfer_encoding && (content_length = content_length(headers))
+        elsif transfer_encoding = headers["Transfer-Encoding"]?
+          # RFC 9112, Section 6.1: Transfer-Encoding is defined as overriding the
+          # Content-Length header that must be ignored.
+          case transfer_encoding
+          when "chunked"
+            body = ChunkedContent.new(io)
+          else
+            # Reject unrecognized transfer encodings
+            return nil
+          end
+        elsif content_length = content_length(headers)
           body = FixedLengthContent.new(io, content_length)
         elsif body_type.mandatory?
           body = UnknownLengthContent.new(io)


### PR DESCRIPTION
Crystal's HTTP implementation only respects `Transfer-Encoding: chunked`. Any other value must be rejected according to [RFC 9112 § 6.1]:

> A server that receives a request message with a transfer coding it does not understand SHOULD respond with `501 (Not Implemented)`.

We wouldn't know what to do with the body anyway.
Currently, the request parser would assume there is no body.

[RFC 9112 § 6.1]: https://www.rfc-editor.org/info/rfc9112/#section-6.1-11