### PR TITLE
Refactor `RangeLiteral#each`

### DIFF
--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -244,7 +244,7 @@ module Crystal
         end
 
         range.each_with_index do |element, index|
-          @vars[element_var.name] = NumberLiteral.new(element)
+          @vars[element_var.name] = element
           if index_var
             @vars[index_var.name] = NumberLiteral.new(index)
           end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1334,7 +1334,7 @@ module Crystal
           end
 
           range.each do |num|
-            interpreter.define_var(block_arg.name, NumberLiteral.new(num)) if block_arg
+            interpreter.define_var(block_arg.name, num) if block_arg
             interpreter.accept block.body
           end
 
@@ -1345,15 +1345,13 @@ module Crystal
           block_arg = block.args.first?
 
           interpret_map(block, interpreter) do |num|
-            interpreter.define_var(block_arg.name, NumberLiteral.new(num)) if block_arg
+            interpreter.define_var(block_arg.name, num) if block_arg
             interpreter.accept block.body
           end
         end
       when "to_a"
         interpret_check_args do
-          interpret_map(nil, interpreter) do |num|
-            NumberLiteral.new(num)
-          end
+          interpret_map(nil, interpreter, &.itself)
         end
       else
         super
@@ -1376,7 +1374,7 @@ module Crystal
       node = interpreter.accept(self.from)
       from = case node
              when NumberLiteral
-               node.to_number.to_i
+               node
              else
                raise "range begin must be a NumberLiteral, not #{node.class_desc}"
              end
@@ -1384,7 +1382,7 @@ module Crystal
       node = interpreter.accept(self.to)
       to = case node
            when NumberLiteral
-             node.to_number.to_i
+             node
            else
              raise "range end must be a NumberLiteral, not #{node.class_desc}"
            end

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -395,6 +395,8 @@ module Crystal
 
   # Any number literal.
   class NumberLiteral < ASTNode
+    include Comparable(self)
+
     property value : String
     property kind : NumberKind
 
@@ -414,7 +416,7 @@ module Crystal
         raise "BUG: called 'integer_value' for non-integer literal"
       end
 
-      kind.cast(value)
+      kind.cast(value).as(Int)
     end
 
     # Returns true if this literal is representable in the *other_type*. Used to
@@ -433,6 +435,22 @@ module Crystal
         true
       else
         false
+      end
+    end
+
+    def <=>(other : self)
+      if (kind.signed_int? || kind.unsigned_int?) && (other.kind.signed_int? || other.kind.unsigned_int?)
+        integer_value <=> other.integer_value
+      else
+        value.to_f64 <=> other.value.to_f64
+      end
+    end
+
+    def succ : self
+      if kind.signed_int? || kind.unsigned_int?
+        NumberLiteral.new(integer_value.succ.to_s, kind)
+      else
+        raise "BUG: called 'succ' for non-integer literal"
       end
     end
 


### PR DESCRIPTION
We can simplify iterating range literals by using ranges of literal nodes, instead of hard-coding them to numeric values. This enables integrating other types, such as char literals (#17170).

Prefactoring for #17170