### PR TITLE
Add `XML::Node#line_number`

### DIFF
--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -636,4 +636,38 @@ describe XML do
   it ".libxml2_version" do
     XML.libxml2_version.should match /2\.\d+\.\d+/
   end
+
+  describe "#line_number" do
+    it "returns the line number of a node in the source document" do
+      doc = XML.parse(<<-XML)
+        <?xml version='1.0' encoding='UTF-8'?>
+        <people>
+          <person/>
+        </people>
+        XML
+
+      root = doc.root.should_not(be_nil)
+      root.line_number.should eq(2)
+      root.first_element_child.should_not(be_nil).line_number.should eq(3)
+    end
+
+    it "reports line numbers greater than 65535 with the BIG_LINES option" do
+      newlines = 70_000
+      # libxml2 stores big line numbers in the PSVI field of text nodes, so the
+      # element needs some text content for `xmlGetLineNo` to recover the value.
+      xml = "#{"\n" * (newlines - 1)}<root>x</root>"
+
+      # Without BIG_LINES the raw 16-bit `line` field saturates at 65535, which
+      # is exactly why `#line_number` must go through `xmlGetLineNo`.
+      XML.parse(xml).root.should_not(be_nil).line_number.should eq(65_535)
+
+      doc = XML.parse(xml, XML::ParserOptions.default | XML::ParserOptions::BIG_LINES)
+      doc.root.should_not(be_nil).line_number.should eq(newlines)
+    end
+
+    it "returns nil when the line number is not available" do
+      # The document node itself carries no source line.
+      XML.parse("<root/>").line_number.should be_nil
+    end
+  end
 end

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -186,6 +186,7 @@ lib LibXML
   fun xmlXPathNodeSetCreate(node : Node*) : NodeSet*
   fun xmlXPathNodeSetAddUnique(cur : NodeSet*, val : Node*) : Int
   fun xmlNodeGetContent(node : Node*) : UInt8*
+  fun xmlGetLineNo(node : Node*) : LibC::Long
   fun xmlNodeSetContent(node : Node*, content : UInt8*)
   fun xmlNodeSetName(node : Node*, name : UInt8*)
   fun xmlUnlinkNode(node : Node*)

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -365,8 +365,8 @@ class XML::Node
   # doc.root.not_nil!.first_element_child.not_nil!.line_number # => 3
   # ```
   def line_number : Int64?
-    line = LibXML.xmlGetLineNo(@node)
-    line == -1 ? nil : line.to_i64
+    line_number = LibXML.xmlGetLineNo(@node)
+    line_number.to_i64 unless line_number == -1
   end
 
   # Returns the name for this Node.

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -346,6 +346,29 @@ class XML::Node
     nil
   end
 
+  # Returns the line number in the source document where this Node was parsed,
+  # or `nil` if the information is not available (for example, a Node that was
+  # not parsed from a document).
+  #
+  # Line numbers greater than `65535` are only reported when the document was
+  # parsed with the `XML::ParserOptions::BIG_LINES` option, which is not part of
+  # `XML::ParserOptions.default`.
+  #
+  # ```
+  # doc = XML.parse(<<-XML)
+  #   <?xml version='1.0' encoding='UTF-8'?>
+  #   <people>
+  #     <person/>
+  #   </people>
+  #   XML
+  # doc.root.not_nil!.line_number                              # => 2
+  # doc.root.not_nil!.first_element_child.not_nil!.line_number # => 3
+  # ```
+  def line_number : Int64?
+    line = LibXML.xmlGetLineNo(@node)
+    line == -1 ? nil : line.to_i64
+  end
+
   # Returns the name for this Node.
   def name : String
     if document?


### PR DESCRIPTION
## Add `XML::Node#line_number`

`XML::Node` has no way to report the line number of a node in its source
document, even though libxml2 — the parser behind `XML` — tracks it.

The stdlib is already halfway there, which makes the gap sharper:

- `XML::ParserOptions::BIG_LINES` is exposed and documented ("Store big lines
  numbers in text PSVI field"). Its only purpose is to make line numbers beyond
  65535 readable.
- `LibXML::Node` already carries the `line : UInt16` field.
- But `xmlGetLineNo()` was bound nowhere and `XML::Node` exposed no accessor.

In other words: you could ask libxml2 to record big line numbers, with no way
to read them back. This PR closes that.

### Changes

- Bind `long xmlGetLineNo(const xmlNode *)` in `src/xml/libxml2.cr`.
- Add `XML::Node#line_number : Int64?` in `src/xml/node.cr`.

### Design notes

- Named `#line_number` rather than `#line`, matching the existing
  `XML::Error#line_number`.
- Routes through `xmlGetLineNo()` rather than reading the raw `line` field:
  `xmlGetLineNo` fetches the extended value from `psvi` when `BIG_LINES` is
  active and falls back to the 16-bit field otherwise. Reading the field
  directly would silently cap at 65535 and make `BIG_LINES` unusable.
- Return type `Int64?`: `xmlGetLineNo` returns `long` and yields `-1` when the
  information is unavailable. `nil` for that case matches the nil-for-absence
  convention already used throughout `node.cr` (`#parent`, `#root`,
  `#namespace`, …), and `Int64` mirrors the C `long` so big line numbers are
  never re-capped.

### Specs

Under `spec/std/xml/xml_spec.cr`: a node in a short document, a node past line
65535 with `BIG_LINES` (the case that justifies going through `xmlGetLineNo`,
contrasted with the 65535 cap without the option), and the unavailable case.

No API break: addition only.
