### PR TITLE
YAML: add options object and budget limits

### DIFF
--- a/spec/std/yaml/builder_spec.cr
+++ b/spec/std/yaml/builder_spec.cr
@@ -203,30 +203,28 @@ describe YAML::Builder do
 
   it "errors on max nesting (sequence)" do
     io = IO::Memory.new
-    builder = YAML::Builder.new(io)
-    builder.max_nesting = 3
+    builder = YAML::Builder.new(io, YAML::Options.new(max_nesting: 3))
     builder.start_stream
     builder.start_document
     3.times do
       builder.start_sequence
     end
 
-    expect_raises(YAML::Error, "Nesting of 4 is too deep") do
+    expect_raises(YAML::Error, "Exceeded maximum depth") do
       builder.start_sequence
     end
   end
 
   it "errors on max nesting (mapping)" do
     io = IO::Memory.new
-    builder = YAML::Builder.new(io)
-    builder.max_nesting = 3
+    builder = YAML::Builder.new(io, YAML::Options.new(max_nesting: 3))
     builder.start_stream
     builder.start_document
     3.times do
       builder.start_mapping
     end
 
-    expect_raises(YAML::Error, "Nesting of 4 is too deep") do
+    expect_raises(YAML::Error, "Exceeded maximum depth") do
       builder.start_mapping
     end
   end

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -1232,4 +1232,19 @@ describe "YAML::Serializable" do
   it "supports generic type variables in converters" do
     YAMLAttrWithGenericConverter(Time::EpochConverter).from_yaml(%({"value":1459859781})).value.should eq(Time.unix(1459859781))
   end
+
+  it ".from_yaml enforces limits" do
+    yaml = String.build do |str|
+      11.times { str << "- John\n" }
+    end
+    expect_raises YAML::ParseException, "Exceeded maximum number of nodes" do
+      YAMLAttrPerson.from_yaml(yaml, YAML::Options.new(max_nodes: 10))
+    end
+  end
+
+  it ".to_yaml enforces limits" do
+    expect_raises YAML::Error, "Exceeded maximum number of nodes" do
+      Array.new(10) { YAMLAttrPerson.new("John") }.to_yaml(YAML::Options.new(max_nodes: 10))
+    end
+  end
 end

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -482,6 +482,20 @@ describe "YAML serialization" do
           Array(Hash(String, String)).from_yaml(yaml, YAML::Options.new(max_nesting: 3))
         end
       end
+
+      it "enforces limits (keyword arguments)" do
+        yaml = String.build do |str|
+          11.times { str << "- name\n" }
+        end
+        expect_raises YAML::ParseException, "Exceeded maximum number of nodes" do
+          Array(Hash(String, String)).from_yaml(yaml, max_nodes: 10)
+        end
+
+        yaml = "-\n  -\n    -\n      - too deep"
+        expect_raises YAML::ParseException, "Exceeded maximum depth" do
+          Array(Hash(String, String)).from_yaml(yaml, max_nesting: 3)
+        end
+      end
     end
   end
 
@@ -750,6 +764,16 @@ describe "YAML serialization" do
 
       expect_raises YAML::Error, "Exceeded maximum depth" do
         [[[["too deep"]]]].to_yaml(YAML::Options.new(max_nesting: 3))
+      end
+    end
+
+    it "enforces limits (keyword arguments)" do
+      expect_raises YAML::Error, "Exceeded maximum number of nodes" do
+        Array.new(10) { Hash{"name" => "John"} }.to_yaml(max_nodes: 10)
+      end
+
+      expect_raises YAML::Error, "Exceeded maximum depth" do
+        [[[["too deep"]]]].to_yaml(max_nesting: 3)
       end
     end
   end

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -468,6 +468,20 @@ describe "YAML serialization" do
         end
         ex.location.should eq({2, 3})
       end
+
+      it "enforces limits" do
+        yaml = String.build do |str|
+          11.times { str << "- name\n" }
+        end
+        expect_raises YAML::ParseException, "Exceeded maximum number of nodes" do
+          Array(Hash(String, String)).from_yaml(yaml, YAML::Options.new(max_nodes: 10))
+        end
+
+        yaml = "-\n  -\n    -\n      - too deep"
+        expect_raises YAML::ParseException, "Exceeded maximum depth" do
+          Array(Hash(String, String)).from_yaml(yaml, YAML::Options.new(max_nesting: 3))
+        end
+      end
     end
   end
 
@@ -727,6 +741,16 @@ describe "YAML serialization" do
       h[h] = h
 
       h.to_yaml.should match(/\A--- &1\n1: 2\n\*1 ?: \*1\n\z/)
