### PR TITLE
Fix parse `OP_SLASH` after block

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -719,6 +719,13 @@ module Crystal
     it_parses "foo &.as?(T).bar", Call.new("foo", block: Block.new([Var.new("__arg0")], Call.new(NilableCast.new(Var.new("__arg0"), "T".path), "bar")))
     it_parses "foo(\n  &.block\n)", Call.new("foo", block: Block.new([Var.new("__arg0")], Call.new(Var.new("__arg0"), "block")))
 
+    it_parses "foo(&.bar)/2", Call.new(Call.new("foo", block: Block.new([Var.new("__arg0")], Call.new(Var.new("__arg0"), "bar"))), "/", 2.int32)
+    it_parses "foo do end/2", Call.new(Call.new("foo", block: Block.new(body: Nop.new)), "/", 2.int32)
+    it_parses "foo { }/2", Call.new(Call.new("foo", block: Block.new(body: Nop.new)), "/", 2.int32)
+    it_parses "foo(&.bar)/ 2", Call.new(Call.new("foo", block: Block.new([Var.new("__arg0")], Call.new(Var.new("__arg0"), "bar"))), "/", 2.int32)
+    it_parses "foo do end/ 2", Call.new(Call.new("foo", block: Block.new(body: Nop.new)), "/", 2.int32)
+    it_parses "foo { }/ 2", Call.new(Call.new("foo", block: Block.new(body: Nop.new)), "/", 2.int32)
+
     it_parses "foo.[0]", Call.new("foo".call, "[]", 0.int32)
     it_parses "foo.[0] = 1", Call.new("foo".call, "[]=", [0.int32, 1.int32] of ASTNode)
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1474,6 +1474,7 @@ module Crystal
 
       check_ident :end
       slash_is_not_regex!
+      @wants_regex = false
       next_token_skip_space
 
       if rescues || a_ensure
@@ -1609,6 +1610,7 @@ module Crystal
         skip_space_or_newline
         check :OP_RPAREN
         end_location = token_end_location
+        @wants_regex = false
         next_token_skip_space
       else
         skip_space
@@ -4595,6 +4597,7 @@ module Crystal
           check :OP_RCURLY
           end_location = token_end_location
           slash_is_not_regex!
+          @wants_regex = false
           next_token_skip_space
           {body, end_location}
         end


### PR DESCRIPTION
Originally mentioned in https://forum.crystal-lang.org/t/unexpected-token-delimiter-start-was-well-unexpected/9070