### PR TITLE
Replace `Time::Span::ZERO` with `.zero`

### DIFF
--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -387,7 +387,7 @@ struct Time::Span
   # 1.second.zero? # => false
   # ```
   def zero? : Bool
-    self == ZERO
+    self == Span.zero
   end
 
   # Returns `true` if `self` represents a positive time span.
@@ -398,7 +398,7 @@ struct Time::Span
   # -3.days.positive? # => false
   # ```
   def positive? : Bool
-    self > ZERO
+    self > Span.zero
   end
 
   # Returns `true` if `self` represents a negative time span.
@@ -409,7 +409,7 @@ struct Time::Span
   # -3.days.negative? # => true
   # ```
   def negative? : Bool
-    self < ZERO
+    self < Span.zero
   end
 end
 


### PR DESCRIPTION
The constant is unnecessary and can cause extra overhead. We can cheaply construct an instance instead.

See #17215

Depends on #17216 to effectively avoid the constant.