### PR TITLE
Add `Thread#wait` and `Thread#wake` methods

### DIFF
--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -33,6 +33,19 @@ module Crystal::System::Thread
   # private def system_wait_suspended : Nil
 
   # private def system_resume : Nil
+
+  # Called to initialize the object (usually a semaphore) for #wait and #wake.
+  # protected def init_semaphore : Nil
+
+  # Suspend a thread until #wake is called. Synchronizes with #wake so it won't
+  # block if #wake was called before (race).
+  #
+  # WARNING: must only be called on the current thread.
+  # def wait : Nil
+
+  # Wake a waiting thread. Synchronizes with #wait so it won't block if #wake
+  # has been called before (race).
+  # def wake : Nil
 end
 
 {% if flag?(:wasi) %}
@@ -145,6 +158,7 @@ class Thread
   def initialize(@name : String? = nil, &@func : Thread ->)
     @system_handle = uninitialized Crystal::System::Thread::Handle
     init_handle
+    init_semaphore
   end
 
   # Used once to initialize the thread object representing the main thread of
@@ -153,6 +167,7 @@ class Thread
     @func = ->(t : Thread) { }
     @system_handle = Crystal::System::Thread.current_handle
     @current_fiber = @main_fiber = Fiber.new(stack_address, self)
+    init_semaphore
 
     Thread.threads.push(self)
   end

--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -7,7 +7,7 @@ module Crystal::System::Thread
   alias Handle = LibC::PthreadT
 
   {% if flag?(:darwin) %}
-    @semaphore : LibC::SemT* = LibC::SEM_FAILED
+    @semaphore : LibC::SemT* = Pointer(LibC::SemT).new(-1.to_u64!) # LibC::SEM_FAILED
   {% else %}
     @semaphore = uninitialized LibC::SemT
   {% end %}
@@ -290,9 +290,9 @@ module Crystal::System::Thread
       # to a named semaphore that we immediately unlink to keep it private (and
       # maybe leaking a semaphore name); it will be destroyed when we close it,
       # at worst on exec or when the process exits
-      sem_name = "/crystal-thread-#{LibC.getpid}-#{@system_handle.address}"
+      sem_name = "/crystal-thread-#{LibC.getpid}-#{LibC.gettid}"
       @semaphore = LibC.sem_open(sem_name, LibC::O_CREAT | LibC::O_EXCL, 0o644, 0)
-      raise RuntimeError.from_errno("sem_open") if @semaphore == LibC::SEM_FAILED
+      raise RuntimeError.from_errno("sem_open") if @semaphore == Pointer(LibC::SemT).new(-1.to_u64!) # LibC::SEM_FAILED
       LibC.sem_unlink(sem_name)
     {% else %}
       if LibC.sem_init(pointerof(@semaphore), 0, 0) == -1

--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -290,7 +290,8 @@ module Crystal::System::Thread
       # to a named semaphore that we immediately unlink to keep it private (and
       # maybe leaking a semaphore name); it will be destroyed when we close it,
       # at worst on exec or when the process exits
-      sem_name = "/crystal-thread-#{LibC.getpid}-#{LibC.gettid}"
+      LibC.pthread_threadid_np(@system_handle, out tid)
+      sem_name = "/crystal-thread-#{LibC.getpid}-#{tid}"
       @semaphore = LibC.sem_open(sem_name, LibC::O_CREAT | LibC::O_EXCL, 0o644, 0)
       raise RuntimeError.from_errno("sem_open") if @semaphore == Pointer(LibC::SemT).new(-1.to_u64!) # LibC::SEM_FAILED
       LibC.sem_unlink(sem_name)

--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -1,9 +1,12 @@
 require "c/pthread"
 require "c/sched"
+require "c/semaphore"
 require "../panic"
 
 module Crystal::System::Thread
   alias Handle = LibC::PthreadT
+
+  @semaphore = uninitialized LibC::SemT
 
   def to_unsafe
     @system_handle
@@ -132,6 +135,7 @@ module Crystal::System::Thread
   end
 
   private def system_close
+    LibC.sem_destroy(pointerof(@semaphore))
     GC.pthread_detach(@system_handle)
   end
 
@@ -269,6 +273,24 @@ module Crystal::System::Thread
   private def system_resume : Nil
     if LibC.pthread_kill(@system_handle, SIG_RESUME) == -1
       System.panic("pthread_kill()", Errno.value)
