### PR TITLE
Fix bug allowing `self` in private top-level method

### DIFF
--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -534,6 +534,16 @@ describe "Semantic: def" do
       CRYSTAL
   end
 
+  it "can't use self in private toplevel method (#13899)" do
+    assert_error <<-CRYSTAL, "there's no self in this scope"
+      private def foo
+        self
+      end
+
+      foo
+      CRYSTAL
+  end
+
   it "points error at name (#6937)" do
     ex = assert_error <<-CRYSTAL,
       1.

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -361,7 +361,7 @@ module Crystal
     def visit(node : Var)
       var = @vars[node.name]?
       if var
-        if var.type?.is_a?(Program) && node.name == "self"
+        if var.type?.is_a?(Program | FileModule) && node.name == "self"
           node.raise "there's no self in this scope"
         end
 


### PR DESCRIPTION
Closes #13899