### PR TITLE
Fix coverage hits for Expressions under "else" macros

### DIFF
--- a/spec/compiler/crystal/tools/macro_code_coverage_spec.cr
+++ b/spec/compiler/crystal/tools/macro_code_coverage_spec.cr
@@ -1027,122 +1027,120 @@ describe "macro_code_coverage" do
     test 2
     CRYSTAL
 
-  # then-body is Expressions - case 1:  top-level block-form if/else, both branches taken across expansions
+  # else is Expressions: top-level if/else statement, both branches taken across expansions
   assert_coverage <<-'CRYSTAL', {2 => 2, 4 => 1}
-    macro define_view(downcase)
-      {% if downcase %}
+    macro test(val)
+      {% if val %}
         1 + 1
       {% else %}
         2 + 2
       {% end %}
     end
 
-    define_view(true)
-    define_view(false)
+    test(true)
+    test(false)
     CRYSTAL
 
-  # then-body is Expressions - case 2 : block-form if/else inside a def, no outer `if`
+  # else is Expressions: if/else statement inside a def, no outer `if`
   assert_coverage <<-'CRYSTAL', {4 => 2, 6 => 1}
-    macro define_view(downcase)
-      struct View
+    macro test(val)
+      struct Example
         def foo
-          {% if downcase %}
-            puts "downcase"
+          {% if val %}
+            puts "true"
           {% else %}
-            puts "else"
+            puts "false"
           {% end %}
         end
       end
     end
 
-    define_view(true)
-    define_view(false)
+    test(true)
+    test(false)
     CRYSTAL
 
-  # then-body is Expressions - case 3 : block-form if/else inside a def wrapped in a runtime `if ov`
+  # else is Expressions: if/else statement inside a def wrapped in a runtime `if v`
   assert_coverage <<-'CRYSTAL', {2 => 2, 5 => 2, 7 => 1}
-    macro define_view(name, downcase)
+    macro test(name, val)
       struct {{name}}
-        def foo(ov)
-          if ov
-            {% if downcase %}
-              puts "downcase"
+        def foo(v)
+          if v
+            {% if val %}
+              puts "true"
             {% else %}
-              return ov if ov
+              return v if v
             {% end %}
           end
         end
       end
     end
 
-    define_view(A, true)
-    define_view(B, false)
+    test(A, true)
+    test(B, false)
     CRYSTAL
 
-  # then-body is Expressions - case 4 : two-method version: sibling method (foo2)
-  # with an inline-form MacroIf must not corrupt foo1's block-form MacroIf coverage.
-  # Neither the `if` line nor the `else`-associated line should ever read 0
-  # once both branches were actually exercised.
+  # else is Expressions: inline MacroIf (foo2) must not affect a sibling
+  # method's if/else statement coverage (foo1). Neither branch reads 0.
   assert_coverage <<-'CRYSTAL', {2 => 2, 5 => 2, 7 => 1, 13 => "2/2"}
-    macro define_overlay_view(name, downcase)
+    macro test(name, flag)
       struct {{name}}
-        def foo1(ov)
-          if ov
-            {% if downcase %}
-              ov.each { |k, v| puts v }
+        def foo1(v)
+          if v
+            {% if flag %}
+              v.each { |k, v| puts v }
             {% else %}
-              return ov if ov
+              return v if v
             {% end %}
           end
         end
         def foo2
-          ({} of String => String)[{% if downcase %} "a".downcase {% else %} "a" {% end %}] = "b"
+          x = {% if flag %} "a" {% else %} "b" {% end %}
         end
       end
     end
-    define_overlay_view(A, true)
-    define_overlay_view(B, false)
+    test(A, true)
+    test(B, false)
     CRYSTAL
 
-  # then-body is Expressions - case 5 : three-method extended version: duplicate-body branches (foo3) must
-  # still be tracked correctly and not regress foo1/foo2's coverage.
+  # else is Expressions: same as above, plus a third method (foo3) with two
+  # duplicate-body if/else statements, to check the separated tracking.
   assert_coverage <<-'CRYSTAL', {2 => 2, 5 => 2, 7 => 1, 14 => "2/2", 19 => 2, 21 => 1, 27 => 2, 29 => 1}
