### PR TITLE
Add `GC.syscall(&)`

### DIFF
--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -104,12 +104,24 @@ module Crystal::System::Thread
 
   def self.sleep(time : ::Time::Span) : Nil
     req = uninitialized LibC::Timespec
+    rem = uninitialized LibC::Timespec
+
     req.tv_sec = typeof(req.tv_sec).new(time.@seconds)
     req.tv_nsec = typeof(req.tv_nsec).new(time.@nanoseconds)
 
-    loop do
-      return if LibC.nanosleep(pointerof(req), out rem) == 0
-      raise RuntimeError.from_errno("nanosleep() failed") unless Errno.value == Errno::EINTR
+    while true
+      ret, errno = 0, Errno::NONE
+
+      GC.syscall do
+        ret = LibC.nanosleep(pointerof(req), pointerof(rem))
+        errno = Errno.value
+      end
+      return if ret == 0
+
+      unless errno == Errno::EINTR
+        raise RuntimeError.from_os_error("nanosleep", errno)
+      end
+
       req = rem
     end
   end

--- a/src/crystal/system/unix/pthread_condition_variable.cr
+++ b/src/crystal/system/unix/pthread_condition_variable.cr
@@ -29,30 +29,38 @@ class Thread
     end
 
     def wait(mutex : Thread::Mutex) : Nil
-      ret = LibC.pthread_cond_wait(self, mutex)
+      ret = 0
+      GC.syscall do
+        ret = LibC.pthread_cond_wait(self, mutex)
+      end
       raise RuntimeError.from_os_error("pthread_cond_wait", Errno.new(ret)) unless ret == 0
     end
 
     def wait(mutex : Thread::Mutex, time : Time::Span, & : ->)
-      ret =
-        {% if flag?(:darwin) %}
-          ts = uninitialized LibC::Timespec
-          ts.tv_sec = time.to_i
-          ts.tv_nsec = time.nanoseconds
+      ret = 0
 
-          LibC.pthread_cond_timedwait_relative_np(self, mutex, pointerof(ts))
-        {% else %}
-          LibC.clock_gettime(LibC::CLOCK_MONOTONIC, out ts)
-          ts.tv_sec += time.to_i
-          ts.tv_nsec += time.nanoseconds
+      {% if flag?(:darwin) %}
+        ts = uninitialized LibC::Timespec
+        ts.tv_sec = time.to_i
+        ts.tv_nsec = time.nanoseconds
 
-          if ts.tv_nsec >= 1_000_000_000
-            ts.tv_sec += 1
-            ts.tv_nsec -= 1_000_000_000
-          end
+        GC.syscall do
+          ret = LibC.pthread_cond_timedwait_relative_np(self, mutex, pointerof(ts))
+        end
+      {% else %}
+        LibC.clock_gettime(LibC::CLOCK_MONOTONIC, out ts)
+        ts.tv_sec += time.to_i
+        ts.tv_nsec += time.nanoseconds
 
-          LibC.pthread_cond_timedwait(self, mutex, pointerof(ts))
-        {% end %}
+        if ts.tv_nsec >= 1_000_000_000
+          ts.tv_sec += 1
+          ts.tv_nsec -= 1_000_000_000
+        end
+
+        GC.syscall do
+          ret = LibC.pthread_cond_timedwait(self, mutex, pointerof(ts))
+        end
+      {% end %}
 
       case errno = Errno.new(ret)
       when .none?

--- a/src/crystal/system/win32/thread.cr
+++ b/src/crystal/system/win32/thread.cr
@@ -101,7 +101,10 @@ module Crystal::System::Thread
   {% end %}
 
   def self.sleep(time : ::Time::Span) : Nil
