### PR TITLE
Fix: `ThreadPool#main_thread_loop`

### DIFF
--- a/src/fiber/execution_context/thread_pool.cr
+++ b/src/fiber/execution_context/thread_pool.cr
@@ -93,7 +93,7 @@ class Fiber
           # OPTIMIZE: allocate minimum stack size
           pointer = Crystal::System::Fiber.allocate_stack(StackPool::STACK_SIZE, protect: true)
           stack = Stack.new(pointer, StackPool::STACK_SIZE, reusable: true)
-          Fiber.new(execution_context: ExecutionContext.default) { enter_thread_loop(@main_thread) }
+          Fiber.new(stack: stack, execution_context: ExecutionContext.default) { enter_thread_loop(@main_thread) }
         end
       end
 

--- a/src/fiber/execution_context/thread_pool.cr
+++ b/src/fiber/execution_context/thread_pool.cr
@@ -93,7 +93,7 @@ class Fiber
           # OPTIMIZE: allocate minimum stack size
           pointer = Crystal::System::Fiber.allocate_stack(StackPool::STACK_SIZE, protect: true)
           stack = Stack.new(pointer, StackPool::STACK_SIZE, reusable: true)
-          Fiber.new(stack: stack, execution_context: ExecutionContext.default) { enter_thread_loop(@main_thread) }
+          Fiber.new(nil, stack, ExecutionContext.default) { enter_thread_loop(@main_thread) }
         end
       end
 


### PR DESCRIPTION
We manually allocate a stack, so we don't rely on the stack pool of the current ExecutionContext, but we never associate it to the fiber.

Found while investigating #17165. It might fix the issue since the fiber is lazily created, or not.