-    macro define_overlay_view(name, downcase)
+    macro test(name, flag)
       struct {{name}}
-        def foo1(ov)
-          if ov
-            {% if downcase %}
-              ov.each { |k, v| puts v }
+        def foo1(v)
+          if v
+            {% if flag %}
+              v.each { |k, v| puts v }
             {% else %}
-              return ov if ov
+              return v if v
             {% end %}
           end
         end
 
         def foo2
-          ({} of String => String)[{% if downcase %} "a".downcase {% else %} "a" {% end %}] = "b"
+          x = {% if flag %} "a" {% else %} "b" {% end %}
         end
 
-        def foo3(ov)
-          if ov.nil?
-            {% if downcase %}
-              ov.each { |k, v| puts v }
+        def foo3(v)
+          if v.nil?
+            {% if flag %}
+              v.each { |k, v| puts v }
             {% else %}
-              ov.each { |k, v| puts v }
+              v.each { |k, v| puts v }
             {% end %}
             return
           end
 
-          {% if downcase %}
-            ov.each { |k, v| puts v }
+          {% if flag %}
+            v.each { |k, v| puts v }
           {% else %}
-            ov.each { |k, v| puts v }
+            v.each { |k, v| puts v }
           {% end %}
         end
       end
     end
 
-    define_overlay_view(A, true)
-    define_overlay_view(B, false)
+    test(A, true)
+    test(B, false)
     CRYSTAL
 end

--- a/spec/compiler/crystal/tools/macro_code_coverage_spec.cr
+++ b/spec/compiler/crystal/tools/macro_code_coverage_spec.cr
@@ -1026,4 +1026,123 @@ describe "macro_code_coverage" do
     test 1
     test 2
     CRYSTAL
+
+  # then-body is Expressions - case 1:  top-level block-form if/else, both branches taken across expansions
+  assert_coverage <<-'CRYSTAL', {2 => 2, 4 => 1}
+    macro define_view(downcase)
+      {% if downcase %}
+        1 + 1
+      {% else %}
+        2 + 2
+      {% end %}
+    end
+
+    define_view(true)
+    define_view(false)
+    CRYSTAL
+
+  # then-body is Expressions - case 2 : block-form if/else inside a def, no outer `if`
+  assert_coverage <<-'CRYSTAL', {4 => 2, 6 => 1}
+    macro define_view(downcase)
+      struct View
+        def foo
+          {% if downcase %}
+            puts "downcase"
+          {% else %}
+            puts "else"
+          {% end %}
+        end
+      end
+    end
+
+    define_view(true)
+    define_view(false)
+    CRYSTAL
+
+  # then-body is Expressions - case 3 : block-form if/else inside a def wrapped in a runtime `if ov`
+  assert_coverage <<-'CRYSTAL', {2 => 2, 5 => 2, 7 => 1}
+    macro define_view(name, downcase)
+      struct {{name}}
+        def foo(ov)
+          if ov
+            {% if downcase %}
+              puts "downcase"
+            {% else %}
+              return ov if ov
+            {% end %}
+          end
+        end
+      end
+    end
+
+    define_view(A, true)
+    define_view(B, false)
+    CRYSTAL
+
+  # then-body is Expressions - case 4 : two-method version: sibling method (foo2)
+  # with an inline-form MacroIf must not corrupt foo1's block-form MacroIf coverage.
+  # Neither the `if` line nor the `else`-associated line should ever read 0
+  # once both branches were actually exercised.
+  assert_coverage <<-'CRYSTAL', {2 => 2, 5 => 2, 7 => 1, 13 => "2/2"}
+    macro define_overlay_view(name, downcase)
+      struct {{name}}
+        def foo1(ov)
+          if ov
+            {% if downcase %}
+              ov.each { |k, v| puts v }
+            {% else %}
+              return ov if ov
+            {% end %}
+          end
+        end
+        def foo2
+          ({} of String => String)[{% if downcase %} "a".downcase {% else %} "a" {% end %}] = "b"
+        end
+      end
+    end
+    define_overlay_view(A, true)
+    define_overlay_view(B, false)
+    CRYSTAL
+
+  # then-body is Expressions - case 5 : three-method extended version: duplicate-body branches (foo3) must
+  # still be tracked correctly and not regress foo1/foo2's coverage.
+  assert_coverage <<-'CRYSTAL', {2 => 2, 5 => 2, 7 => 1, 14 => "2/2", 19 => 2, 21 => 1, 27 => 2, 29 => 1}
+    macro define_overlay_view(name, downcase)
+      struct {{name}}
+        def foo1(ov)
+          if ov
+            {% if downcase %}
+              ov.each { |k, v| puts v }
+            {% else %}
+              return ov if ov
+            {% end %}
+          end
+        end
+
+        def foo2
+          ({} of String => String)[{% if downcase %} "a".downcase {% else %} "a" {% end %}] = "b"
+        end
+
+        def foo3(ov)
+          if ov.nil?
+            {% if downcase %}
+              ov.each { |k, v| puts v }
+            {% else %}
+              ov.each { |k, v| puts v }
+            {% end %}
+            return
+          end
+
+          {% if downcase %}
+            ov.each { |k, v| puts v }
+          {% else %}
+            ov.each { |k, v| puts v }
+          {% end %}
+        end
+      end
+    end
+
+    define_overlay_view(A, true)
+    define_overlay_view(B, false)
+    CRYSTAL
 end

