### PR TITLE
Relax threshold for `sleep` spec with libevent

### DIFF
--- a/spec/std/concurrent_spec.cr
+++ b/spec/std/concurrent_spec.cr
@@ -94,6 +94,12 @@ describe "concurrent" do
     elapsed = Time.measure do
       sleep 50.milliseconds
     end
-    elapsed.should be >= 50.milliseconds
+
+    # libevent seems to occasionally wake up from sleep a bit earlier (up to 800
+    # microseconds observed). It's clearly more than just jitter. But we don't
+    # know exactly what's happening. Maybe a different clock source?  It's not a
+    # big deal and libevent support is a legacy feature, so we just relax the
+    # expectation a little bit.
+    elapsed.should be >= {{ flag?(:"evloop=libevent") ? 49 : 50 }}.milliseconds
   end
 end


### PR DESCRIPTION
`sleep` spec sometimes fails when using `libevent` because it seems to wake a bit earlier than the intended duration.

```
1) concurrent sleep does not return immediately (#16578)
       Failure/Error: elapsed.should be >= 50.milliseconds
  
         Expected 00:00:00.049293944 to be GreaterOrEqual 00:00:00.050000000
  
       # spec/std/concurrent_spec.cr:97
```

We don't know why this happens. It shouldn't. But it seems too insignificant to dig into the details.

So we just relax the spec threshold for libevent.

Recently affected CI run: https://github.com/crystal-lang/crystal/actions/runs/31783395417/job/94722428559