### PR TITLE
Support `CharLiteral` in `RangeLiteral#each`

### DIFF
--- a/spec/compiler/macro/macro_expander_spec.cr
+++ b/spec/compiler/macro/macro_expander_spec.cr
@@ -161,6 +161,10 @@ describe "MacroExpander" do
     it "expands macro with for over range literal, evaluating elements (exclusive)" do
       assert_macro "{%for e in x...y %}{{e}}{%end%}", "345", {x: 3.int32, y: 6.int32}
     end
+
+    it "expands macro with for over char range literal" do
+      assert_macro "{%for e in 'a'..'c' %}{{e}}{%end%}", "'a''b''c'"
+    end
   end
 
   it "does regular if" do

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -3472,9 +3472,16 @@ module Crystal
         assert_macro %({{x.excludes_end?}}), "true", {x: RangeLiteral.new(1.int32, 2.int32, true)}
       end
 
-      it "executes map" do
-        assert_macro %({{x.map(&.stringify)}}), %(["1", "2", "3"]), {x: RangeLiteral.new(1.int32, 3.int32, false)}
-        assert_macro %({{x.map(&.stringify)}}), %(["1", "2"]), {x: RangeLiteral.new(1.int32, 3.int32, true)}
+      describe "#map" do
+        it "with NumberLiteral" do
+          assert_macro %({{x.map(&.stringify)}}), %(["1", "2", "3"]), {x: RangeLiteral.new(1.int32, 3.int32, false)}
+          assert_macro %({{x.map(&.stringify)}}), %(["1", "2"]), {x: RangeLiteral.new(1.int32, 3.int32, true)}
+        end
+
+        it "with CharLiteral" do
+          assert_macro %({{x.map(&.stringify)}}), %(["'a'", "'b'", "'c'"]), {x: RangeLiteral.new(CharLiteral.new('a'), CharLiteral.new('c'), false)}
+          assert_macro %({{x.map(&.stringify)}}), %(["'a'", "'b'"]), {x: RangeLiteral.new(CharLiteral.new('a'), CharLiteral.new('c'), true)}
+        end
       end
 
       it "executes to_a" do

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -3467,9 +3467,16 @@ module Crystal
         assert_macro %({{x.excludes_end?}}), "true", {x: RangeLiteral.new(1.int32, 2.int32, true)}
       end
 
-      it "executes map" do
-        assert_macro %({{x.map(&.stringify)}}), %(["1", "2", "3"]), {x: RangeLiteral.new(1.int32, 3.int32, false)}
-        assert_macro %({{x.map(&.stringify)}}), %(["1", "2"]), {x: RangeLiteral.new(1.int32, 3.int32, true)}
+      describe "#map" do
+        it "with NumberLiteral" do
+          assert_macro %({{x.map(&.stringify)}}), %(["1", "2", "3"]), {x: RangeLiteral.new(1.int32, 3.int32, false)}
+          assert_macro %({{x.map(&.stringify)}}), %(["1", "2"]), {x: RangeLiteral.new(1.int32, 3.int32, true)}
+        end
+
+        it "with CharLiteral" do
+          assert_macro %({{x.map(&.stringify)}}), %(["'a'", "'b'", "'c'"]), {x: RangeLiteral.new(CharLiteral.new('a'), CharLiteral.new('c'), false)}
+          assert_macro %({{x.map(&.stringify)}}), %(["'a'", "'b'"]), {x: RangeLiteral.new(CharLiteral.new('a'), CharLiteral.new('c'), true)}
+        end
       end
 
       it "executes to_a" do

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -244,7 +244,7 @@ module Crystal
         end
 
         range.each_with_index do |element, index|
-          @vars[element_var.name] = NumberLiteral.new(element)
+          @vars[element_var.name] = element
           if index_var
             @vars[index_var.name] = NumberLiteral.new(index)
           end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1381,8 +1381,12 @@ module Crystal
       Range.new(from, to, self.exclusive?)
     end
 
+    def interpret_to_range(from : CharLiteral, to : CharLiteral)
+      Range.new(from, to, self.exclusive?)
+    end
+
     def interpret_to_range(from, to)
-      raise "range begin and must be both NumberLiteral, not #{from.class_desc}..#{to.class_desc}"
+      raise "range begin and must be both NumberLiteral or both CharLiteral, not #{from.class_desc}..#{to.class_desc}"
     end
 
     def interpret_to_nilable_range(interpreter)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1389,8 +1389,12 @@ module Crystal
       Range.new(from, to, self.exclusive?)
     end
 
+    def interpret_to_range(from : CharLiteral, to : CharLiteral)
+      Range.new(from, to, self.exclusive?)
+    end
+
     def interpret_to_range(from, to)
-      raise "range begin and must be both NumberLiteral, not #{from.class_desc}..#{to.class_desc}"
+      raise "range begin and must be both NumberLiteral or both CharLiteral, not #{from.class_desc}..#{to.class_desc}"
     end
 
     def interpret_to_nilable_range(interpreter)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1371,23 +1371,18 @@ module Crystal
     end
 
     def interpret_to_range(interpreter)
