### PR TITLE
Fix missing NULL terminator for `execve` vargs

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -1088,6 +1088,15 @@ describe Process do
   end
 
   {% unless flag?(:win32) %}
+    describe "Crystal::System::Process.prepare_args" do
+      it "null-terminates argv for execve (#17183)" do
+        _, argv = Crystal::System::Process.prepare_args(["echo", "hello"])
+        String.new(argv[0]).should eq("echo")
+        String.new(argv[1]).should eq("hello")
+        argv[2].null?.should be_true
+      end
+    end
+
     describe "#signal(Signal::KILL)" do
       it "kills a process" do
         process = Process.new(*standing_command)

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -310,8 +310,7 @@ struct Crystal::System::Process
 
   def self.prepare_args(args : Enumerable(String)) : {String, LibC::Char**}
     pathname = args.first
-    # `execve` requires argv[argc] == NULL. Allocate the terminator slot
-    # explicitly; do not rely on GC size-class padding beyond the request.
+    # `execve` requires NULL terminator
     argv = Pointer(Pointer(UInt8)).malloc(args.size + 1)
     args.each_with_index do |arg, i|
       argv[i] = arg.check_no_null_byte.to_unsafe

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -310,7 +310,9 @@ struct Crystal::System::Process
 
   def self.prepare_args(args : Enumerable(String)) : {String, LibC::Char**}
     pathname = args.first
-    argv = Pointer(Pointer(UInt8)).malloc(args.size)
+    # `execve` requires argv[argc] == NULL. Allocate the terminator slot
+    # explicitly; do not rely on GC size-class padding beyond the request.
+    argv = Pointer(Pointer(UInt8)).malloc(args.size + 1)
     args.each_with_index do |arg, i|
       argv[i] = arg.check_no_null_byte.to_unsafe
     end


### PR DESCRIPTION
## Summary
- `Crystal::System::Process.prepare_args` allocated `args.size` pointers for `execve` argv without the required trailing `NULL`.
- Boehm size-class padding usually masked this; exact-fit allocators fail with `EFAULT` (`Bad address`).
- Allocate `args.size + 1` and add a regression spec.
Fixes #17183
Related discovery: https://github.com/sdogruyol/gcry/issues/14