### PR TITLE
Add `Runnables#lazy_grab?` to skip the mutex on quick dequeue

### DIFF
--- a/src/fiber/execution_context/global_queue.cr
+++ b/src/fiber/execution_context/global_queue.cr
@@ -63,6 +63,12 @@ module Fiber::ExecutionContext
       @mutex.synchronize { unsafe_grab?(runnables, divisor) }
     end
 
+    # Same as `grab?` but skips the mutex when the global queue looks empty
+    # (lazy check).
+    def lazy_grab?(runnables : Runnables, divisor : Int32) : Fiber?
+      grab?(runnables, divisor) unless @list.empty?
+    end
+
     # Try to grab a batch of fibers from the global runnable queue. Returns the
     # next runnable fiber or `nil` if the queue was empty. Assumes the lock is
     # currently held.

--- a/src/fiber/execution_context/parallel/scheduler.cr
+++ b/src/fiber/execution_context/parallel/scheduler.cr
@@ -122,7 +122,7 @@ module Fiber::ExecutionContext
         # run loop
         if @execution_context.capacity == 1
           # try to refill local queue
-          if fiber = @global_queue.grab?(@runnables, divisor: @execution_context.size)
+          if fiber = @global_queue.lazy_grab?(@runnables, divisor: @execution_context.size)
             return fiber
           end
 


### PR DESCRIPTION
It makes sense, though the benefits probably can't be noticed.