--- a/src/compiler/crystal/tools/macro_code_coverage.cr
+++ b/src/compiler/crystal/tools/macro_code_coverage.cr
@@ -211,10 +211,11 @@ module Crystal
         return
       end
 
-      # For `MacroIf` nodes whose both then and else bodies consist only of a single `MacroLiteral`, the cond and then's body will both have the same start location.
-      # We need to handle the edge case of if the then body was missed by marking the cond as hit, and the `else` control line as hit (which is the end location of then's body.
-      # This will at least indicate the else block executed as we can't actually mark any line in either body as hit since they're non-macro code.
-      if first_node.is_a?(MacroIf) && (last_node = nodes.last?) && last_node[0].is_a?(MacroLiteral) && last_node[2]
+      # For `MacroIf` nodes whose then/else bodies live on the same line as another
+      # missed node, the cond and then's body may share a start location.
+      # We need to handle the edge case of if the "then" body was missed by marking the cond as hit,
+      # and the "else" control line as hit (which is the end location of then's body).
+      if first_node.is_a?(MacroIf) && (last_node = nodes.last?) && last_node[0].is_a?(MacroLiteral | Expressions) && last_node[2]
         yield({1, location, nil})
 
         if end_loc = last_node[0].end_location


### PR DESCRIPTION
When using macros, a block of `{% if %}...{% else %}...{% end %}` inside a `def`/`struct` that is itself inside a macro was reported with no hits (`else=0`) even when the else branch was taken.

### Root cause
In `src/compiler/crystal/tools/macro_code_coverage.cr`, inside the `process_line` method that handles `MacroIf` nodes, the edge-case that marks the `else` line as hit only checked for a `MacroLiteral` (`is_a?(MacroLiteral)`).

And when the `{% else %}` body is a multi-node expression (`Expressions`), the check was simply skipping it and incorrectly  marking 0 hits for these cases.

### Fix
Allow `MacroLiteral | Expressions` instead of just `MacroLiteral`, changing the check to `is_a?(MacroLiteral | Expressions)`.

It might look like a simplistic fix, but after exhaustive debugging and multiple attempts, the root cause turned out to be right in front of me the whole time.

### Tests

I created 5 different reproduction cases that triggered the bug, and added them as 5 spec examples in the respective spec file.

To run the specific tests:

```bash
bin/crystal spec spec/compiler/crystal/tools/macro_code_coverage_spec.cr
```

After the fix, all these reproductions correctly report `if=2, else=1` and the inline `"2/2"` instead of `0`.