### PR TITLE
Use Cygwin to build libffi for MSVC CI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -124,7 +124,7 @@ jobs:
             dlls/pcre2-8.dll
             dlls/iconv-2.dll
             dlls/gc.dll
-            dlls/libffi.dll
+            dlls/libffi-8.dll
             dlls/zlib1.dll
             dlls/mpir.dll
             dlls/yaml.dll

--- a/.github/workflows/win_arm64.yml
+++ b/.github/workflows/win_arm64.yml
@@ -1,6 +1,5 @@
 # temporary workflow definition for bootstrapping an ARM64 MSVC-based Crystal
 # compiler, to be later merged into `win.yml` and `win_build_portable.yml`
-# TODO: build libffi
 
 name: Windows ARM64 CI
 
@@ -44,6 +43,7 @@ jobs:
             libs/pcre2-8.lib
             libs/iconv.lib
             libs/gc.lib
+            libs/ffi.lib
             libs/z.lib
             libs/mpir.lib
             libs/yaml.lib
@@ -66,9 +66,9 @@ jobs:
       - name: Build libiconv
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version 1.19
-      # - name: Build libffi
-      #   if: steps.cache-libs.outputs.cache-hit != 'true'
-      #   run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.5.1
+      - name: Build libffi
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.5.1
       - name: Build zlib
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1
@@ -123,6 +123,7 @@ jobs:
             libs/pcre2-8-dynamic.lib
             libs/iconv-dynamic.lib
             libs/gc-dynamic.lib
+            libs/ffi-dynamic.lib
             libs/z-dynamic.lib
             libs/mpir-dynamic.lib
             libs/yaml-dynamic.lib
@@ -130,6 +131,7 @@ jobs:
             dlls/pcre2-8.dll
             dlls/iconv-2.dll
             dlls/gc.dll
+            dlls/libffi-8.dll
             dlls/zlib1.dll
             dlls/mpir.dll
             dlls/yaml.dll
@@ -151,9 +153,9 @@ jobs:
       - name: Build libiconv
         if: steps.cache-dlls.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version 1.19 -Dynamic
-      # - name: Build libffi
-      #   if: steps.cache-dlls.outputs.cache-hit != 'true'
-      #   run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.4.7 -Dynamic
+      - name: Build libffi
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.4.7 -Dynamic
       - name: Build zlib
         if: steps.cache-dlls.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1 -Dynamic
@@ -252,6 +254,7 @@ jobs:
             libs/pcre2-8.lib
             libs/iconv.lib
             libs/gc.lib
+            libs/ffi.lib
             libs/z.lib
             libs/mpir.lib
             libs/yaml.lib
@@ -275,6 +278,7 @@ jobs:
             libs/pcre2-8-dynamic.lib
             libs/iconv-dynamic.lib
             libs/gc-dynamic.lib
+            libs/ffi-dynamic.lib
             libs/z-dynamic.lib
             libs/mpir-dynamic.lib
             libs/yaml-dynamic.lib
@@ -282,6 +286,7 @@ jobs:
             dlls/pcre2-8.dll
             dlls/iconv-2.dll
             dlls/gc.dll
+            dlls/libffi-8.dll
             dlls/zlib1.dll
             dlls/mpir.dll
             dlls/yaml.dll
@@ -323,11 +328,11 @@ jobs:
 
       - name: Cross-compile Crystal
         run: |
