### PR TITLE
Makefile: Add `build` and `manpages` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ all: ##
 ##   $ make clean crystal
 ## Build the compiler in release mode
 ##   $ make crystal release=1 interpreter=1
+## Build all assets for a package install (compiler and manpages)
+##   $ make build
+## Build and install crystal package
+##   $ make build && sudo make install
 ## Run tests
 ##   $ make test
 ## Run stdlib tests
@@ -73,6 +77,8 @@ override EXPORTS_BUILD += \
 	$(EXPORT_CC) \
 	CRYSTAL_CONFIG_LIBRARY_PATH=$(CRYSTAL_CONFIG_LIBRARY_PATH)
 SHELL = sh
+
+manpages_gz := $(patsubst %.1,%.1.gz,$(MAN1PAGES))
 
 ifeq ($(LLVM_VERSION),)
 	ifndef LLVM_CONFIG
@@ -188,6 +194,17 @@ docs: ## Generate standard library documentation
 .PHONY: crystal
 crystal: $(O)/$(CRYSTAL_BIN) ## Build the compiler
 
+.PHONY: build
+build: ## Build all files for a package install (currently the compiler and manpages)
+# bake-format off: Mbake bug with Duplicate target rule https://github.com/EbodShojaei/bake/issues/106
+build: release := 1
+build: crystal manpages
+# bake-format on
+
+.PHONY: manpages
+manpage: ## Build the manpages
+manpages: $(manpages_gz)
+
 .PHONY: deps llvm_ext
 deps: $(DEPS) ## Build dependencies
 llvm_ext: $(LLVM_EXT_OBJ)
@@ -228,7 +245,7 @@ uninstall_compiler:
 	rm -f "$(DESTDIR)$(DATADIR)/licenses/crystal/LICENSE"
 
 .PHONY: install_man
-install_man: $(patsubst %.1,%.1.gz,$(MAN1PAGES))
+install_man: $(manpages_gz)
 	$(INSTALL) -d -m 0755 "$(DESTDIR)$(MANDIR)/man1/"
 	$(INSTALL) -m 644 $^ "$(DESTDIR)$(MANDIR)/man1/"
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -12,6 +12,10 @@ all: ##
 ##   $ make -f Makefile.win clean crystal
 ## Build the compiler in release mode
 ##   $ make -f Makefile.win crystal release=1 interpreter=1
+## Build all assets for a package install (compiler)
+##   $ make -f Makefile.win build
+## Build and install crystal package
+##   $ make -f Makefile.win build && sudo make -f Makefile.win install
 ## Run tests
 ##   $ make -f Makefile.win test
 ## Run stdlib tests
@@ -152,6 +156,14 @@ docs: ## Generate standard library documentation
 
 .PHONY: crystal
 crystal: $(O)\crystal.exe ## Build the compiler
+
+.PHONY: build
+build: ## Build all files for a package install (currently the compiler)
+
+# bake-format off: Mbake bug with Duplicate target rule https://github.com/EbodShojaei/bake/issues/106
+build: release := 1
+build: crystal
+# bake-format on
 
 .PHONY: deps llvm_ext
 deps: $(DEPS) ## Build dependencies


### PR DESCRIPTION
These new targets allow building the package-ready manpages explicitly (`manpages`), as well as all dependencies for a package install (`build`).

`make build` produces everything needed for `make install`.

Without this change, there is no command to explicitly build the manpages. But `make install` has them as prerequisites, so it would build them. This is inconvenient for running when building and installing as different users.

I'm not changing the default target (`all`) to build manpages, though. But we might want to do that.
For now, the typical build and install command is `make build && sudo make install`.