### PR TITLE
Bootstrap ARM64 MSVC-based Crystal compiler

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,7 +5,7 @@ self-hosted-runner:
     - runner=*
     - family=*
     - ram=*
-    - windows-11-arm # actionlint doesn't understand this label yet
+    - windows-11-vs2026-arm # actionlint doesn't understand this label yet
 
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.

--- a/.github/workflows/win_arm64.yml
+++ b/.github/workflows/win_arm64.yml
@@ -1,0 +1,340 @@
+# temporary workflow definition for bootstrapping an ARM64 MSVC-based Crystal
+# compiler, to be later merged into `win.yml` and `win_build_portable.yml`
+# TODO: build MPIR and libffi
+
+name: Windows ARM64 CI
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+env:
+  SPEC_SPLIT_DOTS: 160
+  CI_LLVM_VERSION: "22.1.8"
+  CI_LLVM_TARGETS: "X86,AArch64"
+  CI_LLVM_LDFLAGS: "psapi.lib shell32.lib ole32.lib uuid.lib advapi32.lib ws2_32.lib ntdll.lib"
+
+jobs:
+  aarch64-windows-libs:
+    runs-on: windows-11-vs2026-arm
+    steps:
+      - name: Disable CRLF line ending substitution
+        run: |
+          git config --global core.autocrlf false
+
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          arch: arm64
+
+      - name: Download Crystal source
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Cache libraries
+        id: cache-libs
+        uses: actions/cache@v6
+        with:
+          path: | # openssl and llvm take much longer to build so they are cached separately
+            libs/pcre2-8.lib
+            libs/iconv.lib
+            libs/gc.lib
+            libs/z.lib
+            libs/yaml.lib
+            libs/xml2.lib
+            libs/libxml_VERSION
+          key: win-libs-msvc-aarch64-${{ hashFiles('.github/workflows/win_arm64.yml', 'etc/win-ci/*.ps1') }}
+      - name: Set up Cygwin
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        uses: cygwin/cygwin-install-action@3f0a3f9f988f7e96b8c18098ae05eaec175f5b52 # v6
+        with:
+          packages: make
+          install-dir: C:\cygwin64
+          add-to-path: false
+      - name: Build libgc
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.12 -AtomicOpsVersion 7.10.0
+      - name: Build libpcre2
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.47
+      - name: Build libiconv
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version 1.19
+      # - name: Build libffi
+      #   if: steps.cache-libs.outputs.cache-hit != 'true'
+      #   run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.5.1
+      - name: Build zlib
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1
+      # - name: Build mpir
+      #   if: steps.cache-libs.outputs.cache-hit != 'true'
+      #   run: .\etc\win-ci\build-mpir.ps1 -BuildTree deps\mpir
+      - name: Build libyaml
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version 0.2.5
+      - name: Build libxml2
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.15.3
+
+      - name: Cache OpenSSL
+        id: cache-openssl
+        uses: actions/cache@v6
+        with:
+          path: |
+            libs/crypto.lib
+            libs/ssl.lib
+            libs/openssl_VERSION
+          key: win-openssl-libs-3.5.0-msvc-aarch64-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
+      - name: Set up NASM
+        if: steps.cache-openssl.outputs.cache-hit != 'true'
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
+      - name: Build OpenSSL
+        if: steps.cache-openssl.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.5.0
+
+  aarch64-windows-dlls:
+    runs-on: windows-11-vs2026-arm
+    steps:
+      - name: Disable CRLF line ending substitution
+        run: |
+          git config --global core.autocrlf false
+
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          arch: arm64
+
+      - name: Download Crystal source
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Cache libraries
+        id: cache-dlls
+        uses: actions/cache@v6
+        with:
+          path: | # openssl and llvm take much longer to build so they are cached separately
+            libs/pcre2-8-dynamic.lib
+            libs/iconv-dynamic.lib
+            libs/gc-dynamic.lib
+            libs/z-dynamic.lib
+            libs/yaml-dynamic.lib
+            libs/xml2-dynamic.lib
+            dlls/pcre2-8.dll
+            dlls/iconv-2.dll
+            dlls/gc.dll
+            dlls/zlib1.dll
+            dlls/yaml.dll
+            dlls/libxml2.dll
+          key: win-dlls-msvc-aarch64-${{ hashFiles('.github/workflows/win_arm64.yml', 'etc/win-ci/*.ps1') }}
+      - name: Set up Cygwin
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        uses: cygwin/cygwin-install-action@3f0a3f9f988f7e96b8c18098ae05eaec175f5b52 # v6
+        with:
+          packages: make
+          install-dir: C:\cygwin64
+          add-to-path: false
+      - name: Build libgc
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.12 -AtomicOpsVersion 7.10.0 -Dynamic
+      - name: Build libpcre2
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.47 -Dynamic
+      - name: Build libiconv
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version 1.19 -Dynamic
+      # - name: Build libffi
+      #   if: steps.cache-dlls.outputs.cache-hit != 'true'
+      #   run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.4.7 -Dynamic
+      - name: Build zlib
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1 -Dynamic
+      # - name: Build mpir
+      #   if: steps.cache-dlls.outputs.cache-hit != 'true'
+      #   run: .\etc\win-ci\build-mpir.ps1 -BuildTree deps\mpir -Dynamic
+      - name: Build libyaml
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version 0.2.5 -Dynamic
+      - name: Build libxml2
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.15.3 -Dynamic
+
+      - name: Cache OpenSSL
+        id: cache-openssl-dlls
+        uses: actions/cache@v6
+        with:
+          path: |
+            libs/crypto-dynamic.lib
+            libs/ssl-dynamic.lib
+            dlls/libcrypto-3-arm64.dll
+            dlls/libssl-3-arm64.dll
+          key: win-openssl-dlls-3.5.0-msvc-aarch64-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
+      - name: Set up NASM
+        if: steps.cache-openssl-dlls.outputs.cache-hit != 'true'
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
+      - name: Build OpenSSL
+        if: steps.cache-openssl-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.5.0 -Dynamic
+
+  aarch64-windows-llvm-dlls:
+    runs-on: windows-11-vs2026-arm
+    steps:
+      - name: Disable CRLF line ending substitution
+        run: |
+          git config --global core.autocrlf false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          arch: arm64
+
+      - name: Download Crystal source
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Cache LLVM
+        id: cache-llvm-dlls
+        uses: actions/cache@v6
+        with:
+          path: |
+            libs/llvm_VERSION
+            libs/llvm-dynamic.lib
+            dlls/LLVM-C.dll
+          key: llvm-dlls-${{ env.CI_LLVM_VERSION }}-msvc-aarch64-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}
+
+      - name: Build LLVM
+        if: steps.cache-llvm-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-llvm.ps1 -BuildTree deps\llvm -Version ${{ env.CI_LLVM_VERSION }} -TargetsToBuild ${{ env.CI_LLVM_TARGETS }} -UseClangCl -Dynamic
+
+  aarch64-windows-release:
+    needs: [aarch64-windows-libs, aarch64-windows-dlls, aarch64-windows-llvm-dlls]
+    runs-on: windows-11-vs2026-arm
+    steps:
+      - name: Disable CRLF line ending substitution
+        run: |
+          git config --global core.autocrlf false
+
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          arch: arm64
+
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        id: install-crystal
+        with:
+          crystal: "1.21.0"
+          arch: "x86_64"
+
+      - name: Download Crystal source
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Restore libraries
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            libs/pcre2-8.lib
+            libs/iconv.lib
+            libs/gc.lib
+            libs/z.lib
+            libs/yaml.lib
+            libs/xml2.lib
+            libs/libxml_VERSION
+          key: win-libs-msvc-aarch64-${{ hashFiles('.github/workflows/win_arm64.yml', 'etc/win-ci/*.ps1') }}
+          fail-on-cache-miss: true
+      - name: Restore OpenSSL
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            libs/crypto.lib
+            libs/ssl.lib
+            libs/openssl_VERSION
+          key: win-openssl-libs-3.5.0-msvc-aarch64-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
+          fail-on-cache-miss: true
+      - name: Restore DLLs
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            libs/pcre2-8-dynamic.lib
+            libs/iconv-dynamic.lib
+            libs/gc-dynamic.lib
+            libs/z-dynamic.lib
+            libs/yaml-dynamic.lib
+            libs/xml2-dynamic.lib
+            dlls/pcre2-8.dll
+            dlls/iconv-2.dll
+            dlls/gc.dll
+            dlls/zlib1.dll
+            dlls/yaml.dll
+            dlls/libxml2.dll
+          key: win-dlls-msvc-aarch64-${{ hashFiles('.github/workflows/win_arm64.yml', 'etc/win-ci/*.ps1') }}
+          fail-on-cache-miss: true
+      - name: Restore OpenSSL DLLs
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            libs/crypto-dynamic.lib
+            libs/ssl-dynamic.lib
+            dlls/libcrypto-3-arm64.dll
+            dlls/libssl-3-arm64.dll
+          key: win-openssl-dlls-3.5.0-msvc-aarch64-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
+          fail-on-cache-miss: true
+      - name: Restore LLVM DLLs
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            libs/llvm_VERSION
+            libs/llvm-dynamic.lib
+            dlls/LLVM-C.dll
+          key: llvm-dlls-${{ env.CI_LLVM_VERSION }}-msvc-aarch64-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}
+          fail-on-cache-miss: true
+
+      - name: Set up environment
+        run: |
+          Add-Content $env:GITHUB_ENV "CRYSTAL_PATH=lib;$(pwd)\src"
+          Add-Content $env:GITHUB_ENV 'CRYSTAL_CONFIG_PATH=lib;$ORIGIN\src'
+          Add-Content $env:GITHUB_ENV 'CRYSTAL_CONFIG_LIBRARY_PATH=$ORIGIN\lib'
+          Add-Content $env:GITHUB_ENV "LLVM_VERSION=$env:INPUTS_LLVM_VERSION"
+          Add-Content $env:GITHUB_ENV "LLVM_TARGETS=$env:INPUTS_LLVM_TARGETS"
+          Add-Content $env:GITHUB_ENV "LLVM_LDFLAGS=$env:INPUTS_LLVM_LDFLAGS"
+        env:
+          INPUTS_LLVM_VERSION: ${{ env.CI_LLVM_VERSION }}
+          INPUTS_LLVM_TARGETS: ${{ env.CI_LLVM_TARGETS }}
+          INPUTS_LLVM_LDFLAGS: ${{ env.CI_LLVM_LDFLAGS }}
+
+      - name: Cross-compile Crystal
+        run: |
+          crystal build --release --cross-compile --target=aarch64-windows-msvc src\compiler\crystal.cr `
+            -Dwithout_ffi -Dwithout_interpreter -Di_know_what_im_doing
+          cl crystal.obj /Fecrystal /link /LIBPATH:$(pwd)\libs /INCREMENTAL:NO /STACK:0x800000 /ENTRY:wmainCRTStartup `
+            kernel32.lib ucrt.lib ole32.lib DbgHelp.lib advapi32.lib ws2_32.lib msvcrt.lib ntdll.lib shell32.lib `
+            gc-dynamic.lib iconv-dynamic.lib llvm-dynamic.lib pcre2-8-dynamic.lib ssl-dynamic.lib crypto-dynamic.lib xml2-dynamic.lib z-dynamic.lib
+
+      - name: Gather Crystal binaries
+        run: |
+          mkdir crystal
+          cp crystal.exe crystal/
+          cp src -Destination crystal/ -Recurse
+          mkdir crystal/lib
+          cp libs/* crystal/lib/
+          cp dlls/* crystal/
+          cp README.md crystal/
+
+      - name: Upload Crystal binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: crystal
+          path: crystal

--- a/.github/workflows/win_arm64.yml
+++ b/.github/workflows/win_arm64.yml
@@ -1,6 +1,6 @@
 # temporary workflow definition for bootstrapping an ARM64 MSVC-based Crystal
 # compiler, to be later merged into `win.yml` and `win_build_portable.yml`
-# TODO: build MPIR and libffi
+# TODO: build libffi
 
 name: Windows ARM64 CI
 
@@ -45,6 +45,7 @@ jobs:
             libs/iconv.lib
             libs/gc.lib
             libs/z.lib
+            libs/mpir.lib
             libs/yaml.lib
             libs/xml2.lib
             libs/libxml_VERSION
@@ -71,9 +72,9 @@ jobs:
       - name: Build zlib
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1
-      # - name: Build mpir
-      #   if: steps.cache-libs.outputs.cache-hit != 'true'
-      #   run: .\etc\win-ci\build-mpir.ps1 -BuildTree deps\mpir
+      - name: Build mpir
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-mpir.ps1 -BuildTree deps\mpir
       - name: Build libyaml
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version 0.2.5
@@ -123,12 +124,14 @@ jobs:
             libs/iconv-dynamic.lib
             libs/gc-dynamic.lib
             libs/z-dynamic.lib
+            libs/mpir-dynamic.lib
             libs/yaml-dynamic.lib
             libs/xml2-dynamic.lib
             dlls/pcre2-8.dll
             dlls/iconv-2.dll
             dlls/gc.dll
             dlls/zlib1.dll
+            dlls/mpir.dll
             dlls/yaml.dll
             dlls/libxml2.dll
           key: win-dlls-msvc-aarch64-${{ hashFiles('.github/workflows/win_arm64.yml', 'etc/win-ci/*.ps1') }}
@@ -154,9 +157,9 @@ jobs:
       - name: Build zlib
         if: steps.cache-dlls.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1 -Dynamic
-      # - name: Build mpir
-      #   if: steps.cache-dlls.outputs.cache-hit != 'true'
-      #   run: .\etc\win-ci\build-mpir.ps1 -BuildTree deps\mpir -Dynamic
+      - name: Build mpir
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-mpir.ps1 -BuildTree deps\mpir -Dynamic
       - name: Build libyaml
         if: steps.cache-dlls.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version 0.2.5 -Dynamic
@@ -250,6 +253,7 @@ jobs:
             libs/iconv.lib
             libs/gc.lib
             libs/z.lib
+            libs/mpir.lib
             libs/yaml.lib
             libs/xml2.lib
             libs/libxml_VERSION
@@ -272,12 +276,14 @@ jobs:
             libs/iconv-dynamic.lib
             libs/gc-dynamic.lib
             libs/z-dynamic.lib
+            libs/mpir-dynamic.lib
             libs/yaml-dynamic.lib
             libs/xml2-dynamic.lib
             dlls/pcre2-8.dll
             dlls/iconv-2.dll
             dlls/gc.dll
             dlls/zlib1.dll
+            dlls/mpir.dll
             dlls/yaml.dll
             dlls/libxml2.dll
           key: win-dlls-msvc-aarch64-${{ hashFiles('.github/workflows/win_arm64.yml', 'etc/win-ci/*.ps1') }}

--- a/_typos.toml
+++ b/_typos.toml
@@ -56,6 +56,8 @@ extend-ignore-re = [
   "writeable writable", # in src/io/memory.cr
   "writeable:", # in spec/std/io/memory_spec.cr
   "File.writeable", # in docs/changelogs/pre-1.0.md
+  # command-line options
+  "", # etc/win-ci/windres-rc.sh
 ]
 
 [files]

--- a/_typos.toml
+++ b/_typos.toml
@@ -57,7 +57,7 @@ extend-ignore-re = [
   "writeable:", # in spec/std/io/memory_spec.cr
   "File.writeable", # in docs/changelogs/pre-1.0.md
   # command-line options
-  "", # etc/win-ci/windres-rc.sh
+  "FO", # etc/win-ci/windres-rc.sh
 ]
 
 [files]

--- a/etc/win-ci/build-iconv.ps1
+++ b/etc/win-ci/build-iconv.ps1
@@ -14,7 +14,9 @@ rm libiconv.tar.gz
 
 Run-InDirectory $BuildTree {
     $env:CHERE_INVOKING = 1
+    cp "$PSScriptRoot\windres-rc.sh" "build-aux\windres-rc"
     [System.IO.File]::WriteAllText("src\Makefile.in", [System.IO.File]::ReadAllText("src\Makefile.in").Replace("chmod 777 .", "true"))
+    [System.IO.File]::WriteAllText("windows\windres-options", [System.IO.File]::ReadAllText("windows\windres-options").Replace("escape=yes", ""))
 
     & 'C:\cygwin64\bin\bash.exe' --login "$PSScriptRoot\cygwin-build-iconv.sh" "$(if ($Dynamic) { 1 })"
     if (-not $?) {

--- a/etc/win-ci/build-llvm.ps1
+++ b/etc/win-ci/build-llvm.ps1
@@ -2,6 +2,7 @@ param(
     [Parameter(Mandatory)] [string] $BuildTree,
     [Parameter(Mandatory)] [string] $Version,
     [Parameter(Mandatory)] [string[]] $TargetsToBuild,
+    [switch] $UseClangCl,
     [switch] $Dynamic
 )
 
@@ -14,16 +15,25 @@ if (-not $Dynamic) {
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
 Setup-Git -Path $BuildTree -Url https://github.com/llvm/llvm-project.git -Ref llvmorg-$Version
+$arch = (Get-CimInstance Win32_operatingsystem).OSArchitecture
 
 Run-InDirectory $BuildTree\build {
-    $args = "-Thost=x64 -DLLVM_TARGETS_TO_BUILD=$($TargetsToBuild -join ';') -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF -DLLVM_INCLUDE_BENCHMARKS=OFF -DLLVM_INCLUDE_DOCS=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_ENABLE_ZSTD=OFF"
+    $platform = if ($arch -eq "ARM 64-bit Processor") { "ARM64" } else { "x64" }
+    $args = "-A$platform -DLLVM_TARGETS_TO_BUILD=$($TargetsToBuild -join ';') -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF -DLLVM_INCLUDE_BENCHMARKS=OFF -DLLVM_INCLUDE_DOCS=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_ENABLE_ZSTD=OFF"
+
+    if ($UseClangCl) {
+        $args = "-TClangCl $args"
+    }
+
     if ($Dynamic) {
         $args = "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL $args"
     } else {
         $args = "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DLLVM_BUILD_LLVM_C_DYLIB=OFF $args"
     }
+
     & $cmake ..\llvm $args.split(' ')
-    & $cmake --build . --config Release --target llvm-config --target LLVM-C
+    & $cmake --build . --config Release --target llvm-config --target LLVM-C -j8
+
     if (-not $?) {
         Write-Host "Error: Failed to build LLVM" -ForegroundColor Red
         Exit 1

--- a/etc/win-ci/build-mpir.ps1
+++ b/etc/win-ci/build-mpir.ps1
@@ -6,7 +6,7 @@ param(
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
-Setup-Git -Path $BuildTree -Url https://github.com/HertzDevil/mpir.git -Ref c3578f8d4a863482a785480e14cbda7e236f194b # vs2026-arm64@{2026-07-24}
+Setup-Git -Path $BuildTree -Url https://github.com/BrianGladman/mpir.git -Ref 5e0c2061af105c151970d41c8394ce956f77e455 # master@{2026-07-24}
 $arch = (Get-CimInstance Win32_operatingsystem).OSArchitecture
 $platform = if ($arch -eq "ARM 64-bit Processor") { "ARM64" } else { "x64" }
 

--- a/etc/win-ci/build-mpir.ps1
+++ b/etc/win-ci/build-mpir.ps1
@@ -6,7 +6,9 @@ param(
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
-Setup-Git -Path $BuildTree -Url https://github.com/BrianGladman/mpir.git -Ref f84ce09218b91d4c4fdf26e75093918c9fdb7046 # master@{2026-02-25}
+Setup-Git -Path $BuildTree -Url https://github.com/HertzDevil/mpir.git -Ref c3578f8d4a863482a785480e14cbda7e236f194b # vs2026-arm64@{2026-07-24}
+$arch = (Get-CimInstance Win32_operatingsystem).OSArchitecture
+$platform = if ($arch -eq "ARM 64-bit Processor") { "ARM64" } else { "x64" }
 
 Run-InDirectory $BuildTree {
     $vsVersion = "vs$((& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -property displayName) -replace '.*\b\d\d(\d\d)\b.*', '$1')"
@@ -30,9 +32,9 @@ Run-InDirectory $BuildTree {
     </Project>' > 'msvc\Override.props'
 
     if ($Dynamic) {
-        MSBuild.exe /p:Platform=x64 /p:Configuration=Release "msvc\$vsVersion\dll_mpir_gc\dll_mpir_gc.vcxproj"
+        MSBuild.exe /p:Platform=$platform /p:Configuration=Release "msvc\$vsVersion\dll_mpir_gc\dll_mpir_gc.vcxproj"
     } else {
-        MSBuild.exe /p:Platform=x64 /p:Configuration=Release "msvc\$vsVersion\lib_mpir_gc\lib_mpir_gc.vcxproj"
+        MSBuild.exe /p:Platform=$platform /p:Configuration=Release "msvc\$vsVersion\lib_mpir_gc\lib_mpir_gc.vcxproj"
     }
     if (-not $?) {
         Write-Host "Error: Failed to build MPIR" -ForegroundColor Red
@@ -41,8 +43,8 @@ Run-InDirectory $BuildTree {
 }
 
 if ($Dynamic) {
-    mv -Force $BuildTree\dll\x64\Release\mpir.lib libs\mpir-dynamic.lib
-    mv -Force $BuildTree\dll\x64\Release\mpir.dll dlls\
+    mv -Force $BuildTree\dll\$platform\Release\mpir.lib libs\mpir-dynamic.lib
+    mv -Force $BuildTree\dll\$platform\Release\mpir.dll dlls\
 } else {
-    mv -Force $BuildTree\lib\x64\Release\mpir.lib libs\
+    mv -Force $BuildTree\lib\$platform\Release\mpir.lib libs\
 }

--- a/etc/win-ci/build-openssl.ps1
+++ b/etc/win-ci/build-openssl.ps1
@@ -8,15 +8,18 @@ param(
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
 Setup-Git -Path $BuildTree -Url https://github.com/openssl/openssl -Ref openssl-$Version
+$arch = (Get-CimInstance Win32_operatingsystem).OSArchitecture
 
 Run-InDirectory $BuildTree {
     Replace-Text Configurations\10-main.conf '/Zi /Fdossl_static.pdb' ''
     Replace-Text Configurations\10-main.conf '"/nologo /debug"' '"/nologo /debug:none"'
 
+    $platform = if ($arch -eq "ARM 64-bit Processor") { "VC-WIN64-ARM" } else { "VC-WIN64A" }
+
     if ($Dynamic) {
-        perl Configure VC-WIN64A no-tests
+        perl Configure "$platform" no-tests
     } else {
-        perl Configure VC-WIN64A /MT -static no-tests
+        perl Configure "$platform" /MT -static no-tests
     }
     nmake
     if (-not $?) {
@@ -27,10 +30,11 @@ Run-InDirectory $BuildTree {
 
 if ($Dynamic) {
     $major = $Version -replace '\..*', ''
+    $suffix = if ($arch -eq "ARM 64-bit Processor") { "arm64" } else { "x64" }
     mv -Force $BuildTree\libcrypto.lib libs\crypto-dynamic.lib
     mv -Force $BuildTree\libssl.lib libs\ssl-dynamic.lib
-    mv -Force $BuildTree\libcrypto-$major-x64.dll dlls\
-    mv -Force $BuildTree\libssl-$major-x64.dll dlls\
+    mv -Force $BuildTree\libcrypto-$major-$suffix.dll dlls\
+    mv -Force $BuildTree\libssl-$major-$suffix.dll dlls\
 } else {
     mv -Force $BuildTree\libcrypto.lib libs\crypto.lib
     mv -Force $BuildTree\libssl.lib libs\ssl.lib

--- a/etc/win-ci/cygwin-build-iconv.sh
+++ b/etc/win-ci/cygwin-build-iconv.sh
@@ -9,6 +9,8 @@ export PATH="$(pwd)/build-aux:$PATH"
 export CC="$(pwd)/build-aux/compile cl -nologo"
 export CXX="$(pwd)/build-aux/compile cl -nologo"
 export AR="$(pwd)/build-aux/ar-lib lib"
+export RC="$(pwd)/build-aux/windres-rc rc"
+export WINDRES="$(pwd)/build-aux/windres-rc rc"
 export LD="link"
 export NM="dumpbin -symbols"
 export STRIP=":"
@@ -31,6 +33,11 @@ fi
 export CPPFLAGS="-O2 -D_WIN32_WINNT=_WIN32_WINNT_WIN7 -I$(pwd)/iconv/include"
 export LDFLAGS="-L$(pwd)/iconv/lib"
 
-./configure --host=x86_64-w64-mingw32 --prefix="$(pwd)/iconv" --enable-shared="${enable_shared}" --enable-static="${enable_static}"
+case "$(uname)" in
+  *-ARM64) host=aarch64-w64-mingw32 ;;
+  *) host=x86_64-w64-mingw32 ;;
+esac
+
+./configure --host="${host}" --prefix="$(pwd)/iconv" --enable-shared="${enable_shared}" --enable-static="${enable_static}"
 make
 make install

--- a/etc/win-ci/windres-rc.sh
+++ b/etc/win-ci/windres-rc.sh
@@ -1,0 +1,59 @@
+#! /bin/sh
+# Minimal wrapper for Microsoft rc.exe
+
+# This wrapper is necessary for libiconv, since by default Cygwin will use
+# x86_64-w64-mingw32-windres to build the library's resource file, even on an
+# ARM64 Windows host, leading to an MSVC linker error about architecture
+# mismatch. The build will call something like:
+#
+#     /bin/sh ../libtool --mode=compile --tag=RC ${RC-:windres} \
+#       `/bin/sh ./../windows/windres-options --escape 1.19` \
+#       -i ./../windows/libiconv.rc -o libiconv.res.lo --output-format=coff
+#
+# which becomes:
+#
+#     windres -DPACKAGE_VERSION_STRING=\\\"1.19\\\" \
+#       -DPACKAGE_VERSION_MAJOR=1 \
+#       -DPACKAGE_VERSION_MINOR=19 \
+#       -DPACKAGE_VERSION_SUBMINOR=0 \
+#       -i ./../windows/libiconv.rc --output-format=coff -o libiconv.res.obj
+#
+# the corresponding rc.exe invocation is:
+#
+#     rc.exe /NOLOGO -DPACKAGE_VERSION_STRING=\"1.19\" \
+#       -DPACKAGE_VERSION_MAJOR=1 \
+#       -DPACKAGE_VERSION_MINOR=19 \
+#       -DPACKAGE_VERSION_SUBMINOR=0 \
+#       /FO libiconv.res.obj libiconv.rc
+
+RC=$1
+input=
+output=
+defines=""
+
+while [ $# -gt 0 ]
+do
+  case $1 in
+    -D* | -d*)
+      defines="$1 ${defines}"
+      shift
+      ;;
+    -i)
+      shift
+      input=$1
+      shift
+      ;;
+    -o)
+      shift
+      output=$1
+      shift
+      ;;
+    *)
+      # ignore --output-format=coff as it is the default already
+      shift
+      ;;
+  esac
+done
+
+# shellcheck disable=SC2086
+$RC -NOLOGO $defines -FO "$output" "$input"

--- a/etc/win-ci/windres-rc.sh
+++ b/etc/win-ci/windres-rc.sh
@@ -32,26 +32,26 @@ output=
 defines=""
 
 while [ $# -gt 0 ]; do
-	case $1 in
-	-D* | -d*)
-		defines="$1 ${defines}"
-		shift
-		;;
-	-i)
-		shift
-		input=$1
-		shift
-		;;
-	-o)
-		shift
-		output=$1
-		shift
-		;;
-	*)
-		# ignore --output-format=coff as it is the default already
-		shift
-		;;
-	esac
+  case $1 in
+    -D* | -d*)
+      defines="$1 ${defines}"
+      shift
+      ;;
+    -i)
+      shift
+      input=$1
+      shift
+      ;;
+    -o)
+      shift
+      output=$1
+      shift
+      ;;
+    *)
+      # ignore --output-format=coff as it is the default already
+      shift
+      ;;
+  esac
 done
 
 # shellcheck disable=SC2086

--- a/etc/win-ci/windres-rc.sh
+++ b/etc/win-ci/windres-rc.sh
@@ -31,28 +31,27 @@ input=
 output=
 defines=""
 
-while [ $# -gt 0 ]
-do
-  case $1 in
-    -D* | -d*)
-      defines="$1 ${defines}"
-      shift
-      ;;
-    -i)
-      shift
-      input=$1
-      shift
-      ;;
-    -o)
-      shift
-      output=$1
-      shift
-      ;;
-    *)
-      # ignore --output-format=coff as it is the default already
-      shift
-      ;;
-  esac
+while [ $# -gt 0 ]; do
+	case $1 in
+	-D* | -d*)
+		defines="$1 ${defines}"
+		shift
+		;;
+	-i)
+		shift
+		input=$1
+		shift
+		;;
+	-o)
+		shift
+		output=$1
+		shift
+		;;
+	*)
+		# ignore --output-format=coff as it is the default already
+		shift
+		;;
+	esac
 done
 
 # shellcheck disable=SC2086

--- a/spec/support/tempfile.cr
+++ b/spec/support/tempfile.cr
@@ -80,7 +80,7 @@ def with_temp_c_object_file(c_code, *, filename = "temp_c", file = __FILE__, &)
         if msvc_path = Crystal::System::VisualStudio.find_latest_msvc_path
           # we won't be cross-compiling the specs binaries, so host and target
           # bits are identical
-          bits = {{ flag?(:bits64) ? "x64" : "x86" }}
+          bits = {{ flag?(:aarch64) ? "ARM64" : flag?(:bits64) ? "x64" : "x86" }}
           cl = Process.quote(msvc_path.join("bin", "Host#{bits}", bits, cl).to_s)
         end
       end

--- a/src/crystal/compiler_rt.cr
+++ b/src/crystal/compiler_rt.cr
@@ -18,7 +18,7 @@ require "./compiler_rt/divmod128.cr"
   require "./compiler_rt/pow.cr"
 {% end %}
 
-{% if flag?(:win32) && flag?(:bits64) %}
+{% if flag?(:win32) && flag?(:x86_64) %}
   # LLVM doesn't honor the Windows x64 ABI when calling certain compiler-rt
   # functions from its own instructions, but calls from Crystal do, so we invoke
   # those functions directly

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -47,7 +47,8 @@
   @[Link(ldflags: "`command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'`")]
 {% end %}
 {% if compare_versions(Crystal::VERSION, "1.11.0-dev") >= 0 %}