+    end
+  end
+
+  protected def init_semaphore : Nil
+    if LibC.sem_init(pointerof(@semaphore), 0, 0) == -1
+      raise RuntimeError.from_errno("sem_init")
+    end
+  end
+
+  def wait : Nil
+    if LibC.sem_wait(pointerof(@semaphore)) == -1
+      raise RuntimeError.from_errno("sem_wait")
+    end
+  end
+
+  def wake : Nil
+    if LibC.sem_post(pointerof(@semaphore)) == -1
+      raise RuntimeError.from_errno("sem_post")
     end
   end
 

--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -6,7 +6,11 @@ require "../panic"
 module Crystal::System::Thread
   alias Handle = LibC::PthreadT
 
-  @semaphore = uninitialized LibC::SemT
+  {% if flag?(:darwin) %}
+    @semaphore : LibC::SemT* = LibC::SEM_FAILED
+  {% else %}
+    @semaphore = uninitialized LibC::SemT
+  {% end %}
 
   def to_unsafe
     @system_handle
@@ -135,7 +139,11 @@ module Crystal::System::Thread
   end
 
   private def system_close
-    LibC.sem_destroy(pointerof(@semaphore))
+    {% if flag?(:darwin) %}
+      LibC.sem_close(semaphore)
+    {% else %}
+      LibC.sem_destroy(semaphore)
+    {% end %}
     GC.pthread_detach(@system_handle)
   end
 
@@ -277,21 +285,40 @@ module Crystal::System::Thread
   end
 
   protected def init_semaphore : Nil
-    if LibC.sem_init(pointerof(@semaphore), 0, 0) == -1
-      raise RuntimeError.from_errno("sem_init")
-    end
+    {% if flag?(:darwin) %}
+      # macOS deprecated then removed unnamed POSIX semaphores, we thus fallback
+      # to a named semaphore that we immediately unlink to keep it private (and
+      # maybe leaking a semaphore name); it will be destroyed when we close it,
+      # at worst on exec or when the process exits
+      sem_name = "/crystal-thread-#{LibC.getpid}-#{@system_handle.address}"
+      @semaphore = LibC.sem_open(sem_name, LibC::O_CREAT | LibC::O_EXCL, 0o644, 0)
+      raise RuntimeError.from_errno("sem_open") if @semaphore == LibC::SEM_FAILED
+      LibC.sem_unlink(sem_name)
+    {% else %}
+      if LibC.sem_init(pointerof(@semaphore), 0, 0) == -1
+        raise RuntimeError.from_errno("sem_init")
+      end
+    {% end %}
   end
 
   def wait : Nil
-    if LibC.sem_wait(pointerof(@semaphore)) == -1
+    if LibC.sem_wait(semaphore) == -1
       raise RuntimeError.from_errno("sem_wait")
     end
   end
 
   def wake : Nil
-    if LibC.sem_post(pointerof(@semaphore)) == -1
+    if LibC.sem_post(semaphore) == -1
       raise RuntimeError.from_errno("sem_post")
     end
+  end
+
+  private def semaphore
+    {% if flag?(:darwin) %}
+      @semaphore
+    {% else %}
+      pointerof(@semaphore)
+    {% end %}
   end
 
   # the suspend/resume signals try to follow BDWGC but aren't exact (e.g. it may

--- a/src/crystal/system/wasi/thread.cr
+++ b/src/crystal/system/wasi/thread.cr
@@ -65,4 +65,15 @@ module Crystal::System::Thread
   private def system_resume : Nil
     raise NotImplementedError.new("Crystal::System::Thread.system_resume")
   end
+
+  protected def init_semaphore : Nil
+  end
+
+  def wait : Nil
+    raise NotImplementedError.new("Crystal::System::Thread#wait")
+  end
+
+  def wake : Nil
+    raise NotImplementedError.new("Crystal::System::Thread#wake")
+  end
 end

--- a/src/crystal/system/win32/thread.cr
+++ b/src/crystal/system/win32/thread.cr
@@ -5,6 +5,8 @@ require "../panic"
 module Crystal::System::Thread
   alias Handle = LibC::HANDLE
 
+  @semaphore : LibC::HANDLE = LibC::INVALID_HANDLE_VALUE
+
   def to_unsafe
     @system_handle
   end
@@ -117,6 +119,7 @@ module Crystal::System::Thread
   end
 
   private def system_close
