### PR TITLE
Add `NumberLiteral#chr`

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -3560,6 +3560,14 @@ module Crystal
       end
     end
 
+    describe NumberLiteral do
+      describe "#chr" do
+        it "executes chr" do
+          assert_macro %({{x.chr}}), %('a'), {x: 97.int32}
+        end
+      end
+    end
+
     describe ClassDef do
       class_def = ClassDef.new(Path.new("Foo"), abstract: true, superclass: Path.new("Parent"))
       struct_def = ClassDef.new(Path.new("Foo", "Bar", global: true), type_vars: %w(A B C D), splat_index: 2, struct: true, body: CharLiteral.new('a'))

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -652,6 +652,10 @@ module Crystal::Macros
     def ~ : NumberLiteral
     end
 
+    # Same as `Int#chr`
+    def chr : CharLiteral
+    end
+
     # The type of the literal: `:i32`, `:u16`, `:f32`, `:f64`, etc.
     def kind : SymbolLiteral
     end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -548,6 +548,12 @@ module Crystal
           raise "undefined method '~' for float literal: #{self}" unless num.is_a?(Int)
           NumberLiteral.new(~num)
         end
+      when "chr"
+        interpret_check_args do
+          num = to_number
+          raise "undefined method 'chr' for float literal: #{self}" unless num.is_a?(Int)
+          CharLiteral.new(num.chr)
+        end
       when "kind"
         interpret_check_args { SymbolLiteral.new(kind.to_s) }
       when "to_number"


### PR DESCRIPTION
Adds a `#chr` method that's equivalent to `Int#chr`.
It raises if `self` is not an integer, or if the value is out of range (just like `Int#chr`).

The opposite `CharLiteral#ord` already exists (#13910).

This was previously discussed in #11256 but the issue was closed because that particular use case actually didn't even need macros in the end.

