### PR TITLE
Use unchecked arithmetic in compiler-rt ports

### DIFF
--- a/src/crystal/compiler_rt/divmod128.cr
+++ b/src/crystal/compiler_rt/divmod128.cr
@@ -4,11 +4,11 @@
 fun __divti3(a : Int128, b : Int128) : Int128
   # Ported from https://github.com/llvm/llvm-project/blob/ce59ccd04023cab3a837da14079ca2dcbfebb70c/compiler-rt/lib/builtins/int_div_impl.inc
 
-  s_a = a >> 127       # s_a = a < 0 ? -1 : 0
-  s_b = b >> 127       # s_b = b < 0 ? -1 : 0
-  a = (a ^ s_a) &- s_a # negate if s_a == -1
-  b = (b ^ s_b) &- s_b # negate if s_b == -1
-  s_a ^= s_b           # sign of quotient
+  s_a = a.unsafe_shr(127) # s_a = a < 0 ? -1 : 0
+  s_b = b.unsafe_shr(127) # s_b = b < 0 ? -1 : 0
+  a = (a ^ s_a) &- s_a    # negate if s_a == -1
+  b = (b ^ s_b) &- s_b    # negate if s_b == -1
+  s_a ^= s_b              # sign of quotient
   quo, _ = _u128_div_rem(a.to_u128!, b.to_u128!)
   ((quo ^ s_a) &- s_a).to_i128! # negate if s_a == -1
 end
@@ -17,10 +17,10 @@ end
 fun __modti3(a : Int128, b : Int128) : Int128
   # Ported from https://github.com/llvm/llvm-project/blob/ce59ccd04023cab3a837da14079ca2dcbfebb70c/compiler-rt/lib/builtins/int_div_impl.inc
 
-  s = b >> 127     # s = b < 0 ? -1 : 0
-  b = (b ^ s) &- s # negate if s == -1
-  s = a >> 127     # s = a < 0 ? -1 : 0
-  a = (a ^ s) &- s # negate if s == -1
+  s = b.unsafe_shr(127) # s = b < 0 ? -1 : 0
+  b = (b ^ s) &- s      # negate if s == -1
+  s = a.unsafe_shr(127) # s = a < 0 ? -1 : 0
+  a = (a ^ s) &- s      # negate if s == -1
   _, rem = _u128_div_rem(a.to_u128!, b.to_u128!)
   (rem.to_i128! ^ s) &- s # negate if s == -1
 end
@@ -46,7 +46,7 @@ def _carrying_mul(lhs : UInt64, rhs : UInt64) : Tuple(UInt64, UInt64)
   # Ported from https://github.com/rust-lang/compiler-builtins/blob/2be2bc086bd9b3c0fc8eb8d2dc7df025e6ffd318/src/int/specialized_div_rem/trifecta.rs
 
   tmp = lhs.to_u128! &* rhs.to_u128!
-  {tmp.to_u64!, (tmp >> 64).to_u64!}
+  {tmp.to_u64!, tmp.unsafe_shr(64).to_u64!}
 end
 
 # :nodoc:
