### PR TITLE
Change `Time.zero` to create new instance instead of returning `ZERO`

### DIFF
--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -376,7 +376,7 @@ struct Time::Span
 
   # Creates a new `Time::Span` representing a span of zero time.
   def self.zero : Time::Span
-    ZERO
+    new(nanoseconds: 0)
   end
 
   # Returns `true` if `self` represents a span of zero time.


### PR DESCRIPTION
This implementation is efficient: LLVM codegen can optimize the instantiation at compile time. There is no reason for using a pre-initialized constant for such a trivial value type.

Reading a constant can in fact incur an extra cost of `crystal_once` (see https://github.com/crystal-lang/crystal/issues/17212#issuecomment-5253140119).

We might deprecate `Time::Span::ZERO` entirely (see #17215).