### PR TITLE
Refactor `#interpret_to_range`

### DIFF
--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1379,23 +1379,18 @@ module Crystal
     end
 
     def interpret_to_range(interpreter)
-      node = interpreter.accept(self.from)
-      from = case node
-             when NumberLiteral
-               node
-             else
-               raise "range begin must be a NumberLiteral, not #{node.class_desc}"
-             end
+      interpret_to_range(
+        interpreter.accept(self.from),
+        interpreter.accept(self.to)
+      )
+    end
 
-      node = interpreter.accept(self.to)
-      to = case node
-           when NumberLiteral
-             node
-           else
-             raise "range end must be a NumberLiteral, not #{node.class_desc}"
-           end
-
+    def interpret_to_range(from : NumberLiteral, to : NumberLiteral)
       Range.new(from, to, self.exclusive?)
+    end
+
+    def interpret_to_range(from, to)
+      raise "range begin and must be both NumberLiteral, not #{from.class_desc}..#{to.class_desc}"
     end
 
     def interpret_to_nilable_range(interpreter)


### PR DESCRIPTION
Reduces code complexity prior to adding support for `CharLiteral` ranges.

Prefactoring for #17170