### PR TITLE
Fix: support bare threads in crystal/once

### DIFF
--- a/src/crystal/once.cr
+++ b/src/crystal/once.cr
@@ -14,18 +14,43 @@ require "crystal/spin_lock"
 module Crystal
   # :nodoc:
   module Once
+    struct Waiter
+      include PointerLinkedList::Node
+
+      def initialize(@object : Fiber | Thread)
+      end
+
+      def suspend : Nil
+        case object = @object
+        in Fiber
+          Fiber.suspend
+        in Thread
+          object.wait
+        end
+      end
+
+      def enqueue : Nil
+        case object = @object
+        in Fiber
+          object.enqueue
+        in Thread
+          object.wake
+        end
+      end
+    end
+
     struct Operation
       include PointerLinkedList::Node
 
       getter fiber : Fiber
       getter flag : Bool*
 
-      def initialize(@flag : Bool*, @fiber : Fiber)
-        @waiting = PointerLinkedList(Fiber::PointerLinkedListNode).new
+      def initialize(@flag, @fiber)
+        @waiting = PointerLinkedList(Waiter).new
       end
 
-      def add_waiter(node) : Nil
-        @waiting.push(node)
+      def add_waiter(waiter : Pointer(Waiter)) : Nil
+        @waiting.push(waiter)
       end
 
       def resume_all : Nil
@@ -75,10 +100,23 @@ module Crystal
     end
 
     private def self.wait_initializer(operation)
-      waiting = Fiber::PointerLinkedListNode.new(Fiber.current)
-      operation.value.add_waiter(pointerof(waiting))
+      fiber = Fiber.current
+
+      waiter =
+        {% if !flag?(:without_mt) && !flag?(:preview_mt) || flag?(:execution_context) %}
+          if fiber.execution_context?
+            Waiter.new(fiber)
+          else
+            Waiter.new(Thread.current)
+          end
+        {% else %}
+          Waiter.new(fiber)
+        {% end %}
+
+      operation.value.add_waiter(pointerof(waiter))
       @@spin.unlock
-      Fiber.suspend
+
+      waiter.suspend
     end
 
     private def self.run_initializer(flag, &)

--- a/src/crystal/once.cr
+++ b/src/crystal/once.cr
@@ -107,6 +107,10 @@ module Crystal
           if fiber.execution_context?
             Waiter.new(fiber)
           else
+            # the fiber is a bare thread's main fiber, either never associated
+            # to an execution context, or the thread got detached (thread pool),
+            # and there is no scheduler to suspend/enqueue the fiber; instead we
+            # suspend/resume the thread
             Waiter.new(Thread.current)
           end
         {% else %}


### PR DESCRIPTION
We use crystal/once to protect the initialization of constants against parallelism issues and as a global can potentially yield to another fiber, against concurrency issues.

The protection only worked when the current thread was attached to an execution context and thus had a scheduler to yield the current fiber and to eventually re-enqueue the fiber into, but threads can be "bare" that is without a scheduler, for example the monitor thread, or when the thread returns to the thread pool.

crystal/once now supports bare threads, i.e. no execution context, and suspends and resumes the thread instead of the fiber.

Fixes #17212
Depends on #17226
Related to #15370