-  @[Link(dll: {{ "libcrypto-#{LibCrypto::VERSION_MAJOR.id}-x64.dll" }})]
+  {% suffix = flag?(:aarch64) ? "arm64" : "x64" %}
+  @[Link(dll: {{ "libcrypto-#{LibCrypto::VERSION_MAJOR.id}-#{suffix.id}.dll" }})]
 {% end %}
 lib LibCrypto
   alias Char = LibC::Char

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -54,8 +54,9 @@ require "./lib_crypto"
   @[Link(ldflags: "`command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'`")]
 {% end %}
 {% if compare_versions(Crystal::VERSION, "1.11.0-dev") >= 0 %}
-  @[Link(dll: {{ "libssl-#{LibSSL::VERSION_MAJOR.id}-x64.dll" }})]
-  @[Link(dll: {{ "libcrypto-#{LibCrypto::VERSION_MAJOR.id}-x64.dll" }})]
+  {% suffix = flag?(:aarch64) ? "arm64" : "x64" %}
+  @[Link(dll: {{ "libssl-#{LibSSL::VERSION_MAJOR.id}-#{suffix.id}.dll" }})]
+  @[Link(dll: {{ "libcrypto-#{LibCrypto::VERSION_MAJOR.id}-#{suffix.id}.dll" }})]
 {% end %}
 lib LibSSL
   alias Int = LibC::Int