+    LibC.CloseHandle(@semaphore) unless @semaphore == LibC::INVALID_HANDLE_VALUE
     LibC.CloseHandle(@system_handle)
   end
 
@@ -166,6 +169,26 @@ module Crystal::System::Thread
   private def system_resume : Nil
     if LibC.ResumeThread(@system_handle) == -1
       Crystal::System.panic("ResumeThread()", WinError.value)
+    end
+  end
+
+  protected def init_semaphore : Nil
+    @semaphore = LibC.CreateSemaphoreA(nil, 0, LibC::LONG::MAX, nil)
+
+    if @semaphore == LibC::INVALID_HANDLE_VALUE
+      raise RuntimeError.from_winerror("CreateSemaphoreA")
+    end
+  end
+
+  def wait : Nil
+    unless LibC.WaitForSingleObject(@semaphore, LibC::INFINITE) == LibC::WAIT_OBJECT_0
+      raise RuntimeError.from_winerror("WaitForSingleObject")
+    end
+  end
+
+  def wake : Nil
+    if LibC.ReleaseSemaphore(@semaphore, 1, out _) == 0
+      raise RuntimeError.from_winerror("ReleaseSemaphore")
     end
   end
 end

--- a/src/lib_c/aarch64-darwin/c/pthread.cr
+++ b/src/lib_c/aarch64-darwin/c/pthread.cr
@@ -30,4 +30,5 @@ lib LibC
   fun pthread_self : PthreadT
   fun pthread_setcancelstate(state : Int, oldstate : Int*) : Int
   fun pthread_setname_np(Char*) : Int
+  fun pthread_threadid_np(PthreadT, ULong*) : Int
 end

--- a/src/lib_c/aarch64-darwin/c/semaphore.cr
+++ b/src/lib_c/aarch64-darwin/c/semaphore.cr
@@ -1,0 +1,7 @@
+lib LibC
+  type SemT = Int
+  fun sem_destroy(SemT*) : Int
+  fun sem_init(SemT*, Int, UInt) : Int
+  fun sem_post(SemT*) : Int
+  fun sem_wait(SemT*) : Int
+end

--- a/src/lib_c/aarch64-darwin/c/semaphore.cr
+++ b/src/lib_c/aarch64-darwin/c/semaphore.cr
@@ -1,7 +1,13 @@
+require "c/fcntl"
+
 lib LibC
+  SEM_FAILED = Pointer(SemT).new(-1.to_u64!)
+
   type SemT = Int
-  fun sem_destroy(SemT*) : Int
-  fun sem_init(SemT*, Int, UInt) : Int
+
+  fun sem_close(SemT*) : Int
+  fun sem_open(Char*, Int, ...) : SemT*
   fun sem_post(SemT*) : Int
+  fun sem_unlink(Char*) : Int
   fun sem_wait(SemT*) : Int
 end

