### PR TITLE
Fix `BigRational#<=>` with an infinite `Float`

### DIFF
--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -200,6 +200,21 @@ describe BigRational do
 
       typeof(1.to_big_r <=> 1.to_big_f).should eq(Int32)
     end
+
+    it "compares against infinities" do
+      (1.to_big_r <=> Float64::INFINITY).should eq(-1)
+      (1.to_big_r <=> -Float64::INFINITY).should eq(1)
+      (1.to_big_r <=> Float32::INFINITY).should eq(-1)
+      (1.to_big_r <=> -Float32::INFINITY).should eq(1)
+
+      (Float64::INFINITY <=> 1.to_big_r).should eq(1)
+      (-Float64::INFINITY <=> 1.to_big_r).should eq(-1)
+      (Float32::INFINITY <=> 1.to_big_r).should eq(1)
+      (-Float32::INFINITY <=> 1.to_big_r).should eq(-1)
+
+      typeof(1.to_big_r <=> Float64::INFINITY).should eq(Int32?)
+      typeof(Float64::INFINITY <=> 1.to_big_r).should eq(Int32?)
+    end
   end
 
   it "#+" do

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -95,7 +95,15 @@ struct BigRational < Number
   end
 
   def <=>(other : Float::Primitive) : Int32?
-    self <=> BigRational.new(other) unless other.nan?
+    return nil if other.nan?
+    # `BigRational.new` rejects non-finite floats, so order against an infinity
+    # directly: every finite rational is greater than -Infinity and less than
+    # +Infinity. `Float#infinite?` is `1` for +Infinity and `-1` for -Infinity.
+    if inf = other.infinite?
+      -inf
+    else
+      self <=> BigRational.new(other)
+    end
   end
 
   def <=>(other : BigFloat) : Int32


### PR DESCRIPTION
Fixes #17208.

### Problem

`BigRational#<=>(Float::Primitive)` only filters `NaN`:

```crystal
def <=>(other : Float::Primitive) : Int32?
  self <=> BigRational.new(other) unless other.nan?
end
```

So comparing against `±Infinity` falls through to `BigRational.new(other)`, which raises `ArgumentError` ("Can only construct from a finite number", added in #13351). `5.to_big_r <=> Float64::INFINITY` therefore raises instead of returning `-1`, and this breaks every `Comparable(Float)` operation (`<`, `<=`, `>`, `>=`, `clamp`, sorting a mixed collection) against an infinity. Ruby orders these: `Rational(5) <=> Float::INFINITY # => -1`.

### Fix

Order against an infinity directly, mirroring the existing NaN guard: a finite rational is less than `+Infinity` and greater than `-Infinity`. `Float#infinite?` returns `1` / `-1` / `nil`, so the comparison result is just its negation. This also fixes the reverse direction `Float#<=>(BigRational)`, which delegates to this method and negates.

### Test

Added a "compares against infinities" example beside the existing "compares against NaNs" one in `spec/std/big/big_rational_spec.cr`, covering both directions and `Float32`/`Float64`. Red-green verified with `CRYSTAL_PATH=$PWD/src crystal spec spec/std/big/big_rational_spec.cr`: before the fix the example errors with `ArgumentError: Can only construct from a finite number`; after, all 63 examples pass. `crystal tool format --check` is clean.
