### PR TITLE
Add specs for `Big*` types compaing against float infinity

### DIFF
--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -437,6 +437,21 @@ describe BigDecimal do
       typeof(Float64::NAN <=> 1.to_big_d).should eq(Int32?)
       typeof(Float32::NAN <=> 1.to_big_d).should eq(Int32?)
     end
+
+    it "compares against infinities" do
+      (1.to_big_d <=> Float64::INFINITY).should eq(-1)
+      (1.to_big_d <=> -Float64::INFINITY).should eq(1)
+      (1.to_big_d <=> Float32::INFINITY).should eq(-1)
+      (1.to_big_d <=> -Float32::INFINITY).should eq(1)
+
+      (Float64::INFINITY <=> 1.to_big_d).should eq(1)
+      (-Float64::INFINITY <=> 1.to_big_d).should eq(-1)
+      (Float32::INFINITY <=> 1.to_big_d).should eq(1)
+      (-Float32::INFINITY <=> 1.to_big_d).should eq(-1)
+
+      typeof(1.to_big_d <=> Float64::INFINITY).should eq(Int32?)
+      typeof(Float64::INFINITY <=> 1.to_big_d).should eq(Int32?)
+    end
   end
 
   it "keeps precision" do

--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -115,6 +115,21 @@ describe "BigFloat" do
 
       typeof(1.to_big_f <=> 1.to_big_f).should eq(Int32)
     end
+
+    it "compares against infinities" do
+      (1.to_big_f <=> Float64::INFINITY).should eq(-1)
+      (1.to_big_f <=> -Float64::INFINITY).should eq(1)
+      (1.to_big_f <=> Float32::INFINITY).should eq(-1)
+      (1.to_big_f <=> -Float32::INFINITY).should eq(1)
+
+      (Float64::INFINITY <=> 1.to_big_f).should eq(1)
+      (-Float64::INFINITY <=> 1.to_big_f).should eq(-1)
+      (Float32::INFINITY <=> 1.to_big_f).should eq(1)
+      (-Float32::INFINITY <=> 1.to_big_f).should eq(-1)
+
+      typeof(1.to_big_f <=> Float64::INFINITY).should eq(Int32?)
+      typeof(Float64::INFINITY <=> 1.to_big_f).should eq(Int32?)
+    end
   end
 
   describe "unary #-" do

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -126,6 +126,21 @@ describe "BigInt" do
     typeof(1.to_big_f <=> 1.to_big_i).should eq(Int32)
   end
 
+  it "compares against infinities" do
+    (1.to_big_i <=> Float64::INFINITY).should eq(-1)
+    (1.to_big_i <=> -Float64::INFINITY).should eq(1)
+    (1.to_big_i <=> Float32::INFINITY).should eq(-1)
+    (1.to_big_i <=> -Float32::INFINITY).should eq(1)
+
+    (Float64::INFINITY <=> 1.to_big_i).should eq(1)
+    (-Float64::INFINITY <=> 1.to_big_i).should eq(-1)
+    (Float32::INFINITY <=> 1.to_big_i).should eq(1)
+    (-Float32::INFINITY <=> 1.to_big_i).should eq(-1)
+
+    typeof(1.to_big_i <=> Float64::INFINITY).should eq(Int32?)
+    typeof(Float64::INFINITY <=> 1.to_big_i).should eq(Int32?)
+  end
+
   it "divides and calculates the modulo" do
     11.to_big_i.divmod(3.to_big_i).should eq({3, 2})
     11.to_big_i.divmod(-3.to_big_i).should eq({-4, -1})


### PR DESCRIPTION
Adds test similar to the ones in #17223 for `BigDecimal#<=>` for other `Big*` types. They already handle float infinity correctly, so there is no change in the implementation.