### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "e40cd636dc3da7b510a97b718411ecee2dbce3ff"
+    default: "99307df7081199ae647f7ea0105371108d69e441"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "03842c696334f7885374ad530b3260eb9b8263bd"
+    default: "e40cd636dc3da7b510a97b718411ecee2dbce3ff"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "99307df7081199ae647f7ea0105371108d69e441"
+    default: "37f308f9287b0476861872a6d34b04b47c675e48"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "5ebcbec18acc95b018e54dfcbc38fd4020e82e8b"
+    default: "03842c696334f7885374ad530b3260eb9b8263bd"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "4205934e01733848a559a2908a14dcb16be7f38f"
+    default: "5ebcbec18acc95b018e54dfcbc38fd4020e82e8b"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/37f308f9287b0476861872a6d34b04b47c675e48

This includes the following changes:

* crystal-lang/distribution-scripts#442
* crystal-lang/distribution-scripts#444
* crystal-lang/distribution-scripts#443
* crystal-lang/distribution-scripts#439
* crystal-lang/distribution-scripts#440
* crystal-lang/distribution-scripts#438
* crystal-lang/distribution-scripts#434
* crystal-lang/distribution-scripts#436
* crystal-lang/distribution-scripts#435
* crystal-lang/distribution-scripts#425
* crystal-lang/distribution-scripts#437
* crystal-lang/distribution-scripts#432
* crystal-lang/distribution-scripts#433
* crystal-lang/distribution-scripts#429
* crystal-lang/distribution-scripts#427
* crystal-lang/distribution-scripts#424
* crystal-lang/distribution-scripts#419
* crystal-lang/distribution-scripts#420
* crystal-lang/distribution-scripts#422
* crystal-lang/distribution-scripts#421
* crystal-lang/distribution-scripts#423
* crystal-lang/distribution-scripts#417
* crystal-lang/distribution-scripts#410
* crystal-lang/distribution-scripts#412
* crystal-lang/distribution-scripts#411
* crystal-lang/distribution-scripts#413
* crystal-lang/distribution-scripts#406
* crystal-lang/distribution-scripts#405
* crystal-lang/distribution-scripts#403