-          crystal build --release --cross-compile --target=aarch64-windows-msvc src\compiler\crystal.cr `
-            -Dwithout_ffi -Dwithout_interpreter -Di_know_what_im_doing
+          cp dlls/libffi-8.dll ${{ steps.install-crystal.outputs.path }}/
+          crystal build --release --cross-compile --target=aarch64-windows-msvc src\compiler\crystal.cr -Di_know_what_im_doing
           cl crystal.obj /Fecrystal /link /LIBPATH:$(pwd)\libs /INCREMENTAL:NO /STACK:0x800000 /ENTRY:wmainCRTStartup `
             kernel32.lib ucrt.lib ole32.lib DbgHelp.lib advapi32.lib ws2_32.lib msvcrt.lib ntdll.lib shell32.lib `
-            gc-dynamic.lib iconv-dynamic.lib llvm-dynamic.lib pcre2-8-dynamic.lib ssl-dynamic.lib crypto-dynamic.lib xml2-dynamic.lib z-dynamic.lib
+            ffi-dynamic.lib gc-dynamic.lib iconv-dynamic.lib llvm-dynamic.lib pcre2-8-dynamic.lib ssl-dynamic.lib crypto-dynamic.lib xml2-dynamic.lib z-dynamic.lib
 
       - name: Gather Crystal binaries
         run: |

--- a/.github/workflows/win_arm64.yml
+++ b/.github/workflows/win_arm64.yml
@@ -328,11 +328,13 @@ jobs:
 
       - name: Cross-compile Crystal
         run: |
-          cp dlls/libffi-8.dll "${{ steps.install-crystal.outputs.path }}/"
+          cp dlls/libffi-8.dll "$env:CRYSTAL_DIR/"
           crystal build --release --cross-compile --target=aarch64-windows-msvc src\compiler\crystal.cr -Di_know_what_im_doing
           cl crystal.obj /Fecrystal /link /LIBPATH:$(pwd)\libs /INCREMENTAL:NO /STACK:0x800000 /ENTRY:wmainCRTStartup `
             kernel32.lib ucrt.lib ole32.lib DbgHelp.lib advapi32.lib ws2_32.lib msvcrt.lib ntdll.lib shell32.lib `
             ffi-dynamic.lib gc-dynamic.lib iconv-dynamic.lib llvm-dynamic.lib pcre2-8-dynamic.lib ssl-dynamic.lib crypto-dynamic.lib xml2-dynamic.lib z-dynamic.lib
+        env:
+          CRYSTAL_DIR: ${{ steps.install-crystal.outputs.path }}
 
       - name: Gather Crystal binaries
         run: |

--- a/.github/workflows/win_arm64.yml
+++ b/.github/workflows/win_arm64.yml
@@ -328,7 +328,7 @@ jobs:
 
       - name: Cross-compile Crystal
         run: |
-          cp dlls/libffi-8.dll ${{ steps.install-crystal.outputs.path }}/
+          cp dlls/libffi-8.dll "${{ steps.install-crystal.outputs.path }}/"
           crystal build --release --cross-compile --target=aarch64-windows-msvc src\compiler\crystal.cr -Di_know_what_im_doing
           cl crystal.obj /Fecrystal /link /LIBPATH:$(pwd)\libs /INCREMENTAL:NO /STACK:0x800000 /ENTRY:wmainCRTStartup `
             kernel32.lib ucrt.lib ole32.lib DbgHelp.lib advapi32.lib ws2_32.lib msvcrt.lib ntdll.lib shell32.lib `

--- a/.github/workflows/win_build_portable.yml
+++ b/.github/workflows/win_build_portable.yml
@@ -79,7 +79,7 @@ jobs:
             dlls/pcre2-8.dll
             dlls/iconv-2.dll
             dlls/gc.dll
-            dlls/libffi.dll
+            dlls/libffi-8.dll
             dlls/zlib1.dll
             dlls/mpir.dll
             dlls/yaml.dll
@@ -122,6 +122,7 @@ jobs:
 
       - name: Build Crystal
         run: |
+          cp dlls/libffi-8.dll ${{ steps.install-crystal.outputs.path }}/
           bin/crystal.bat env
           make -f Makefile.win -B ${{ inputs.release && 'release=1' || '' }} interpreter=1
 

--- a/.github/workflows/win_build_portable.yml
+++ b/.github/workflows/win_build_portable.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Build Crystal
         run: |
-          cp dlls/libffi-8.dll ${{ steps.install-crystal.outputs.path }}/
+          cp dlls/libffi-8.dll "${{ steps.install-crystal.outputs.path }}/"
           bin/crystal.bat env
           make -f Makefile.win -B ${{ inputs.release && 'release=1' || '' }} interpreter=1
 

--- a/.github/workflows/win_build_portable.yml
+++ b/.github/workflows/win_build_portable.yml
@@ -122,9 +122,11 @@ jobs:
 
       - name: Build Crystal
         run: |
-          cp dlls/libffi-8.dll "${{ steps.install-crystal.outputs.path }}/"
+          cp dlls/libffi-8.dll "$env:CRYSTAL_DIR/"
           bin/crystal.bat env
           make -f Makefile.win -B ${{ inputs.release && 'release=1' || '' }} interpreter=1
+        env:
+          CRYSTAL_DIR: ${{ steps.install-crystal.outputs.path }}
 
       - name: Download shards release
         uses: actions/checkout@v7

--- a/etc/win-ci/build-ffi.ps1
+++ b/etc/win-ci/build-ffi.ps1
@@ -7,17 +7,15 @@ param(
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
-Setup-Git -Path $BuildTree -Url https://github.com/crystal-lang/libffi.git -Ref v$Version
+Invoke-WebRequest "https://github.com/libffi/libffi/releases/download/v${Version}/libffi-${Version}.tar.gz" -OutFile libffi.tar.gz
+tar -xzf libffi.tar.gz
+mv libffi-* $BuildTree
+rm libffi.tar.gz
 
 Run-InDirectory $BuildTree {
-    $args = "-DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"
-    if ($Dynamic) {
-        $args = "-DBUILD_SHARED_LIBS=ON $args"
-    } else {
-        $args = "-DBUILD_SHARED_LIBS=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded $args"
-    }
-    & $cmake . $args.split(' ')
-    & $cmake --build . --config Release
+    $env:CHERE_INVOKING = 1
+
+    & 'C:\cygwin64\bin\bash.exe' --login "$PSScriptRoot\cygwin-build-ffi.sh" "$(if ($Dynamic) { 1 })"
     if (-not $?) {
         Write-Host "Error: Failed to build libffi" -ForegroundColor Red
         Exit 1
@@ -25,8 +23,8 @@ Run-InDirectory $BuildTree {
 }
 
 if ($Dynamic) {
-    mv -Force $BuildTree\Release\libffi.lib libs\ffi-dynamic.lib
-    mv -Force $BuildTree\Release\libffi.dll dlls\
+    mv -Force $BuildTree\ffi\libffi.lib libs\ffi-dynamic.lib
+    mv -Force $BuildTree\ffi\libffi-8.dll dlls\
 } else {
-    mv -Force $BuildTree\Release\libffi.lib libs\ffi.lib
+    mv -Force $BuildTree\ffi\libffi.lib libs\ffi.lib
 }

--- a/etc/win-ci/cygwin-build-ffi.sh
+++ b/etc/win-ci/cygwin-build-ffi.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2155
 
 set -e
 

--- a/etc/win-ci/cygwin-build-ffi.sh
+++ b/etc/win-ci/cygwin-build-ffi.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+set -e
+
+Dynamic=$1
+
+case "$(uname)" in
+  *-ARM64)
+    host=aarch64-w64-mingw32
+    mflag=-marm64
+    ;;
+  *)
+    host=x86_64-w64-mingw32
+    mflag=-m64
+    ;;
+esac
+
+export CC="$(pwd)/msvcc.sh ${mflag}"
+export CXX="$(pwd)/msvcc.sh ${mflag}"
+export CPP="cl -nologo -EP"
+export CXXCPP="cl -nologo -EP"
+export AR="$(pwd)/.ci/ar-lib lib"
+export LD="link -nologo"
+export NM="dumpbin -symbols"
+export STRIP=":"
+if [ -n "$Dynamic" ]; then
+  export CFLAGS="-DFFI_BUILDING_DLL"
+  export CXXFLAGS="-DFFI_BUILDING_DLL"
+  export CPPFLAGS="-DFFI_BUILDING_DLL"
+  enable_shared=yes
+  enable_static=no
+else
+  export CFLAGS="-DFFI_BUILDING_DLL -DUSE_STATIC_RTL"
+  export CXXFLAGS="-DFFI_BUILDING_DLL -DUSE_STATIC_RTL"
+  export CPPFLAGS="-DFFI_BUILDING_DLL -DUSE_STATIC_RTL"
+  enable_shared=no
+  enable_static=yes
+fi
+export LDFLAGS="-no-undefined"
+
+./configure --host="${host}" --prefix="$(pwd)/ffi" --enable-shared="${enable_shared}" --enable-static="${enable_static}" --disable-docs
+make
+# `make install` does not work with the `msvcc.sh` wrapper
+mkdir ffi
+if [ -n "$Dynamic" ]; then
+  cp "$(find "${host}/.libs" -name 'libffi-?.dll')" ffi/
+  cp "$(find "${host}/.libs" -name 'libffi-?.lib')" ffi/libffi.lib
+else
+  cp "${host}/.libs/libffi.lib" ffi/
+fi

--- a/src/compiler/crystal/ffi/lib_ffi.cr
+++ b/src/compiler/crystal/ffi/lib_ffi.cr
@@ -6,7 +6,7 @@
 module Crystal
   @[Link("ffi", pkg_config: "libffi")]
   {% if compare_versions(Crystal::VERSION, "1.11.0-dev") >= 0 %}
-    @[Link(dll: "libffi.dll")]
+    @[Link(dll: "libffi-8.dll")]
   {% end %}
   lib LibFFI
     {% begin %}


### PR DESCRIPTION
Part of #17118. Resolves #14802.

With this patch we should now be able to archive https://github.com/crystal-lang/libffi.