+    end
+
+    it "enforces limits" do
+      expect_raises YAML::Error, "Exceeded maximum number of nodes" do
+        Array.new(10) { Hash{"name" => "John"} }.to_yaml(YAML::Options.new(max_nodes: 10))
+      end
+
+      expect_raises YAML::Error, "Exceeded maximum depth" do
+        [[[["too deep"]]]].to_yaml(YAML::Options.new(max_nesting: 3))
+      end
     end
   end
 end

--- a/spec/std/yaml/yaml_pull_parser_spec.cr
+++ b/spec/std/yaml/yaml_pull_parser_spec.cr
@@ -122,40 +122,6 @@ module YAML
       end
     end
 
-    it "prevents stack overflow for arrays" do
-      parser = YAML::PullParser.new(("[" * 513) + ("]" * 513))
-      expect_raises YAML::ParseException, "Nesting of 513 is too deep" do
-        until parser.read_next == EventKind::NONE
-        end
-      end
-    end
-
-    it "prevents stack overflow for hashes" do
-      parser = YAML::PullParser.new(("{" * 513) + ("}" * 513))
-      expect_raises YAML::ParseException, "Nesting of 513 is too deep" do
-        until parser.read_next == EventKind::NONE
-        end
-      end
-    end
-
-    it "prevents excessive node expansions (billion-laugh attacks)" do
-      parser = PullParser.new(<<-YAML)
-      a: &a ["lol","lol","lol","lol","lol","lol","lol","lol","lol"]
-      b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]
-      c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]
-      d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]
-      e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]
-      f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]
-      g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]
-      h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]
-      i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]
-      YAML
-      expect_raises(ParseException, "Document contains excessive aliasing") do
-        until parser.read_next == EventKind::NONE
-        end
-      end
-    end
-
     describe "skip" do
       it "scalar" do
         parser = PullParser.new("[1, 2]")
@@ -242,6 +208,72 @@ module YAML
         parser.kind.should eq(EventKind::STREAM_END)
         parser.skip
         parser.kind.should eq(EventKind::NONE)
+      end
+    end
+
+    describe "budget" do
+      it_raises = ->(parser : PullParser, msg : String) {
+        expect_raises(ParseException, msg) do
+          until parser.read_next == EventKind::NONE
+          end
+        end
+      }
+
+      it "limits maximum number of events" do
+        parser = PullParser.new("- 1\n" * 1001, Options.new(max_events: 1_000))
+        it_raises.call(parser, "Exceeded maximum number of events")
+      end
+
+      it "limits maximum number of documents" do
+        parser = PullParser.new("---\n" * 1001)
+        it_raises.call(parser, "Exceeded maximum number of documents")
+      end
+
+      it "limits maximum number of nodes" do
+        parser = PullParser.new("- lol\n" * 1001, Options.new(max_nodes: 1_000))
+        it_raises.call(parser, "Exceeded maximum number of nodes")
+      end
+
+      it "limits maximum number of aliases" do
+        yaml = String.build do |str|
+          str << %(x: &x lol\n)
+          50_001.times { |i| str << "a" << i << ": *x\n" }
+        end
+        parser = PullParser.new(yaml, Options.new(enforce_alias_anchor_ratio: false))
+        it_raises.call(parser, "Exceeded maximum number of aliases")
+      end
+
+      it "limits maximum number of anchors" do
+        yaml = String.build do |str|
+          50_001.times { |i| str << "a" << i << ": &a" << i << " lol\n" }
+        end
+        parser = PullParser.new(yaml, Options.new(enforce_alias_anchor_ratio: false))
+        it_raises.call(parser, "Exceeded maximum number of anchors")
+      end
+
+      it "limits maximum depth to prevent stack overflows (sequence)" do
+        parser = PullParser.new("x: " + ("[" * 1000))
+        it_raises.call(parser, "Exceeded maximum depth")
+      end
+
+      it "limits maximum depth to prevent stack overflows (mapping)" do
+        parser = PullParser.new "x: " + ("{" * 1000)
+        it_raises.call(parser, "Exceeded maximum depth")
+      end
+
+      it "prevents excessive node expansions (billion-laugh attacks)" do
+        parser = PullParser.new(<<-YAML)
+        a: &a ["lol","lol","lol","lol","lol","lol","lol","lol","lol"]
+        b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]
+        c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]
+        d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]
+        e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]
+        f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]
+        g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]
+        h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]
+        i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]
+        YAML
+        it_raises.call(parser, "Document contains excessive aliasing")
       end
     end
   end

--- a/src/yaml.cr
+++ b/src/yaml.cr
@@ -128,8 +128,8 @@ module YAML
   # # => "paragraph" => "foo\nbar\n"
   # # => }
   # ```
-  def self.parse(data : String | IO) : Any
-    YAML::Schema::Core.parse(data)
+  def self.parse(data : String | IO, options = Options.new) : Any
+    YAML::Schema::Core.parse(data, options)
   end
 
   # Deserializes multiple YAML documents according to the core schema.
