### PR TITLE
Execution contexts directly enqueue fibers during event loop runs

### DIFF
--- a/src/crystal/event_loop.cr
+++ b/src/crystal/event_loop.cr
@@ -77,7 +77,7 @@ abstract class Crystal::EventLoop
     # Same as `#run` but collects runnable fibers into *queue* instead of
     # enqueueing in parallel, so the caller is responsible and in control for
     # when and how the fibers will be enqueued.
-    abstract def run(queue : Fiber::List*, blocking : Bool) : Nil
+    abstract def run(blocking : Bool, & : Fiber ->) : Nil
 
     # Tries to lock the event loop and yields if the lock was acquired. Must
     # unlock before returning. Returns true if the lock was acquired, false

--- a/src/crystal/event_loop/io_uring.cr
+++ b/src/crystal/event_loop/io_uring.cr
@@ -247,8 +247,8 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
   end
 
   {% if !flag?(:without_mt) && !flag?(:preview_mt) || flag?(:execution_context) %}
-    def run(queue : Fiber::List*, blocking : Bool) : Nil
-      system_run(blocking) { |fiber| queue.value.push(fiber) }
+    def run(blocking : Bool, & : Fiber ->) : Nil
+      system_run(blocking) { |fiber| yield fiber }
     end
 
     # no lock: the evloop expects every scheduler to wait on its dedicated ring

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -128,8 +128,8 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
 
   {% if !flag?(:without_mt) && !flag?(:preview_mt) || flag?(:execution_context) %}
     # thread unsafe
-    def run(queue : Fiber::List*, blocking : Bool) : Nil
-      run_impl(blocking) { |fiber| queue.value.push(fiber) }
+    def run(blocking : Bool, & : Fiber ->) : Nil
+      run_impl(blocking) { |fiber| yield fiber }
     end
 
     # the evloop has a single IOCP instance for the context and only one

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -35,19 +35,19 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
     # scheduler must wait on the evloop at any time
     include Lock
 
-    def run(queue : Fiber::List*, blocking : Bool) : Nil
+    def run(blocking : Bool, &callback : Fiber ->) : Nil
       Crystal.trace :evloop, "run", blocking: blocking
-      @runnables = queue
+      @callback = callback
       run(blocking)
     ensure
-      @runnables = nil
+      @callback = nil
     end
 
     def callback_enqueue(fiber : Fiber) : Nil
-      if queue = @runnables
-        queue.value.push(fiber)
+      if callback = @callback
+        callback.call(fiber)
       else
-        raise "BUG: libevent callback executed outside of #run(queue*, blocking) call"
+        raise "BUG: libevent callback executed outside of #run(blocking, &) call"
       end
     end
   {% end %}

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -127,8 +127,8 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     include EventLoop::Lock
 
     # thread unsafe
-    def run(queue : Fiber::List*, blocking : Bool) : Nil
-      system_run(blocking) { |fiber| queue.value.push(fiber) }
+    def run(blocking : Bool, & : Fiber ->) : Nil
+      system_run(blocking) { |fiber| yield fiber }
     end
   {% end %}
 

--- a/src/fiber/execution_context/isolated.cr
+++ b/src/fiber/execution_context/isolated.cr
@@ -184,19 +184,21 @@ module Fiber::ExecutionContext
           @waiting = true
         end
 
+        done = true
+
         # wait on the event loop
-        list = Fiber::List.new
-        event_loop.run(pointerof(list), blocking: true)
+        event_loop.run(blocking: true) do |fiber|
+          # sanity check
+          unless fiber == @main_fiber
+            raise RuntimeError.new("Concurrency is disabled in isolated contexts")
+          end
 
-        # restart if the evloop got interrupted
-        next unless fiber = list.pop?
-
-        # sanity check
-        unless fiber == @main_fiber && list.empty?
-          raise RuntimeError.new("Concurrency is disabled in isolated contexts")
+          # can't just return because EventLoop::LibEvent#run captures the block
+          done = true
         end
 
-        break
+        # the evloop got interrupted: retry
+        break if done
       end
 
       # cleanup

--- a/src/fiber/execution_context/parallel/scheduler.cr
+++ b/src/fiber/execution_context/parallel/scheduler.cr
@@ -127,11 +127,14 @@ module Fiber::ExecutionContext
           end
 
           # run the event loop to see if any event is activable
-          list = Fiber::List.new
-          if @event_loop.lock? { @event_loop.run(pointerof(list), blocking: false) }
-            return enqueue_many(pointerof(list))
+          @event_loop.lock? do
+            if fiber = run_evloop(blocking: false)
+              return fiber
+            end
           end
         end
+
+        nil
       end
 
       protected def run_loop : Nil
@@ -180,8 +183,6 @@ module Fiber::ExecutionContext
       end
 
       private def find_next_runnable(&) : Nil
-        list = Fiber::List.new
-
         # nothing to do: start spinning
         spinning do
           return if @shutdown
@@ -192,22 +193,15 @@ module Fiber::ExecutionContext
 
           yield @global_queue.grab?(@runnables, divisor: @execution_context.size)
 
-          if @event_loop.lock? { @event_loop.run(pointerof(list), blocking: false) }
-            unless list.empty?
-              # must stop spinning before calling enqueue_many that may call
-              # wake_scheduler which returns immediately if a thread is
-              # spinning... but we're spinning, so that would always fail to
-              # wake sleeping schedulers despite having runnable fibers
-              spin_stop
-              yield enqueue_many(pointerof(list))
-            end
+          @event_loop.lock? do
+            yield run_evloop(blocking: false)
           end
 
           yield try_steal?
         end
 
         # wait on the event loop for events and timers to activate
-        evloop_ran = @event_loop.lock? do
+        @event_loop.lock? do
           @state = State::WAITING
 
           # there is a time window between stop spinning and start waiting
@@ -218,11 +212,7 @@ module Fiber::ExecutionContext
 
           # block on the event loop until an event is ready or the loop is
           # interrupted
-          @event_loop.run(pointerof(list), blocking: true)
-        end
-
-        if evloop_ran
-          yield enqueue_many(pointerof(list))
+          yield run_evloop(blocking: true)
 
           # the event loop was interrupted: restart the loop
           return
@@ -251,12 +241,21 @@ module Fiber::ExecutionContext
         @state = State::SPINNING
       end
 
-      private def enqueue_many(list : Fiber::List*) : Fiber?
-        if fiber = list.value.pop?
-          Crystal.trace :sched, "enqueue", size: list.value.size, fiber: fiber
-          @runnables.bulk_push(list) unless list.value.empty?
-          fiber
+      private def run_evloop(blocking)
+        fiber = nil
+        size = 0
+
+        @event_loop.run(blocking) do |runnable|
+          if fiber
+            @runnables.push(runnable)
+          else
+            fiber = runnable
+          end
+          size += 1
         end
+
+        Crystal.trace :sched, "enqueue", size: size, fiber: fiber
+        fiber
       end
 
       # This method always runs in parallel!


### PR DESCRIPTION
Instead of pushing fibers to a `Fiber::List` singly-linked-list then iterate the list to push to the runnables queue, we can directly push to the runnables queue.

Changes the EventLoop interface from `#run(queue : Fiber::List*, blocking : Bool)` to `#run(blocking : Bool, & : Fiber ->)` so the caller decides what to do with the runnable fiber, and the Isolated and Parallel context now directly enqueue the fibers.

While the change is good (the caller decides what to do, no indirect data structure), it sadly doesn't appear to have a noticeable impact on performance in practice. Maybe some workflows will benefit.