### PR TITLE
Add `StringLiteral#bytesize`

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -419,7 +419,7 @@ module Crystal
       end
     end
 
-    describe "string methods" do
+    describe StringLiteral do
       it "executes string == string" do
         assert_macro %({{"foo" == "foo"}}), %(true)
         assert_macro %({{"foo" == "bar"}}), %(false)
@@ -478,6 +478,11 @@ module Crystal
 
       it "executes size" do
         assert_macro %({{"hello".size}}), "5"
+      end
+
+      it "executes bytesize" do
+        assert_macro %({{"hello".bytesize}}), "5"
+        assert_macro %({{"hellö".bytesize}}), "6"
       end
 
       it "executes count" do

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -22,6 +22,10 @@ private macro def_string_methods(klass)
   def +(other : StringLiteral | CharLiteral) : {{klass}}
   end
 
+  # Similar to `String#bytesize`.
+  def bytesize : NumberLiteral
+  end
+
   # Similar to `String#camelcase`.
   def camelcase(*, lower : BoolLiteral = false) : {{klass}}
   end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -711,6 +711,8 @@ module Crystal
 
           StringLiteral.new(@value * num)
         end
+      when "bytesize"
+        interpret_check_args { NumberLiteral.new(@value.bytesize) }
       when "camelcase"
         interpret_check_args(named_params: ["lower"]) do
           lower = if named_args && (lower_arg = named_args["lower"]?)


### PR DESCRIPTION
Knowing the bytesize of strings at compile time can be useful for preparing a sufficiently sized buffer.

See for example
https://github.com/crystal-lang/crystal/blob/fb34eb5452b581fef9275646f29c06376df43ecf/src/enum.cr#L512-L514