@@ -147,8 +147,8 @@ module YAML
   # YAML.parse_all(File.read("./foo.yml"))
   # # => [{"foo" => "bar"}, {"hello" => "world"}]
   # ```
-  def self.parse_all(data : String) : Array(Any)
-    YAML::Schema::Core.parse_all(data)
+  def self.parse_all(data : String, options = Options.new) : Array(Any)
+    YAML::Schema::Core.parse_all(data, options)
   end
 
   # Serializes an object to YAML, returning it as a `String`.

--- a/src/yaml.cr
+++ b/src/yaml.cr
@@ -128,8 +128,14 @@ module YAML
   # # => "paragraph" => "foo\nbar\n"
   # # => }
   # ```
-  def self.parse(data : String | IO, options = Options.new) : Any
+  def self.parse(data : String | IO, options : Options = Options.new) : Any
     YAML::Schema::Core.parse(data, options)
+  end
+
+  # Same as `.parse(String | IO, Options)` but passing options as keyword
+  # arguments.
+  def self.parse(data : String | IO, **options) : Any
+    YAML::Schema::Core.parse(data, Options.new(**options))
   end
 
   # Deserializes multiple YAML documents according to the core schema.
@@ -147,8 +153,14 @@ module YAML
   # YAML.parse_all(File.read("./foo.yml"))
   # # => [{"foo" => "bar"}, {"hello" => "world"}]
   # ```
-  def self.parse_all(data : String, options = Options.new) : Array(Any)
+  def self.parse_all(data : String, options : Options = Options.new) : Array(Any)
     YAML::Schema::Core.parse_all(data, options)
+  end
+
+  # Same as `.parse_all(String, Options)` but passing options as keyword
+  # arguments.
+  def self.parse_all(data : String, **options) : Array(Any)
+    YAML::Schema::Core.parse_all(data, Options.new(**options))
   end
 
   # Serializes an object to YAML, returning it as a `String`.

--- a/src/yaml/budget.cr
+++ b/src/yaml/budget.cr
@@ -1,0 +1,85 @@
+# :nodoc:
+module YAML::Budget
+  @events = 0
+  @documents = 0
+  @nodes = 0
+  @aliases = 0
+  @anchors = 0
+  @depth = 0
+
+  # memoize the cost in nodes and aliases of each anchor, so the counters
+  # reflect the total number of reachables nodes through expanded aliases
+  @anchor_scope = {} of Int32 => {String, Int32, Int32}
+  @anchor_costs = {} of String => {Int32, Int32}
+
+  protected def add_budget(kind : EventKind, anchor : String? = nil) : Nil
+    add_event(1)
+
+    case kind
+    when EventKind::SCALAR
+      add_node(1)
+      add_anchor(1) if anchor
+    when EventKind::SEQUENCE_START, EventKind::MAPPING_START
+      add_node(1)
+      add_depth(1)
+      if anchor
+        add_anchor(1)
+        @anchor_scope[@depth] = {anchor, @nodes, @aliases}
+      end
+    when EventKind::SEQUENCE_END, EventKind::MAPPING_END
+      if scope = @anchor_scope[@depth]?
+        @anchor_scope.delete(@depth)
+        anchor, nodes, aliases = scope
+        @anchor_costs[anchor] = {@nodes - nodes, @aliases - aliases}
+      end
+      @depth -= 1
+    when EventKind::ALIAS
+      nodes, aliases = @anchor_costs[anchor]? || {1, 0}
+      add_node(nodes)
+      add_alias(aliases + 1)
+    when EventKind::DOCUMENT_START
+      add_document(1)
+    end
+  end
+
+  private def add_event(count)
+    if (@events += count) > @options.max_events
+      raise "Exceeded maximum number of events"
+    end
+  end
+
+  private def add_document(count)
+    if (@documents += count) > @options.max_documents
+      raise "Exceeded maximum number of documents"
+    end
+  end
+
+  private def add_node(count)
+    if (@nodes += count) > @options.max_nodes
+      raise "Exceeded maximum number of nodes"
+    end
+  end
+
+  private def add_alias(count)
+    if (@aliases += count) > @options.max_aliases
+      raise "Exceeded maximum number of aliases"
+    end
+    if @options.enforce_alias_anchor_ratio &&
+       @aliases > @options.alias_anchor_min_aliases &&
+       @aliases > @options.alias_anchor_multiplier * @anchors
+      raise "Document contains excessive aliasing"
+    end
+  end
+
+  private def add_anchor(count)
+    if (@anchors += count) > @options.max_anchors
+      raise "Exceeded maximum number of anchors"
+    end
+  end
+
+  private def add_depth(count)
+    if (@depth += count) > @options.max_nesting
+      raise "Exceeded maximum depth"
+    end
+  end
+end