-      node = interpreter.accept(self.from)
-      from = case node
-             when NumberLiteral
-               node
-             else
-               raise "range begin must be a NumberLiteral, not #{node.class_desc}"
-             end
+      interpret_to_range(
+        interpreter.accept(self.from),
+        interpreter.accept(self.to)
+      )
+    end
 
-      node = interpreter.accept(self.to)
-      to = case node
-           when NumberLiteral
-             node
-           else
-             raise "range end must be a NumberLiteral, not #{node.class_desc}"
-           end
-
+    def interpret_to_range(from : NumberLiteral, to : NumberLiteral)
       Range.new(from, to, self.exclusive?)
+    end
+
+    def interpret_to_range(from, to)
+      raise "range begin and must be both NumberLiteral, not #{from.class_desc}..#{to.class_desc}"
     end
 
     def interpret_to_nilable_range(interpreter)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1394,7 +1394,7 @@ module Crystal
     end
 
     def interpret_to_range(from, to)
-      raise "range begin and must be both NumberLiteral or both CharLiteral, not #{from.class_desc}..#{to.class_desc}"
+      raise "range begin and end must be both NumberLiteral or both CharLiteral, not #{from.class_desc}..#{to.class_desc}"
     end
 
     def interpret_to_nilable_range(interpreter)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1334,7 +1334,7 @@ module Crystal
           end
 
           range.each do |num|
-            interpreter.define_var(block_arg.name, NumberLiteral.new(num)) if block_arg
+            interpreter.define_var(block_arg.name, num) if block_arg
             interpreter.accept block.body
           end
 
@@ -1345,15 +1345,13 @@ module Crystal
           block_arg = block.args.first?
 
           interpret_map(block, interpreter) do |num|
-            interpreter.define_var(block_arg.name, NumberLiteral.new(num)) if block_arg
+            interpreter.define_var(block_arg.name, num) if block_arg
             interpreter.accept block.body
           end
         end
       when "to_a"
         interpret_check_args do
-          interpret_map(nil, interpreter) do |num|
-            NumberLiteral.new(num)
-          end
+          interpret_map(nil, interpreter, &.itself)
         end
       else
         super
@@ -1376,7 +1374,7 @@ module Crystal
       node = interpreter.accept(self.from)
       from = case node
              when NumberLiteral
-               node.to_number.to_i
+               node
              else
                raise "range begin must be a NumberLiteral, not #{node.class_desc}"
              end
@@ -1384,7 +1382,7 @@ module Crystal
       node = interpreter.accept(self.to)
       to = case node
            when NumberLiteral
-             node.to_number.to_i
+             node
            else
              raise "range end must be a NumberLiteral, not #{node.class_desc}"
            end

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -395,6 +395,8 @@ module Crystal
 
   # Any number literal.
   class NumberLiteral < ASTNode
+    include Comparable(self)
+
     property value : String
     property kind : NumberKind
 
@@ -414,7 +416,7 @@ module Crystal
         raise "BUG: called 'integer_value' for non-integer literal"
       end
 
-      kind.cast(value)
+      kind.cast(value).as(Int)
     end
 
     # Returns true if this literal is representable in the *other_type*. Used to
@@ -433,6 +435,22 @@ module Crystal
         true
       else
         false
+      end
+    end
+
+    def <=>(other : self)
+      if (kind.signed_int? || kind.unsigned_int?) && (other.kind.signed_int? || other.kind.unsigned_int?)
+        integer_value <=> other.integer_value
+      else
+        value.to_f64 <=> other.value.to_f64
+      end
+    end
+
+    def succ : self
+      if kind.signed_int? || kind.unsigned_int?
+        NumberLiteral.new(integer_value.succ.to_s, kind)
+      else
+        raise "BUG: called 'succ' for non-integer literal"
       end
     end
 

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -475,6 +475,8 @@ module Crystal
   #     "'" \w "'"
   #
   class CharLiteral < ASTNode
+    include Comparable(self)
+
     property value : Char
 
     def initialize(@value : Char)
@@ -485,6 +487,14 @@ module Crystal
     end
 
     def_equals_and_hash value
+
+    def <=>(other : self)
+      value <=> other.value
+    end
+
+    def succ : self
+      CharLiteral.new(value.succ)
+    end
 
     def pretty_print(pp) : Nil
       pp_type(pp, "CharLiteral[", "]") do


### PR DESCRIPTION
Currently, `RangeLiteral#each` and `#map` and `#to_a` as well as `{% for range %}` only work with numeric ranges. This patch adds support for ranges of `CharLiteral`, which we can iterate just like `NumberLiteral`.

Iterating `CharLiteral` is useful for building lookup tables for characters. They are better readable than the equivalent `NumberLiteral` expression.

For example:
```cr
NUMERIC_CHARS = {% begin %}
    {%
      table = (0...256).map { 0 }
      ('0'..'9').each do |c|
        table[c.ord] = 1
      end
    %}
    Slice.literal({{ table.splat }})
  {% end %}
```

Theoretically, we could do the same for `StringLiteral`, although I don't see a big use case for that.

<del>The first two commits are a bit of prefactoring. I'll probably extract them to independent PRs.</del>

