### PR TITLE
Fix `Int#humanize_bytes` to use `KiB` in IEC format

### DIFF
--- a/spec/std/humanize_spec.cr
+++ b/spec/std/humanize_spec.cr
@@ -304,7 +304,7 @@ end
 describe Int do
   describe "#humanize_bytes" do
     # default IEC
-    it { assert_prints 1024.humanize_bytes, "1.0kiB" }
+    it { assert_prints 1024.humanize_bytes, "1.0KiB" }
 
     it { assert_prints 0.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC), "0B" }
     it { assert_prints 1.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC), "1B" }
@@ -329,7 +329,7 @@ describe Int do
     it { assert_prints 1.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC, unit_separator: '\u2009'), "1\u2009B" }
     it { assert_prints 1152921504606846976.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC, unit_separator: '\u2009'), "1.0\u2009EB" }
 
-    it { assert_prints 1024.humanize_bytes(format: Int::BinaryPrefixFormat::IEC), "1.0kiB" }
+    it { assert_prints 1024.humanize_bytes(format: Int::BinaryPrefixFormat::IEC), "1.0KiB" }
     it { assert_prints 1073741824.humanize_bytes(format: Int::BinaryPrefixFormat::IEC), "1.0GiB" }
   end
 end

--- a/src/humanize.cr
+++ b/src/humanize.cr
@@ -299,7 +299,7 @@ end
 struct Int
   enum BinaryPrefixFormat
     # The IEC standard prefixes (`Ki`, `Mi`, `Gi`, `Ti`, `Pi`, `Ei`, `Zi`, `Yi`, `Ri`, `Qi`)
-    # based on powers of 1000.
+    # based on powers of 1024.
     IEC
 
     # Extended range of the JEDEC units (`K`, `M`, `G`, `T`, `P`, `E`, `Z`, `Y`, `R`, `Q`)
@@ -315,7 +315,7 @@ struct Int
   # typically expressed using unit prefixes based on 1024 (instead of multiples
   # of 1000 as per SI standard). This method by default uses the IEC standard
   # prefixes (`Ki`, `Mi`, `Gi`, `Ti`, `Pi`, `Ei`, `Zi`, `Yi`, `Ri`, `Qi`) based
-  # on powers of 1000 (see `BinaryPrefixFormat::IEC`).
+  # on powers of 1024 (see `BinaryPrefixFormat::IEC`).
   #
   # *format* can be set to use the extended range of JEDEC units (`K`, `M`, `G`,
   # `T`, `P`, `E`, `Z`, `Y`, `R`, `Q`) which equals to the prefixes of the SI
@@ -324,9 +324,9 @@ struct Int
   #
   # ```
   # 1.humanize_bytes                        # => "1B"
-  # 1024.humanize_bytes                     # => "1.0kiB"
-  # 1536.humanize_bytes                     # => "1.5kiB"
-  # 524288.humanize_bytes                   # => "512kiB"
+  # 1024.humanize_bytes                     # => "1.0KiB"
+  # 1536.humanize_bytes                     # => "1.5KiB"
+  # 524288.humanize_bytes                   # => "512KiB"
   # 1073741824.humanize_bytes(format: :IEC) # => "1.0GiB"
   # ```
   #
@@ -340,7 +340,7 @@ struct Int
         unit = "B"
       else
         if format.iec?
-          unit = "#{prefix}iB"
+          unit = "#{prefix.upcase}iB"
         else
           unit = "#{prefix.upcase}B"
         end


### PR DESCRIPTION
The IEC branch was using the SI prefix `k` as-is instead of `K`, so `1024.humanize_bytes` returned `"1.0kiB"` rather than `"1.0KiB"`.

The JEDEC branch already had `prefix.upcase`. This applies the same to the IEC branch to follow IEC 60027-2 and match the documentation.

Also updates the documentation examples, specs, and fixes a typo in the documentation ("powers of 1000" -> "powers of 1024").

This pull request was created with the assistance of GLM-5.2.