--- a/src/lib_c/aarch64-darwin/c/unistd.cr
+++ b/src/lib_c/aarch64-darwin/c/unistd.cr
@@ -30,7 +30,6 @@ lib LibC
   fun getpgid(x0 : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
-  fun gettid : PidT
   fun getuid : UidT
   fun setuid(uid : UidT) : Int
   fun isatty(x0 : Int) : Int

--- a/src/lib_c/aarch64-darwin/c/unistd.cr
+++ b/src/lib_c/aarch64-darwin/c/unistd.cr
@@ -30,6 +30,7 @@ lib LibC
   fun getpgid(x0 : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun gettid : PidT
   fun getuid : UidT
   fun setuid(uid : UidT) : Int
   fun isatty(x0 : Int) : Int

--- a/src/lib_c/aarch64-linux-android/c/semaphore.cr
+++ b/src/lib_c/aarch64-linux-android/c/semaphore.cr
@@ -1,0 +1,7 @@
+lib LibC
+  type SemT = UInt32[4]
+  fun sem_destroy(SemT*) : Int
+  fun sem_init(SemT*, Int, UInt) : Int
+  fun sem_post(SemT*) : Int
+  fun sem_wait(SemT*) : Int
+end

--- a/src/lib_c/aarch64-linux-gnu/c/semaphore.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/semaphore.cr
@@ -1,0 +1,7 @@
+lib LibC
+  type SemT = UInt64[4]
+  fun sem_destroy(SemT*) : Int
+  fun sem_init(SemT*, Int, UInt) : Int
+  fun sem_post(SemT*) : Int
+  fun sem_wait(SemT*) : Int
+end

--- a/src/lib_c/aarch64-linux-musl/c/semaphore.cr
+++ b/src/lib_c/aarch64-linux-musl/c/semaphore.cr
@@ -1,0 +1,7 @@
+lib LibC
+  type SemT = UInt32[8]
+  fun sem_destroy(SemT*) : Int
+  fun sem_init(SemT*, Int, UInt) : Int
+  fun sem_post(SemT*) : Int
+  fun sem_wait(SemT*) : Int
+end

--- a/src/lib_c/arm-linux-gnueabihf/c/semaphore.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/semaphore.cr
@@ -1,0 +1,7 @@
+lib LibC
+  type SemT = UInt64[2]
+  fun sem_destroy(SemT*) : Int
+  fun sem_init(SemT*, Int, UInt) : Int
+  fun sem_post(SemT*) : Int
+  fun sem_wait(SemT*) : Int
+end

--- a/src/lib_c/i386-linux-gnu/c/semaphore.cr
+++ b/src/lib_c/i386-linux-gnu/c/semaphore.cr
@@ -1,0 +1,7 @@
+lib LibC
+  type SemT = UInt64[2]
+  fun sem_destroy(SemT*) : Int
+  fun sem_init(SemT*, Int, UInt) : Int
+  fun sem_post(SemT*) : Int
+  fun sem_wait(SemT*) : Int
+end

--- a/src/lib_c/i386-linux-musl/c/semaphore.cr
+++ b/src/lib_c/i386-linux-musl/c/semaphore.cr
@@ -1,0 +1,7 @@
+lib LibC
+  type SemT = UInt32[8]
+  fun sem_destroy(SemT*) : Int
+  fun sem_init(SemT*, Int, UInt) : Int
+  fun sem_post(SemT*) : Int
+  fun sem_wait(SemT*) : Int
+end

--- a/src/lib_c/x86_64-darwin/c/pthread.cr
+++ b/src/lib_c/x86_64-darwin/c/pthread.cr
@@ -30,4 +30,5 @@ lib LibC
   fun pthread_self : PthreadT
   fun pthread_setcancelstate(state : Int, oldstate : Int*) : Int
   fun pthread_setname_np(Char*) : Int
+  fun pthread_threadid_np(PthreadT, ULong*) : Int
 end

--- a/src/lib_c/x86_64-darwin/c/semaphore.cr
+++ b/src/lib_c/x86_64-darwin/c/semaphore.cr
@@ -1,0 +1,7 @@
+lib LibC
+  type SemT = Int
+  fun sem_destroy(SemT*) : Int
+  fun sem_init(SemT*, Int, UInt) : Int
+  fun sem_post(SemT*) : Int
+  fun sem_wait(SemT*) : Int
+end

--- a/src/lib_c/x86_64-darwin/c/semaphore.cr
+++ b/src/lib_c/x86_64-darwin/c/semaphore.cr
@@ -1,7 +1,13 @@
+require "c/fcntl"
+
 lib LibC
+  SEM_FAILED = Pointer(SemT).new(-1.to_u64!)
+
   type SemT = Int
-  fun sem_destroy(SemT*) : Int
-  fun sem_init(SemT*, Int, UInt) : Int
+
+  fun sem_close(SemT*) : Int
+  fun sem_open(Char*, Int, ...) : SemT*
   fun sem_post(SemT*) : Int
+  fun sem_unlink(Char*) : Int
   fun sem_wait(SemT*) : Int
 end

--- a/src/lib_c/x86_64-darwin/c/unistd.cr
+++ b/src/lib_c/x86_64-darwin/c/unistd.cr
@@ -30,7 +30,6 @@ lib LibC
   fun getpgid(x0 : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
-  fun gettid : PidT
   fun getuid : UidT
   fun setuid(uid : UidT) : Int
   fun isatty(x0 : Int) : Int

--- a/src/lib_c/x86_64-darwin/c/unistd.cr
+++ b/src/lib_c/x86_64-darwin/c/unistd.cr
@@ -30,6 +30,7 @@ lib LibC
   fun getpgid(x0 : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun gettid : PidT
   fun getuid : UidT
   fun setuid(uid : UidT) : Int
   fun isatty(x0 : Int) : Int

--- a/src/lib_c/x86_64-dragonfly/c/semaphore.cr
+++ b/src/lib_c/x86_64-dragonfly/c/semaphore.cr
@@ -1,0 +1,7 @@
+lib LibC
+  type SemT = Void*
+  fun sem_destroy(SemT*) : Int
+  fun sem_init(SemT*, Int, UInt) : Int
+  fun sem_post(SemT*) : Int
+  fun sem_wait(SemT*) : Int
+end

--- a/src/lib_c/x86_64-freebsd/c/semaphore.cr
+++ b/src/lib_c/x86_64-freebsd/c/semaphore.cr
@@ -1,0 +1,7 @@
+lib LibC
+  type SemT = UInt32[4]
+  fun sem_destroy(SemT*) : Int
+  fun sem_init(SemT*, Int, UInt) : Int
+  fun sem_post(SemT*) : Int
+  fun sem_wait(SemT*) : Int
+end

--- a/src/lib_c/x86_64-linux-gnu/c/semaphore.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/semaphore.cr
@@ -1,0 +1,7 @@
+lib LibC
+  type SemT = UInt64[4]
+  fun sem_destroy(SemT*) : Int
+  fun sem_init(SemT*, Int, UInt) : Int
+  fun sem_post(SemT*) : Int
+  fun sem_wait(SemT*) : Int
+end

--- a/src/lib_c/x86_64-linux-musl/c/semaphore.cr
+++ b/src/lib_c/x86_64-linux-musl/c/semaphore.cr
@@ -1,0 +1,7 @@
+lib LibC
+  type SemT = UInt32[8]
+  fun sem_destroy(SemT*) : Int
+  fun sem_init(SemT*, Int, UInt) : Int
+  fun sem_post(SemT*) : Int
+  fun sem_wait(SemT*) : Int
+end

--- a/src/lib_c/x86_64-netbsd/c/semaphore.cr
+++ b/src/lib_c/x86_64-netbsd/c/semaphore.cr
@@ -1,0 +1,7 @@
+lib LibC
+  type SemT = Void*
+  fun sem_destroy(SemT*) : Int
+  fun sem_init(SemT*, Int, UInt) : Int
+  fun sem_post(SemT*) : Int
+  fun sem_wait(SemT*) : Int
+end

--- a/src/lib_c/x86_64-openbsd/c/semaphore.cr
+++ b/src/lib_c/x86_64-openbsd/c/semaphore.cr
@@ -1,0 +1,7 @@
+lib LibC
+  type SemT = Void*
+  fun sem_destroy(SemT*) : Int
+  fun sem_init(SemT*, Int, UInt) : Int
+  fun sem_post(SemT*) : Int
+  fun sem_wait(SemT*) : Int
+end

--- a/src/lib_c/x86_64-solaris/c/semaphore.cr
+++ b/src/lib_c/x86_64-solaris/c/semaphore.cr
@@ -1,0 +1,7 @@
+lib LibC
+  type SemT = UInt64[6]
+  fun sem_destroy(SemT*) : Int
+  fun sem_init(SemT*, Int, UInt) : Int
+  fun sem_post(SemT*) : Int
+  fun sem_wait(SemT*) : Int
+end

--- a/src/lib_c/x86_64-windows-msvc/c/synchapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/synchapi.cr
@@ -39,4 +39,7 @@ lib LibC
   fun CreateWaitableTimerExW(lpTimerAttributes : SECURITY_ATTRIBUTES*, lpTimerName : LPWSTR, dwFlags : DWORD, dwDesiredAccess : DWORD) : HANDLE
   fun SetWaitableTimer(hTimer : HANDLE, lpDueTime : LARGE_INTEGER*, lPeriod : LONG, pfnCompletionRoutine : PTIMERAPCROUTINE*, lpArgToCompletionRoutine : Void*, fResume : BOOL) : BOOL
   fun CancelWaitableTimer(hTimer : HANDLE) : BOOL
+
+  fun CreateSemaphoreA(lpSemaphoreAttributes : SECURITY_ATTRIBUTES*, lInitialCount : LONG, lMaximumCount : LONG, name : LPSTR) : HANDLE
+  fun ReleaseSemaphore(hSemaphore : HANDLE, lReleaseCount : LONG, lpPreviousCount : LONG*) : BOOL
 end


### PR DESCRIPTION
Implemented using a counting semaphore, usually either 0 (running, waiting) or 1 (wake), on both POSIX and Windows targets.

Related to #17212 