--- a/src/yaml/builder.cr
+++ b/src/yaml/builder.cr
@@ -24,20 +24,29 @@
 # string # => "---\nfoo:\n- 1\n- 2\nbar:\n  baz: qux\n"
 # ```
 class YAML::Builder
+  include Budget
+
   @box : Void*
 
   # By default the maximum nesting of sequences/mappings is 99. Nesting more
   # than this will result in a YAML::Error. Changing the value of this property
   # allows more/less nesting.
-  property max_nesting = 99
+  @[Deprecated("Use YAML::Options to configure limits")]
+  def max_nesting
+    @options.max_nesting
+  end
+
+  @[Deprecated("Use YAML::Options to configure limits")]
+  def max_nesting=(max_nesting)
+    @options.max_nesting = max_nesting
+  end
 
   # Creates a `YAML::Builder` that will write to the given `IO`.
-  def initialize(@io : IO)
+  def initialize(@io : IO, @options = Options.new(max_nesting: 99))
     @box = Box.box(io)
     @emitter = Pointer(Void).malloc(LibYAML::EMITTER_SIZE).as(LibYAML::Emitter*)
     @event = LibYAML::Event.new
     @closed = false
-    @nesting = 0
     LibYAML.yaml_emitter_initialize(@emitter)
     LibYAML.yaml_emitter_set_unicode(@emitter, 1)
     LibYAML.yaml_emitter_set_output(@emitter, ->(data, buffer, size) {
@@ -50,8 +59,8 @@ class YAML::Builder
   # Creates a `YAML::Builder` that writes to *io* and yields it to the block.
   #
   # After returning from the block the builder is closed.
-  def self.build(io : IO, & : self ->) : Nil
-    builder = new(io)
+  def self.build(io : IO, options = Options.new, & : self ->) : Nil
+    builder = new(io, options)
     yield builder ensure builder.close
   end
 
@@ -105,13 +114,11 @@ class YAML::Builder
   def start_sequence(anchor : String? = nil, tag : String? = nil, style : YAML::SequenceStyle = YAML::SequenceStyle::ANY) : Nil
     implicit = tag ? 0 : 1
     emit sequence_start, get_anchor(anchor), string_to_unsafe(tag), implicit, style
-    increase_nesting
   end
 
   # Ends a sequence.
   def end_sequence : Nil
     emit sequence_end
-    decrease_nesting
   end
 
   # Starts a sequence, invokes the block, and the ends it.
@@ -124,13 +131,11 @@ class YAML::Builder
   def start_mapping(anchor : String? = nil, tag : String? = nil, style : YAML::MappingStyle = YAML::MappingStyle::ANY) : Nil
     implicit = tag ? 0 : 1
     emit mapping_start, get_anchor(anchor), string_to_unsafe(tag), implicit, style
-    increase_nesting
   end
 
   # Ends a mapping.
   def end_mapping : Nil
     emit mapping_end
-    decrease_nesting
   end
 
   # Starts a mapping, invokes the block, and then ends it.
@@ -155,7 +160,7 @@ class YAML::Builder
   # ```
   def alias(anchor : String) : Nil
     LibYAML.yaml_alias_event_initialize(pointerof(@event), anchor)
-    yaml_emit("alias")
+    yaml_emit("alias", EventKind::ALIAS)
   end
 
   # Emits the scalar `"<<"` followed by an alias to the given *anchor*.
@@ -206,14 +211,15 @@ class YAML::Builder
 
   private macro emit(event_name, *args)
     LibYAML.yaml_{{event_name}}_event_initialize(pointerof(@event), {{args.splat}})
-    yaml_emit({{event_name.stringify}})
+    yaml_emit({{event_name.stringify}}, EventKind::{{event_name.stringify.upcase.id}})
   end
 
-  private def yaml_emit(event_name)
+  private def yaml_emit(event_name, event_kind)
     ret = LibYAML.yaml_emitter_emit(@emitter, pointerof(@event))
     if ret != 1
       raise YAML::Error.new(build_libyaml_message(event_name))
     end
+    add_budget(event_kind)
   end
 
   private def build_libyaml_message(event_name)
@@ -225,15 +231,8 @@ class YAML::Builder
     end
   end
 
-  private def increase_nesting
-    @nesting += 1
-    if @nesting > @max_nesting
-      raise YAML::Error.new("Nesting of #{@nesting} is too deep")
-    end
-  end
-
-  private def decrease_nesting
-    @nesting -= 1
+  def raise(msg : String)
+    ::raise Error.new(msg)
   end
 end
 
@@ -254,17 +253,17 @@ module YAML
   # end
   # string # => "---\nfoo:\n- 1\n- 2\n"
   # ```
-  def self.build(&)
+  def self.build(options = Options.new(max_nesting: 99), &)
     String.build do |str|
-      build(str) do |yaml|
+      build(str, options) do |yaml|
         yield yaml
       end
     end
   end
 
   # Writes YAML into the given `IO`. A `YAML::Builder` is yielded to the block.
-  def self.build(io : IO, &) : Nil
-    YAML::Builder.build(io) do |yaml|
+  def self.build(io : IO, options = Options.new(max_nesting: 99), &) : Nil
+    YAML::Builder.build(io, options) do |yaml|
       yaml.stream do
         yaml.document do
           yield yaml

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -12,10 +12,20 @@ def Object.from_yaml(string_or_io : String | IO, options : YAML::Options = YAML:
   new(YAML::ParseContext.new, parse_yaml(string_or_io, options))
 end
 
+# Same as `.from_yaml(String | IO, Options)` but passing options as keyword
+# arguments.
+def Object.from_yaml(string_or_io : String | IO, **options)
+  from_yaml(string_or_io, YAML::Options.new(**options))
+end
+
 def Array.from_yaml(string_or_io : String | IO, options : YAML::Options = YAML::Options.new, &)
   new(YAML::ParseContext.new, parse_yaml(string_or_io, options)) do |element|
     yield element
   end
+end
+
+def Array.from_yaml(string_or_io : String | IO, **options)
+  from_yaml(string_or_io, YAML::Options.new(**options))
 end
 
 private def parse_yaml(string_or_io, options)

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -8,18 +8,18 @@
 # ```
 # Hash(String, String).from_yaml("{env: production}") # => {"env" => "production"}
 # ```
-def Object.from_yaml(string_or_io : String | IO)
-  new(YAML::ParseContext.new, parse_yaml(string_or_io))
+def Object.from_yaml(string_or_io : String | IO, options : YAML::Options = YAML::Options.new)
+  new(YAML::ParseContext.new, parse_yaml(string_or_io, options))
 end
 
-def Array.from_yaml(string_or_io : String | IO, &)
-  new(YAML::ParseContext.new, parse_yaml(string_or_io)) do |element|
+def Array.from_yaml(string_or_io : String | IO, options : YAML::Options = YAML::Options.new, &)
+  new(YAML::ParseContext.new, parse_yaml(string_or_io, options)) do |element|
     yield element
   end
 end
 
-private def parse_yaml(string_or_io)
-  document = YAML::Nodes.parse(string_or_io)
+private def parse_yaml(string_or_io, options)
+  document = YAML::Nodes.parse(string_or_io, options)
 
   # If the document is empty we simulate an empty scalar with
   # plain style, that parses to Nil

--- a/src/yaml/nodes.cr
+++ b/src/yaml/nodes.cr
@@ -9,12 +9,24 @@ require "./parser"
 # invoking `to_yaml` on the document object.
 module YAML::Nodes
   # Parses a `String` or `IO` into a `YAML::Nodes::Document`.
-  def self.parse(string_or_io : String | IO, options = Options.new) : Document
+  def self.parse(string_or_io : String | IO, options : Options = Options.new) : Document
     Parser.new string_or_io, options, &.parse
   end
 
+  # Same as `.parse(String | IO, Options)` but passing options as keyword
+  # arguments.
+  def self.parse(string_or_io : String | IO, **options) : Document
+    parse string_or_io, Options.new(**options)
+  end
+
   # Parses a `String` or `IO` into multiple `YAML::Nodes::Document`s.
-  def self.parse_all(string_or_io : String | IO, options = Options.new) : Array(Document)
+  def self.parse_all(string_or_io : String | IO, options : Options = Options.new) : Array(Document)
     Parser.new string_or_io, options, &.parse_all
+  end
+
+  # Same as `.parse_all(String | IO, Options)` but passing options as keyword
+  # arguments.
+  def self.parse_all(string_or_io : String | IO, **options) : Array(Document)
+    parse_all string_or_io, Options.new(**options)
   end
 end

--- a/src/yaml/nodes.cr
+++ b/src/yaml/nodes.cr
@@ -9,12 +9,12 @@ require "./parser"
 # invoking `to_yaml` on the document object.
 module YAML::Nodes
   # Parses a `String` or `IO` into a `YAML::Nodes::Document`.
-  def self.parse(string_or_io : String | IO) : Document
-    Parser.new string_or_io, &.parse
+  def self.parse(string_or_io : String | IO, options = Options.new) : Document
+    Parser.new string_or_io, options, &.parse
   end
 
   # Parses a `String` or `IO` into multiple `YAML::Nodes::Document`s.
-  def self.parse_all(string_or_io : String | IO) : Array(Document)
-    Parser.new string_or_io, &.parse_all
+  def self.parse_all(string_or_io : String | IO, options = Options.new) : Array(Document)
+    Parser.new string_or_io, options, &.parse_all
   end
 end

--- a/src/yaml/nodes/parser.cr
+++ b/src/yaml/nodes/parser.cr
@@ -1,14 +1,6 @@
 # :nodoc:
 class YAML::Nodes::Parser < YAML::Parser
-  def initialize(content : String | IO)
-    super
-    @anchors = {} of String => Node
-  end
-
-  def self.new(content, &)
-    parser = new(content)
-    yield parser ensure parser.close
-  end
+  @anchors = {} of String => Node
 
   def new_documents : Array(YAML::Nodes::Document)
     [] of Document

--- a/src/yaml/options.cr
+++ b/src/yaml/options.cr
@@ -1,0 +1,44 @@
+struct YAML::Options
+  # Maximum number of events allowed.
+  property max_events : Int32 = 1_000_000
+
+  # Maximum number of documents allowed.
+  property max_documents : Int32 = 1_000
+
+  # Maximum number of nodes (sequences + mappings + scalars) allowed.
+  property max_nodes : Int32 = 250_000
+
+  # Maximum number of aliases (`*ref`) allowed.
+  property max_aliases : Int32 = 50_000
+
+  # Maximum number of anchors (`&ref`) allowed.
+  property max_anchors : Int32 = 50_000
+
+  # Maximum structural depth (nested sequences and mappings) allowed.
+  property max_nesting : Int32 = 1_000
+
+  # If true, evaluates the alias/anchor ratio to avoid excessive expansion of
+  # aliases.
+  property enforce_alias_anchor_ratio : Bool = true
+
+  # Minimum number of aliases required before starting to evaluate the
+  # alias/anchor ratio. This avoids affecting smaller documents.
+  property alias_anchor_min_aliases : Int32 = 100
+
+  # The multiplier for the alias/anchor ratio evaluation. An error will be
+  # raised when `aliases > multiplier * anchors` once `min_aliases` has been
+  # reached.
+  property alias_anchor_multiplier : Int32 = 10
+
+  def initialize(*,
+                 @max_events = 1_000_000,
+                 @max_documents = 1_000,
+                 @max_nodes = 250_000,
+                 @max_aliases = 50_000,
+                 @max_anchors = 50_000,
+                 @max_nesting = 1_000,
+                 @enforce_alias_anchor_ratio = true,
+                 @alias_anchor_min_aliases = 100,
+                 @alias_anchor_multiplier = 10)
+  end
+end

--- a/src/yaml/parser.cr
+++ b/src/yaml/parser.cr
@@ -1,11 +1,11 @@
 # :nodoc:
 abstract class YAML::Parser
-  def initialize(content : String | IO)
-    @pull_parser = PullParser.new(content)
+  def initialize(content : String | IO, options = Options.new)
+    @pull_parser = PullParser.new(content, options)
   end
 
-  def self.new(content, &)
-    parser = new(content)
+  def self.new(content, options = Options.new, &)
+    parser = new(content, options)
     yield parser ensure parser.close
   end
 

--- a/src/yaml/pull_parser.cr
+++ b/src/yaml/pull_parser.cr
@@ -8,42 +8,28 @@
 #
 # Invoking `read_next` reads the next event.
 class YAML::PullParser
+  include Budget
+
   protected getter content
 
-  # :nodoc:
-  #
-  # Maximum structural depth (nested sequences and mappings) allowed.
-  property max_nesting = 512
+  {% for name in %w[max_nesting enforce_alias_anchor_ratio alias_anchor_min_aliases alias_anchor_multiplier] %}
+    # :nodoc:
+    @[Deprecated("Use YAML::Options to configure limits")]
+    def {{name.id}}
+      @options.{{name.id}}
+    end
 
-  # :nodoc:
-  #
-  # If true, evaluates the alias/anchor ratio to avoid excessive expansion of
-  # aliases.
-  property enforce_alias_anchor_ratio = true
+    # :nodoc:
+    @[Deprecated("Use YAML::Options to configure limits")]
+    def {{name.id}}=({{name.id}})
+      @options.{{name.id}} = {{name.id}}
+    end
+  {% end %}
 
-  # :nodoc:
-  #
-  # Minimum number of aliases required before starting to evaluate the
-  # alias/anchor ratio. This avoids affecting smaller documents.
-  property alias_anchor_min_aliases = 100
-
-  # :nodoc:
-  #
-  # The multiplier for the alias/anchor ratio evaluation. An error will be
-  # raised when `aliases > multiplier * anchors` once `min_aliases` has been
-  # reached.
-  property alias_anchor_multiplier = 10
-
-  def initialize(@content : String | IO)
+  def initialize(@content : String | IO, @options : Options = Options.new)
     @parser = Pointer(Void).malloc(LibYAML::PARSER_SIZE).as(LibYAML::Parser*)
     @event = LibYAML::Event.new
     @closed = false
-
-    @nesting = 0
-    @anchors = 0
-    @aliases = 0
-    @anchor_scope = Hash(Int32, {String, Int32}).new
-    @anchor_costs = Hash(String, Int32).new
 
     LibYAML.yaml_parser_initialize(@parser)
 
@@ -139,17 +125,8 @@ class YAML::PullParser
       raise msg, *location, context_info
     end
 
-    read_anchor
-    @anchors += 1 if @anchor
-
-    case kind
-    when EventKind::SEQUENCE_START, EventKind::MAPPING_START
-      increase_nesting
-    when EventKind::SEQUENCE_END, EventKind::MAPPING_END
-      decrease_nesting
-    when EventKind::ALIAS
-      increase_alias
-    end
+    @anchor = read_anchor
+    add_budget(kind, @anchor)
 
     kind
   end
@@ -375,42 +352,10 @@ class YAML::PullParser
       else
         Pointer(UInt8).null
       end
-    @anchor = anchor ? String.new(anchor) : nil
+    anchor ? String.new(anchor) : nil
   end
 
   def raise(msg : String, line_number = self.start_line, column_number = self.start_column, context_info = nil) : NoReturn
     ::raise ParseException.new(msg, line_number, column_number, context_info)
-  end
-
-  private def increase_nesting
-    @nesting += 1
-
-    if @nesting > @max_nesting
-      raise "Nesting of #{@nesting} is too deep"
-    end
-
-    if anchor = @anchor
-      @anchor_scope[@nesting] = {anchor, @aliases}
-    end
-  end
-
-  private def decrease_nesting
-    if scope = @anchor_scope.delete(@nesting)
-      anchor, aliases = scope
-      @anchor_costs[anchor] = @aliases - aliases
-    end
-
-    @nesting -= 1
-  end
-
-  private def increase_alias
-    aliases = @anchor_costs[@anchor]? || 0
-    @aliases += aliases + 1
-
-    if @enforce_alias_anchor_ratio &&
-       @aliases > @alias_anchor_min_aliases &&
-       @aliases > @alias_anchor_multiplier * @anchors
-      raise "Document contains excessive aliasing"
-    end
   end
 end

--- a/src/yaml/schema/core.cr
+++ b/src/yaml/schema/core.cr
@@ -4,15 +4,15 @@ module YAML::Schema::Core
   # Deserializes a YAML document.
   #
   # Same as `YAML.parse`.
-  def self.parse(data : String | IO) : YAML::Any
-    Parser.new data, &.parse
+  def self.parse(data : String | IO, options = Options.new) : YAML::Any
+    Parser.new data, options, &.parse
   end
 
   # Deserializes multiple YAML documents.
   #
   # Same as `YAML.parse_all`.
-  def self.parse_all(data : String | IO) : Array(YAML::Any)
-    Parser.new data, &.parse_all
+  def self.parse_all(data : String | IO, options = Options.new) : Array(YAML::Any)
+    Parser.new data, options, &.parse_all
   end
 
   # Assuming the *pull_parser* is positioned in a scalar,

--- a/src/yaml/schema/core.cr
+++ b/src/yaml/schema/core.cr
@@ -4,15 +4,27 @@ module YAML::Schema::Core
   # Deserializes a YAML document.
   #
   # Same as `YAML.parse`.
-  def self.parse(data : String | IO, options = Options.new) : YAML::Any
+  def self.parse(data : String | IO, options : Options = Options.new) : YAML::Any
     Parser.new data, options, &.parse
+  end
+
+  # Same as `.parse(String | IO, Options)` but passing options as keyword
+  # arguments.
+  def self.parse(data : String | IO, **options) : YAML::Any
+    Parser.new data, Options.new(**options), &.parse
   end
 
   # Deserializes multiple YAML documents.
   #
   # Same as `YAML.parse_all`.
-  def self.parse_all(data : String | IO, options = Options.new) : Array(YAML::Any)
+  def self.parse_all(data : String | IO, options : Options = Options.new) : Array(YAML::Any)
     Parser.new data, options, &.parse_all
+  end
+
+  # Same as `.parse_all(String | IO, Options)` but passing options as keyword
+  # arguments.
+  def self.parse_all(data : String | IO, **options) : Array(YAML::Any)
+    Parser.new data, Options.new(**options), &.parse_all
   end
 
   # Assuming the *pull_parser* is positioned in a scalar,

--- a/src/yaml/schema/fail_safe.cr
+++ b/src/yaml/schema/fail_safe.cr
@@ -3,13 +3,13 @@
 # where all scalar values are considered strings.
 module YAML::Schema::FailSafe
   # Deserializes a YAML document.
-  def self.parse(data : String | IO) : Any
-    Parser.new data, &.parse
+  def self.parse(data : String | IO, options = Options.new) : Any
+    Parser.new data, options, &.parse
   end
 
   # Deserializes multiple YAML documents.
-  def self.parse_all(data : String | IO) : Array(Any)
-    Parser.new data, &.parse_all
+  def self.parse_all(data : String | IO, options = Options.new) : Array(Any)
+    Parser.new data, options, &.parse_all
   end
 
   # :nodoc:

--- a/src/yaml/schema/fail_safe.cr
+++ b/src/yaml/schema/fail_safe.cr
@@ -3,13 +3,25 @@
 # where all scalar values are considered strings.
 module YAML::Schema::FailSafe
   # Deserializes a YAML document.
-  def self.parse(data : String | IO, options = Options.new) : Any
+  def self.parse(data : String | IO, options : Options = Options.new) : Any
     Parser.new data, options, &.parse
   end
 
+  # Same as `.parse(String | IO, Options)` but passing options as keyword
+  # arguments.
+  def self.parse(data : String | IO, **options) : YAML::Any
+    Parser.new data, Options.new(**options), &.parse
+  end
+
   # Deserializes multiple YAML documents.
-  def self.parse_all(data : String | IO, options = Options.new) : Array(Any)
+  def self.parse_all(data : String | IO, options : Options = Options.new) : Array(Any)
     Parser.new data, options, &.parse_all
+  end
+
+  # Same as `.parse_all(String | IO, Options)` but passing options as keyword
+  # arguments.
+  def self.parse_all(data : String | IO, **options) : Array(YAML::Any)
+    Parser.new data, Options.new(**options), &.parse_all
   end
 
   # :nodoc:

--- a/src/yaml/to_yaml.cr
+++ b/src/yaml/to_yaml.cr
@@ -1,11 +1,11 @@
 class Object
-  def to_yaml : String
+  def to_yaml(options : YAML::Options = YAML::Options.new(max_nesting: 99)) : String
     String.build do |io|
-      to_yaml(io)
+      to_yaml(io, options)
     end
   end
 
-  def to_yaml(io : IO) : Nil
+  def to_yaml(io : IO, options : YAML::Options = YAML::Options.new(max_nesting: 99)) : Nil
     # First convert the object to an in-memory tree.
     # With this, `to_yaml` will be invoked just once
     # on every object and we can use anchors and aliases
@@ -14,7 +14,7 @@ class Object
     to_yaml(nodes_builder)
 
     # Then we convert the tree to YAML.
-    YAML.build(io) do |builder|
+    YAML.build(io, options) do |builder|
       nodes_builder.document.to_yaml(builder)
     end
   end

--- a/src/yaml/to_yaml.cr
+++ b/src/yaml/to_yaml.cr
@@ -5,6 +5,11 @@ class Object
     end
   end
 
+  # Same as `.to_yaml(Options)` but passing options as keyword arguments.
+  def to_yaml(*, max_nesting = 99, **options) : String
+    to_yaml YAML::Options.new(**options, max_nesting: max_nesting)
+  end
+
   def to_yaml(io : IO, options : YAML::Options = YAML::Options.new(max_nesting: 99)) : Nil
     # First convert the object to an in-memory tree.
     # With this, `to_yaml` will be invoked just once
@@ -17,6 +22,11 @@ class Object
     YAML.build(io, options) do |builder|
       nodes_builder.document.to_yaml(builder)
     end
+  end
+
+  # Same as `.to_yaml(IO, Options)` but passing options as keyword arguments.
+  def to_yaml(io : IO, *, max_nesting = 99, **options) : String
+    to_yaml YAML::Options.new(**options, max_nesting: max_nesting)
   end
 end
 


### PR DESCRIPTION
I'm proposing a `YAML::Options` object to centralize the configuration of YAML parsers and builders.

The current setof options introduces a budget (aka limits) to parsing and generating YAML files. For example a maximum number of documents, nodes, max nesting (avoid stack overflows), and much more (see `YAML::Options`).

While using keyword arguments is nicer, it would require to pass blind `**options` around, or to have the whole list of options as keyword arguments, in _lots_ of places. The type also to centralize the list of options, their default value, and their documentation. A type also allows to have a global options and to use it everywhere (it's ready-only).

The PR includes a commit with simple overloads for the public helpers methods, so we can have the best of both?

_Credis where its due_: the budget idea comes from the [serde-saphyr](https://crates.io/crates/serde-saphyr) crate, that has a bunch more budget options (max bytes, ...).

Follow up to #17107 and #17109. The limits introduced in both PR are now easily configurable.

Closes #17187.