-    LibC.Sleep(time.total_milliseconds.to_i.clamp(1..))
+    milliseconds = (time.@seconds * 1_000 + time.@nanoseconds // 1_000_000).clamp(1..)
+    GC.syscall do
+      LibC.Sleep(milliseconds)
+    end
   end
 
   private def system_join : Exception?

--- a/src/crystal/system/win32/thread.cr
+++ b/src/crystal/system/win32/thread.cr
@@ -101,7 +101,7 @@ module Crystal::System::Thread
   {% end %}
 
   def self.sleep(time : ::Time::Span) : Nil
-    milliseconds = (time.@seconds * 1_000 + time.@nanoseconds // 1_000_000).clamp(1..)
+    milliseconds = time.total_milliseconds.to_i.clamp(1..)
     GC.syscall do
       LibC.Sleep(milliseconds)
     end

--- a/src/crystal/system/win32/thread_condition_variable.cr
+++ b/src/crystal/system/win32/thread_condition_variable.cr
@@ -23,10 +23,15 @@ class Thread
     end
 
     def wait(mutex : Thread::Mutex, time : Time::Span, & : ->)
-      ret = LibC.SleepConditionVariableCS(self, mutex, time.total_milliseconds)
+      ret, error = 0, WinError::NONE
+      timeout = time.total_milliseconds
+
+      GC.syscall do
+        ret = LibC.SleepConditionVariableCS(self, mutex, timeout)
+        error = WinError.value
+      end
       return if ret != 0
 
-      error = WinError.value
       if error == WinError::ERROR_TIMEOUT
         yield
       else

--- a/src/crystal/system/win32/thread_condition_variable.cr
+++ b/src/crystal/system/win32/thread_condition_variable.cr
@@ -23,7 +23,7 @@ class Thread
     end
 
     def wait(mutex : Thread::Mutex, time : Time::Span, & : ->)
-      ret, error = 0, WinError::NONE
+      ret, error = 0, WinError::ERROR_SUCCESS
       timeout = time.total_milliseconds
 
       GC.syscall do

--- a/src/gc.cr
+++ b/src/gc.cr
@@ -134,6 +134,22 @@ module GC
   def self.realloc(pointer : T*, size : Int) : T* forall T
     realloc(pointer.as(Void*), LibC::SizeT.new(size)).as(T*)
   end
+
+  # :nodoc:
+  #
+  # Marks the thread as doing a call that doesn't involve the GC, for example a
+  # blocking syscall such as `nanosleep` or `pthread_cond_timedwait`.
+  #
+  # The GC records the stack pointer at the entrypoint of the function, so the
+  # thread's stack will be scanned up to the stack pointer. The thread won't
+  # need to be suspended or resumed on wakeup (for the duration of the block).
+  #
+  # WARNING: Allocating memory into the GC HEAP (e.g. raising an exception), or
+  # mutating memory allocated into the GC HEAP are undefined behavior.
+  #
+  # WARNING: A system error (e.g. Errno, WinError) must be read before the block
+  # terminates as the value can change before the method returns.
+  # abstract def self.syscall(&block : ->) : Nil
 end
 
 {% if flag?(:gc_none) || flag?(:wasm32) %}

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -180,6 +180,9 @@ lib LibGC
   fun start_world_external = GC_start_world_external
   fun get_suspend_signal = GC_get_suspend_signal : Int
   fun get_thr_restart_signal = GC_get_thr_restart_signal : Int
+
+  alias FnType = Void* -> Void*
+  fun do_blocking = GC_do_blocking(FnType, Void*) : Void*
 end
 
 module GC
@@ -515,4 +518,15 @@ module GC
       Signal.new(LibGC.get_thr_restart_signal)
     end
   {% end %}
+
+  # :nodoc:
+  def self.syscall(&proc : ->) : Nil
+    # `GC_do_blocking` immediately calls the callback and the thread's stack
+    # will be scanned up to the entry of `GC_do_blocking` so we don't need to
+    # box the proc
+    LibGC.do_blocking(->(data : Void*) {
+      data.as(Proc(Nil)*).value.call
+      Pointer(Void).null
+    }, pointerof(proc))
+  end
 end

--- a/src/gc/none.cr
+++ b/src/gc/none.cr
@@ -219,4 +219,9 @@ module GC
     # finally, we can release the lock
     Thread.unlock
   end
+
+  # :nodoc:
+  def self.syscall(&proc : ->) : Nil
+    proc.call
+  end
 end


### PR DESCRIPTION
Adds an internal `GC.syscall(&)` similar to the `Fiber.syscall(&)` method, but that applies to the current thread in relation to the GC. Internally uses `GC_do_blocking` of BDWGC as proposed by @stakach.

The method declares the current thread as doing something that doesn't involve the GC, for instance a blocking syscall such as `nanosleep(2)` or `pthread_cond_timedwait(3)`.

The GC records the stack pointer at the entrypoint of the function. The thread won't need to be suspended or resumed on wakeup (for the duration of the block), but its stack will still be scanned up to the stack pointer.

The method is used by `Thread.sleep` and `Thread::ConditionVariable#wait` to wrap the actual syscalls. This avoids interrupting the monitor thread as well as parked threads (e.g. thread pool, isolated context) from being suspended then resumed... just to block again.

Related to #17144.
Alternative to #17145.