### PR TITLE
Avoid duplicate argument placeholders in Crystal CLI help

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -441,7 +441,7 @@ class Crystal::Command
         end
       end
 
-      opts.on("-D FLAG", "--define FLAG", "Define a compile-time flag") do |flag|
+      opts.on("-D", "--define FLAG", "Define a compile-time flag") do |flag|
         compiler.flags << flag
       end
 
@@ -472,17 +472,17 @@ class Crystal::Command
       end
 
       if cursor_command
-        opts.on("-c LOC", "--cursor LOC", "Cursor location with LOC as path/to/file.cr:line:column") do |cursor|
+        opts.on("-c", "--cursor LOC", "Cursor location with LOC as path/to/file.cr:line:column") do |cursor|
           cursor_location = cursor
         end
       end
 
       if dependencies
-        opts.on("-i <path>", "--include <path>", "Include path") do |f|
+        opts.on("-i", "--include <path>", "Include path") do |f|
           includes << f
         end
 
-        opts.on("-e <path>", "--exclude <path>", "Exclude path (default: lib)") do |f|
+        opts.on("-e", "--exclude <path>", "Exclude path (default: lib)") do |f|
           excludes << f
         end
 
@@ -491,7 +491,7 @@ class Crystal::Command
         end
       end
 
-      opts.on("-f #{allowed_formats.join("|")}", "--format #{allowed_formats.join("|")}", "Output format: #{allowed_formats[0]} (default), #{allowed_formats[1..].join(", ")}") do |f|
+      opts.on("-f", "--format #{allowed_formats.join("|")}", "Output format: #{allowed_formats[0]} (default), #{allowed_formats[1..].join(", ")}") do |f|
         output_format = f
       end
 
@@ -516,11 +516,11 @@ class Crystal::Command
       end
 
       if path_filter
-        opts.on("-i <path>", "--include <path>", "Include path") do |f|
+        opts.on("-i", "--include <path>", "Include path") do |f|
           includes << f
         end
 
-        opts.on("-e <path>", "--exclude <path>", "Exclude path (default: lib)") do |f|
+        opts.on("-e", "--exclude <path>", "Exclude path (default: lib)") do |f|
           excludes << f
         end
       end
@@ -545,7 +545,7 @@ class Crystal::Command
         opts.on("--no-codegen", "Don't do code generation") do
           compiler.no_codegen = true
         end
-        opts.on("-o FILE", "--output FILE", "Output path. If a directory, the filename is derived from the first source file (default: ./)") do |an_output_filename|
+        opts.on("-o", "--output FILE", "Output path. If a directory, the filename is derived from the first source file (default: ./)") do |an_output_filename|
           opt_output_filename = an_output_filename
           specified_output = true
         end
@@ -695,7 +695,7 @@ class Crystal::Command
     opts.on("--no-debug", "Skip any symbolic debug info") do
       compiler.debug = Crystal::Debug::None
     end
-    opts.on("-D FLAG", "--define FLAG", "Define a compile-time flag") do |flag|
+    opts.on("-D", "--define FLAG", "Define a compile-time flag") do |flag|
       compiler.flags << flag
     end
     opts.on("--error-trace", "Show full error trace") do

--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -41,10 +41,10 @@ class Crystal::Command
         project_info.source_url_pattern = value
       end
 
-      opts.on("-o DIR", "--output=DIR", "Set the output directory (default: #{output_directory})") do |value|
+      opts.on("-o", "--output=DIR", "Set the output directory (default: #{output_directory})") do |value|
         output_directory = value
       end
-      opts.on("-f FORMAT", "--format=FORMAT", "Set the output format [#{VALID_OUTPUT_FORMATS.join(", ")}] (default: #{output_format})") do |value|
+      opts.on("-f", "--format=FORMAT", "Set the output format [#{VALID_OUTPUT_FORMATS.join(", ")}] (default: #{output_format})") do |value|
         if !VALID_OUTPUT_FORMATS.includes? value
           STDERR.puts "Invalid format '#{value}'"
           abort! opts, :USAGE_ERROR
@@ -64,7 +64,7 @@ class Crystal::Command
         project_info.base_path = value
       end
 
-      opts.on("-b URL", "--sitemap-base-url=URL", "Set the sitemap base URL and generates sitemap") do |value|
+      opts.on("-b", "--sitemap-base-url=URL", "Set the sitemap base URL and generates sitemap") do |value|
         sitemap_base_url = value
       end
 
@@ -76,7 +76,7 @@ class Crystal::Command
         sitemap_changefreq = value
       end
 
-      opts.on("-D FLAG", "--define FLAG", "Define a compile-time flag") do |flag|
+      opts.on("-D", "--define FLAG", "Define a compile-time flag") do |flag|
         compiler.flags << flag
       end
 

--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -28,11 +28,11 @@ class Crystal::Command
         check = true
       end
 
-      opts.on("-i <path>", "--include <path>", "Include path") do |f|
+      opts.on("-i", "--include <path>", "Include path") do |f|
         includes << f
       end
 
-      opts.on("-e <path>", "--exclude <path>", "Exclude path (default: lib)") do |f|
+      opts.on("-e", "--exclude <path>", "Exclude path (default: lib)") do |f|
         excludes << f
       end
 

--- a/src/compiler/crystal/command/playground.cr
+++ b/src/compiler/crystal/command/playground.cr
@@ -10,13 +10,13 @@ class Crystal::Command
     OptionParser.parse(@options) do |opts|
       opts.banner = "Usage: crystal play [options] [file]\n\nOptions:"
 
-      opts.on("-p PORT", "--port PORT", "Runs the playground on the specified port") do |port|
+      opts.on("-p", "--port PORT", "Runs the playground on the specified port") do |port|
         port = port.to_i?
         raise Error.new("Invalid port number: #{port}") unless port && Socket::IPAddress.valid_port?(port)
         server.port = port
       end
 
-      opts.on("-b HOST", "--binding HOST", "Binds the playground to the specified IP") do |host|
+      opts.on("-b", "--binding HOST", "Binds the playground to the specified IP") do |host|
         server.host = host
       end
 

--- a/src/compiler/crystal/command/repl.cr
+++ b/src/compiler/crystal/command/repl.cr
@@ -10,7 +10,7 @@ class Crystal::Command
     parse_with_crystal_opts do |opts|
       opts.banner = "Usage: crystal i [options] [programfile] [arguments]\n\nOptions:"
 
-      opts.on("-D FLAG", "--define FLAG", "Define a compile-time flag") do |flag|
+      opts.on("-D", "--define FLAG", "Define a compile-time flag") do |flag|
         repl.program.flags << flag
       end
 


### PR DESCRIPTION
Hello.

This pull request proposes changing the help messages for the Crystal compiler.
It does not intend to change the compiler behavior.

Currently, some options show the same argument placeholder for both the short and long forms.

```text
-o FILE, --output FILE
```

This looks a little redundant, especially after [indentation was added for long options](https://github.com/crystal-lang/crystal/pull/16914).

I considered changing `OptionParser` behavior, but that would affect how users can format their own help messages.
So this pull request only updates the option definitions used by the Crystal compiler.

With this change, the argument placeholder is kept only on the long option.

```text
-o, --output FILE
```

There are variations in argument notation, such as `--foo BAR`, `--foo=BAR`, and `--foo <bar>`.
However, they are outside the scope of this pull request.

Thank you.