@@ -56,7 +56,7 @@ def _carrying_mul_add(lhs : UInt64, mul : UInt64, add : UInt64) : Tuple(UInt64, 
   tmp = lhs.to_u128!
   tmp &*= mul.to_u128!
   tmp &+= add.to_u128!
-  {tmp.to_u64!, (tmp >> 64).to_u64!}
+  {tmp.to_u64!, tmp.unsafe_shr(64).to_u64!}
 end
 
 # :nodoc:
@@ -78,7 +78,7 @@ def _u128_div_rem(duo : UInt128, div : UInt128) : Tuple(UInt128, UInt128)
     # Resulting quotient is 0 or 1 at this point
     # The highest set bit of `duo` needs to be at least one place higher than `div` for the quotient to be more than one.
     if duo >= div
-      return {1_u128, duo - div}
+      return {1_u128, duo &- div}
     else
       return {0_u128, duo}
     end
@@ -88,31 +88,31 @@ def _u128_div_rem(duo : UInt128, div : UInt128) : Tuple(UInt128, UInt128)
   if duo_lz >= 64
     # duo fits in a 64-bit integer
     # Because of the previous branch (div_lz <= duo_lz), div will also fit in an 64-bit integer
-    quo_local1 = duo.to_u64! // div.to_u64!
-    rem_local1 = duo.to_u64! % div.to_u64!
+    quo_local1 = duo.to_u64!.unsafe_div(div.to_u64!)
+    rem_local1 = duo.to_u64!.unsafe_mod(div.to_u64!)
     return {quo_local1.to_u128!, rem_local1.to_u128!}
   end
 
   # Short division branch
   if div_lz >= 96
-    duo_hi = (duo >> 64).to_u64!
+    duo_hi = duo.unsafe_shr(64).to_u64!
     div_0 = div.to_u32!.to_u64!
-    quo_hi = duo_hi // div_0
-    rem_3 = duo_hi % div_0
+    quo_hi = duo_hi.unsafe_div(div_0)
+    rem_3 = duo_hi.unsafe_mod(div_0)
 
-    duo_mid = (duo >> 32).to_u32!.to_u64! | (rem_3 << 32)
-    quo_1 = duo_mid // div_0
-    rem_2 = duo_mid % div_0
+    duo_mid = duo.unsafe_shr(32).to_u32!.to_u64! | rem_3.unsafe_shl(32)
+    quo_1 = duo_mid.unsafe_div(div_0)
+    rem_2 = duo_mid.unsafe_mod(div_0)
 
-    duo_lo = duo.to_u32!.to_u64! | (rem_2 << 32)
-    quo_0 = duo_lo // div_0
-    rem_1 = duo_lo % div_0
+    duo_lo = duo.to_u32!.to_u64! | rem_2.unsafe_shl(32)
+    quo_0 = duo_lo.unsafe_div(div_0)
+    rem_1 = duo_lo.unsafe_mod(div_0)
 
-    return {quo_0.to_u128! | (quo_1.to_u128! << 32) | (quo_hi.to_u128! << 64), rem_1.to_u128!}
+    return {quo_0.to_u128! | quo_1.to_u128!.unsafe_shl(32) | quo_hi.to_u128!.unsafe_shl(64), rem_1.to_u128!}
   end
 
   # Relative leading significant bits (cannot overflow because of above branches)
-  lz_diff = div_lz - duo_lz
+  lz_diff = div_lz &- duo_lz
 
   if lz_diff < 32
     # Two possibility division algorithm
@@ -121,66 +121,66 @@ def _u128_div_rem(duo : UInt128, div : UInt128) : Tuple(UInt128, UInt128)
     # If we take the n most significant bits of duo and divide them by the corresponding bits in div, it produces the quotient value quo.
     # It happens that quo or quo - 1 will always be the correct quotient for the whole number.
 
-    shift = 64 - duo_lz
-    duo_sig_n = (duo >> shift).to_u64!
-    div_sig_n = (div >> shift).to_u64!
-    quo_local2 = duo_sig_n // div_sig_n
+    shift = 64 &- duo_lz
+    duo_sig_n = duo.unsafe_shr(shift).to_u64!
+    div_sig_n = div.unsafe_shr(shift).to_u64!
+    quo_local2 = duo_sig_n.unsafe_div(div_sig_n)
 
     # The larger quo can overflow, so a manual carrying mul is used with manual overflow checking.
     div_lo = div.to_u64!
-    div_hi = (div >> 64).to_u64!
+    div_hi = div.unsafe_shr(64).to_u64!
     tmp_lo, carry = _carrying_mul(quo_local2, div_lo)
     tmp_hi, overflow = _carrying_mul_add(quo_local2, div_hi, carry)
-    tmp = tmp_lo.to_u128! | (tmp_hi.to_u128! << 64)
+    tmp = tmp_lo.to_u128! | tmp_hi.to_u128!.unsafe_shl(64)
     if (overflow != 0) || (duo < tmp)
       # In `duo &+ div &- tmp`, both the subtraction and addition can overflow, but the result is always a correct positive number.
-      return {(quo_local2 - 1).to_u128!, duo &+ div &- tmp}
+      return {(quo_local2 &- 1).to_u128!, duo &+ div &- tmp}
     else
-      return {quo_local2.to_u128!, duo - tmp}
+      return {quo_local2.to_u128!, duo &- tmp}
     end
   end
 
   # Undersubtracting long division algorithm.
 
   quo : UInt128 = 0
-  div_extra = 96 - div_lz                  # Number of lesser significant bits that aren't part of div_sig_32
-  div_sig_32 = (div >> div_extra).to_u32!  # Most significant 32 bits of div
-  div_sig_32_add1 = div_sig_32.to_u64! + 1 # This must be a UInt64 because this can overflow
+  div_extra = 96 &- div_lz                       # Number of lesser significant bits that aren't part of div_sig_32
+  div_sig_32 = div.unsafe_shr(div_extra).to_u32! # Most significant 32 bits of div
+  div_sig_32_add1 = div_sig_32.to_u64! &+ 1      # This must be a UInt64 because this can overflow
 
   loop do
-    duo_extra = 64 - duo_lz                # Number of lesser significant bits that aren't part of duo_sig_n
-    duo_sig_n = (duo >> duo_extra).to_u64! # Most significant 64 bits of duo
+    duo_extra = 64 &- duo_lz                      # Number of lesser significant bits that aren't part of duo_sig_n
+    duo_sig_n = duo.unsafe_shr(duo_extra).to_u64! # Most significant 64 bits of duo
 
     # The two possibility algorithm requires that the difference between most significant bits is less than 32
     if div_extra <= duo_extra
       # Undersubtracting long division step
-      quo_part = (duo_sig_n // div_sig_32_add1).to_u128!
-      extra_shl = duo_extra - div_extra
+      quo_part = duo_sig_n.unsafe_div(div_sig_32_add1).to_u128!
+      extra_shl = duo_extra &- div_extra
 
       # Addition to the quotient
-      quo += (quo_part << extra_shl)
+      quo &+= quo_part.unsafe_shl(extra_shl)
 
       # Subtraction from duo. At least 31 bits are cleared from duo here
-      duo -= ((div &* quo_part) << extra_shl)
+      duo &-= (div &* quo_part).unsafe_shl(extra_shl)
     else
       # Two possibility algorithm
 
-      shift = 64 - duo_lz
-      duo_sig_n = (duo >> shift).to_u64!
-      div_sig_n = (div >> shift).to_u64!
-      quo_part = duo_sig_n // div_sig_n
+      shift = 64 &- duo_lz
+      duo_sig_n = duo.unsafe_shr(shift).to_u64!
+      div_sig_n = div.unsafe_shr(shift).to_u64!
+      quo_part = duo_sig_n.unsafe_div(div_sig_n)
       div_lo = div.to_u64!
-      div_hi = (div >> 64).to_u64!
+      div_hi = div.unsafe_shr(64).to_u64!
 
       tmp_lo, carry = _carrying_mul(quo_part, div_lo)
       # The undersubtracting long division algorithm has already run once, so overflow beyond 128 bits is impossible
       tmp_hi, _ = _carrying_mul_add(quo_part, div_hi, carry)
-      tmp = tmp_lo.to_u128! | (tmp_hi.to_u128! << 64)
+      tmp = tmp_lo.to_u128! | tmp_hi.to_u128!.unsafe_shl(64)
 
       if duo < tmp
-        return {quo + (quo_part - 1), duo &+ div &- tmp}
+        return {quo &+ (quo_part &- 1), duo &+ div &- tmp}
       else
-        return {quo + quo_part, duo - tmp}
+        return {quo &+ quo_part, duo &- tmp}
       end
     end
 
@@ -189,7 +189,7 @@ def _u128_div_rem(duo : UInt128, div : UInt128) : Tuple(UInt128, UInt128)
     if div_lz <= duo_lz
       # Quotient can have 0 or 1 added to it
       if div <= duo
-        return {quo + 1, duo - div}
+        return {quo &+ 1, duo &- div}
       else
         return {quo, duo}
       end
@@ -197,9 +197,9 @@ def _u128_div_rem(duo : UInt128, div : UInt128) : Tuple(UInt128, UInt128)
 
     # This can only happen if div_sd < 64
     if 64 <= duo_lz
-      quo_local3 = duo.to_u64! // div.to_u64!
-      rem_local2 = duo.to_u64! % div.to_u64!
-      return {quo + quo_local3, rem_local2.to_u128!}
+      quo_local3 = duo.to_u64!.unsafe_div(div.to_u64!)
+      rem_local2 = duo.to_u64!.unsafe_mod(div.to_u64!)
+      return {quo &+ quo_local3, rem_local2.to_u128!}
     end
   end
 end

--- a/src/crystal/compiler_rt/fixint.cr
+++ b/src/crystal/compiler_rt/fixint.cr
@@ -27,8 +27,12 @@ private macro __fixint_impl(name, from, to)
       end
 
       # If 0 <= exponent < significandBits, right shift to get the result.
-      # Otherwise, shift left. (`#<<` handles this)
-      {{to}}.new!(sign) * ({{to}}.new!(significand) << (exponent &- significand_bits))
+      # Otherwise, shift left.
+      if exponent < significand_bits
+        {{to}}.new!(sign) &* {{to}}.new!(significand).unsafe_shr(significand_bits &- exponent)
+      else
+        {{to}}.new!(sign) &* {{to}}.new!(significand).unsafe_shl(exponent &- significand_bits)
+      end
     {% else %}
       # If either the value or the exponent is negative, the result is zero.
       if sign == -1 || exponent < 0
@@ -41,8 +45,12 @@ private macro __fixint_impl(name, from, to)
       end
 
       # If 0 <= exponent < significandBits, right shift to get the result.
-      # Otherwise, shift left. (`#<<` handles this)
-      {{to}}.new!(significand) << (exponent &- significand_bits)
+      # Otherwise, shift left.
+      if exponent < significand_bits
+        {{to}}.new!(significand).unsafe_shr(significand_bits &- exponent)
+      else
+        {{to}}.new!(significand).unsafe_shl(exponent &- significand_bits)
+      end
     {% end %}
   end
 end

--- a/src/crystal/compiler_rt/mul.cr
+++ b/src/crystal/compiler_rt/mul.cr
@@ -17,19 +17,19 @@ private macro __mul_impl(name, type, n)
       end
       return result
     end
-    sa = a >> {{n - 1}}
+    sa = a.unsafe_shr({{n - 1}})
     abs_a = (a ^ sa) &- sa
-    sb = b >> {{n - 1}}
+    sb = b.unsafe_shr({{n - 1}})
     abs_b = (b ^ sb) &- sb
     if abs_a < 2 || abs_b < 2
       return result
     end
     if sa == sb
-      if abs_a > ({{type}}::MAX // abs_b)
+      if abs_a > {{type}}::MAX.unsafe_div(abs_b)
         overflow.value = 1
       end
     else
-      if abs_a > ({{type}}::MIN // ({{type}}.new(0) &- abs_b))
+      if abs_a > {{type}}::MIN.unsafe_div({{type}}.new!(0) &- abs_b)
         overflow.value = 1
       end
     end

--- a/src/crystal/compiler_rt/multi3.cr
+++ b/src/crystal/compiler_rt/multi3.cr
@@ -1,32 +1,32 @@
 private def __mulddi3(a : UInt64, b : UInt64) : Int128
-  bits_in_dword_2 = (sizeof(Int64) &* 8) // 2
-  lower_mask = ~0_u64 >> bits_in_dword_2
+  bits_in_dword_2 = (sizeof(Int64) &* 8).unsafe_div(2)
+  lower_mask = (~0_u64).unsafe_shr(bits_in_dword_2)
 
   low = (a & lower_mask) &* (b & lower_mask)
-  t = low >> bits_in_dword_2
+  t = low.unsafe_shr(bits_in_dword_2)
   low &= lower_mask
-  t &+= (a >> bits_in_dword_2) &* (b & lower_mask)
-  low &+= (t & lower_mask) << bits_in_dword_2
-  high = t >> bits_in_dword_2
-  t = low >> bits_in_dword_2
+  t &+= a.unsafe_shr(bits_in_dword_2) &* (b & lower_mask)
+  low &+= (t & lower_mask).unsafe_shl(bits_in_dword_2)
+  high = t.unsafe_shr(bits_in_dword_2)
+  t = low.unsafe_shr(bits_in_dword_2)
   low &= lower_mask
-  t &+= (b >> bits_in_dword_2) &* (a & lower_mask)
-  low &+= (t & lower_mask) << bits_in_dword_2
-  high &+= t >> bits_in_dword_2
-  high &+= (a >> bits_in_dword_2) &* (b >> bits_in_dword_2)
+  t &+= b.unsafe_shr(bits_in_dword_2) &* (a & lower_mask)
+  low &+= (t & lower_mask).unsafe_shl(bits_in_dword_2)
+  high &+= t.unsafe_shr(bits_in_dword_2)
+  high &+= a.unsafe_shr(bits_in_dword_2) &* b.unsafe_shr(bits_in_dword_2)
 
-  (high.to_i128! << 64) &+ low
+  high.to_i128!.unsafe_shl(64) &+ low
 end
 
 # :nodoc:
 # Ported from https://github.com/llvm/llvm-project/blob/ce59ccd04023cab3a837da14079ca2dcbfebb70c/compiler-rt/lib/builtins/multi3.c
 fun __multi3(a : Int128, b : Int128) : Int128
   a_low = (a & ~0_u64).to_u64!
-  a_high = (a >> 64).to_i64!
+  a_high = a.unsafe_shr(64).to_i64!
   b_low = (b & ~0_u64).to_u64!
-  b_high = (b >> 64).to_i64!
+  b_high = b.unsafe_shr(64).to_i64!
 
   result = __mulddi3(a_low, b_low)
-  result &+= ((a_high &* b_low) &+ (a_low &* b_high)).to_i128! << 64
+  result &+= ((a_high &* b_low) &+ (a_low &* b_high)).to_i128!.unsafe_shl(64)
   result
 end

--- a/src/crystal/compiler_rt/pow.cr
+++ b/src/crystal/compiler_rt/pow.cr
@@ -12,7 +12,7 @@ private macro __pow_impl(name, one, float_type)
       a *= a
     end
 
-    recip ? 1 / r : r
+    recip ? {{float_type}}.new(1) / r : r
   end
 end
 


### PR DESCRIPTION
These are all source ports of implementations using unchecked arithmetic, so they cannot overflow (or any overflow is proven to be harmless).