### PR TITLE
Fix `String#gsub` when `Regex` pattern matches empty string and advances

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2031,6 +2031,13 @@ describe "String" do
       "┬  7".gsub(/\B/, "-").should eq "-┬- - 7"
     end
 
+    it "empty match + advanced offset" do
+      "a  b".gsub(/(?= )/, "-").should eq "a- - b"
+      "┬  7".gsub(/(?= )/, "-").should eq "┬- - 7"
+      "a  ".gsub(/(?<= )/, "-").should eq "a - -"
+      "┬  ".gsub(/(?<= )/, "-").should eq "┬ - -"
+    end
+
     it "empty string" do
       "ab".gsub("", "-").should eq "-a-b-"
       "┬7".gsub("", "-").should eq "-┬-7-"

--- a/src/string.cr
+++ b/src/string.cr
@@ -2877,7 +2877,7 @@ class String
 
         if str.bytesize == 0
           # The pattern matched an empty result. We must advance one character to avoid stagnation.
-          byte_offset = index + char_bytesize_at(byte_offset)
+          byte_offset = index + char_bytesize_at(index)
           last_byte_offset = index
         else
           byte_offset = index + str.bytesize


### PR DESCRIPTION
Fixes #17197.

When a regex pattern match returns an empty string but has advanced part of the subject string, the search position for the next match should be calculated using the character byte size at this match's beginning, not at this match's original search position. Note that `index` may be equal to `bytesize` in the case of a lookbehind pattern, but this is fine since the subject should be null-terminated.

The similar overload `#gsub(string : String, &block)` does not have this problem; an empty match implies no advancing.