### PR TITLE
Fix monitor thread GC performance regression

### DIFF
--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -109,7 +109,8 @@ module Crystal::System::Thread
 
     loop do
       return if LibC.nanosleep(pointerof(req), out rem) == 0
-      raise RuntimeError.from_errno("nanosleep() failed") unless Errno.value == Errno::EINTR
+      error = Errno.value
+      System.panic("nanosleep()", error) unless error == Errno::EINTR
       req = rem
     end
   end

--- a/src/crystal/system/wasi/thread.cr
+++ b/src/crystal/system/wasi/thread.cr
@@ -1,3 +1,5 @@
+require "../panic"
+
 module Crystal::System::Thread
   alias Handle = Nil
 
@@ -34,7 +36,8 @@ module Crystal::System::Thread
 
     loop do
       return if LibC.nanosleep(pointerof(req), out rem) == 0
-      raise RuntimeError.from_errno("nanosleep() failed") unless Errno.value == Errno::EINTR
+      error = Errno.value
+      System.panic("nanosleep()", error) unless error == Errno::EINTR
       req = rem
     end
   end

--- a/src/fiber/execution_context/monitor.cr
+++ b/src/fiber/execution_context/monitor.cr
@@ -52,7 +52,12 @@ module Fiber::ExecutionContext
       remaining = @every
 
       loop do
-        Thread.sleep(remaining)
+        GC.do_blocking(
+          ->(data : Void*) {
+            Thread.sleep(data.as(Time::Span*).value)
+            Pointer(Void).null
+          },
+          pointerof(remaining).as(Void*))
 
         start = Crystal::System::Time.instant
         yield(start)

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -162,6 +162,9 @@ lib LibGC
 
   fun size = GC_size(addr : Void*) : LibC::SizeT
 
+  alias BlockingProc = Void* -> Void*
+  fun do_blocking = GC_do_blocking(fn : BlockingProc, client_data : Void*) : Void*
+
   # Boehm GC requires to use its own thread manipulation routines instead of pthread's or Win32's
   {% if flag?(:win32) %}
     fun beginthreadex = GC_beginthreadex(security : Void*, stack_size : LibC::UInt, start_address : Void* -> LibC::UInt,
@@ -325,6 +328,11 @@ module GC
     Crystal.trace :gc, "free" do
       LibGC.free(pointer)
     end
+  end
+
+  # :nodoc:
+  def self.do_blocking(fn : Void* -> Void*, data : Void*) : Nil
+    LibGC.do_blocking(fn, data)
   end
 
   def self.add_finalizer(object : Reference) : Nil

--- a/src/gc/none.cr
+++ b/src/gc/none.cr
@@ -69,6 +69,11 @@ module GC
     {% end %}
   end
 
+  # :nodoc:
+  def self.do_blocking(fn : Void* -> Void*, data : Void*) : Nil
+    fn.call(data)
+  end
+
   def self.is_heap_ptr(pointer : Void*) : Bool
     false
   end


### PR DESCRIPTION
Fixes [#17144](https://github.com/crystal-lang/crystal/issues/17144).

Wrap the monitor thread's `Thread.sleep` in Boehm's `GC_do_blocking`, so collections no longer suspend and resume the sleeper. Monitor work runs normally after the blocking call returns, and the nanosleep error path uses non-allocating `System.panic`.

Tested with the GC and execution-context specs, blocked FIFO transfer, `gc_none`, `without_mt`, and a GC thread-event probe.