### PR TITLE
Fix: free dead fiber stack when there's no stack pool

### DIFF
--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -194,7 +194,11 @@ class Fiber
         if stack = Thread.current.dying_fiber(self)
           # we can however release the stack of a previously dying fiber (we
           # since swapped context)
-          execution_context.stack_pool.release(stack)
+          if stack_pool = execution_context.stack_pool?
+            stack_pool.release(stack)
+          else
+            Crystal::System::Fiber.free_stack(stack.pointer, stack.size)
+          end
         end
       {% else %}
         Crystal::Scheduler.stack_pool.release(@stack)


### PR DESCRIPTION
When a fiber is dying, its saving its stack on the current thread, so it can be released after the fiber context switch (we can't release the currently running stack in a MT environment).

There might already be a dead fiber stack on the thread, in which case we release that stack back into the stack pool. We're long after the fiber context switch so it's safe at this point.

Problem is, an execution context such as isolated might not have a stack pool, in that case, there is no stack pool to return the stack to, and we shall just free it.

Should fix these CI failures: [one](https://github.com/crystal-lang/crystal/actions/runs/31610559990/job/94174245900) and [two](https://app.circleci.com/pipelines/gh/crystal-lang/crystal/22314/workflows/c97aa8ac-2cac-4ae6-99ad-3632b85d8b19/jobs/100360)