### PR DESCRIPTION
Part of #17118. Part of #14802.

This is a initial stage-1 `aarch64-windows-msvc` compiler that can be used either as a release artifact, or to immediately build another stage-2 compiler + Shards for the next minor release. The temporary workflow definition mirrors most of `win.yml` and `win_build_portable.yml`, it will be removed shortly afterwards.

Third-party libraries using CMake usually build correctly out-of-the-box. The other libraries are:

* OpenSSL: This uses custom platform names and embeds the architecture name in the build products.
* GNU libiconv: x86-64 Cygwin works for the most part on an ARM64 host, except that only the x86-64 binutils are available, and libiconv would use the x86-64 resource tool by default. This PR adds a wrapper script that calls the host ARM64 MSVC resource tool.
* LLVM: For some reason ARM64 MSVC seems to produce bad code, so the clang-cl toolset (available via Visual Studio) must be used. The resulting libraries are ABI-compatible with MSVC.
* MPIR: ~~Not built yet~~ I created a [PR to upstream](https://github.com/BrianGladman/mpir/pull/37) that regenerates the VS2022 and VS2026 project files with full ARM64 configurations, `build-mpir.ps1` now uses the official repository as it has been merged.
* libffi: Not built yet, the upstream now has a [Cygwin-based CI workflow](https://github.com/libffi/libffi/blob/46cb2e3871059f7f5113329ddcca818de3a8cfae/.github/workflows/build.yml#L247) similar to GNU libiconv, and we have plans to ditch our own CMake-enabled fork.