### PR TITLE
Validate method, version, and host in `HTTP::WebSocketHandler`

### DIFF
--- a/spec/std/http/server/handlers/websocket_handler_spec.cr
+++ b/spec/std/http/server/handlers/websocket_handler_spec.cr
@@ -137,6 +137,28 @@ describe HTTP::WebSocketHandler do
     io.to_s.should eq("HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nContent-Length: 16\r\n\r\n400 Bad Request\n")
   end
 
+  it "returns bad request if the request HTTP version is not HTTP/1.1" do
+    io = IO::Memory.new
+
+    headers = HTTP::Headers{
+      "Host"                  => "example.com",
+      "Upgrade"               => "websocket",
+      "Connection"            => "Upgrade",
+      "Sec-WebSocket-Key"     => "dGhlIHNhbXBsZSBub25jZQ==",
+      "Sec-WebSocket-Version" => "13",
+    }
+    request = HTTP::Request.new("GET", "/", headers: headers, version: "HTTP/1.0")
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+
+    handler = HTTP::WebSocketHandler.new { }
+    handler.call context
+
+    response.close
+
+    io.to_s.should eq("HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nContent-Length: 16\r\n\r\n400 Bad Request\n")
+  end
+
   it "returns upgrade required if Sec-WebSocket-Version is missing" do
     io = IO::Memory.new
 

--- a/spec/std/http/server/handlers/websocket_handler_spec.cr
+++ b/spec/std/http/server/handlers/websocket_handler_spec.cr
@@ -45,6 +45,7 @@ describe HTTP::WebSocketHandler do
     it "gives upgrade response for websocket upgrade request with '{{connection.id}}' request" do
       io = IO::Memory.new
       headers = HTTP::Headers{
+        "Host" =>              "example.com",
         "Upgrade" =>           "websocket",
         "Connection" =>        {{connection}},
         "Sec-WebSocket-Key" => "dGhlIHNhbXBsZSBub25jZQ==",
@@ -72,6 +73,7 @@ describe HTTP::WebSocketHandler do
   it "gives upgrade response for case-insensitive 'WebSocket' upgrade request" do
     io = IO::Memory.new
     headers = HTTP::Headers{
+      "Host"                  => "example.com",
       "Upgrade"               => "WebSocket",
       "Connection"            => "Upgrade",
       "Sec-WebSocket-Key"     => "dGhlIHNhbXBsZSBub25jZQ==",
@@ -99,6 +101,7 @@ describe HTTP::WebSocketHandler do
     io = IO::Memory.new
 
     headers = HTTP::Headers{
+      "Host"                  => "example.com",
       "Upgrade"               => "websocket",
       "Connection"            => "Upgrade",
       "Sec-WebSocket-Version" => "13",
@@ -159,10 +162,32 @@ describe HTTP::WebSocketHandler do
     io.to_s.should eq("HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nContent-Length: 16\r\n\r\n400 Bad Request\n")
   end
 
+  it "returns bad request if Host header is missing" do
+    io = IO::Memory.new
+
+    headers = HTTP::Headers{
+      "Upgrade"               => "websocket",
+      "Connection"            => "Upgrade",
+      "Sec-WebSocket-Key"     => "dGhlIHNhbXBsZSBub25jZQ==",
+      "Sec-WebSocket-Version" => "13",
+    }
+    request = HTTP::Request.new("GET", "/", headers: headers)
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+
+    handler = HTTP::WebSocketHandler.new { }
+    handler.call context
+
+    response.close
+
+    io.to_s.should eq("HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nContent-Length: 16\r\n\r\n400 Bad Request\n")
+  end
+
   it "returns upgrade required if Sec-WebSocket-Version is missing" do
     io = IO::Memory.new
 
     headers = HTTP::Headers{
+      "Host"              => "example.com",
       "Upgrade"           => "websocket",
       "Connection"        => "Upgrade",
       "Sec-WebSocket-Key" => "dGhlIHNhbXBsZSBub25jZQ==",
@@ -183,6 +208,7 @@ describe HTTP::WebSocketHandler do
     io = IO::Memory.new
 
     headers = HTTP::Headers{
+      "Host"                  => "example.com",
       "Upgrade"               => "websocket",
       "Connection"            => "Upgrade",
       "Sec-WebSocket-Key"     => "dGhlIHNhbXBsZSBub25jZQ==",
@@ -203,6 +229,7 @@ describe HTTP::WebSocketHandler do
   it "includes Sec-WebSocket-Protocol in upgrade response if it is valid" do
     io = IO::Memory.new
     headers = HTTP::Headers{
+      "Host"                   => "example.com",
       "Upgrade"                => "WebSocket",
       "Connection"             => "Upgrade",
       "Sec-WebSocket-Key"      => "dGhlIHNhbXBsZSBub25jZQ==",
@@ -230,6 +257,7 @@ describe HTTP::WebSocketHandler do
   it "excludes Sec-WebSocket-Protocol in upgrade response if it is not valid" do
     io = IO::Memory.new
     headers = HTTP::Headers{
+      "Host"                   => "example.com",
       "Upgrade"                => "WebSocket",
       "Connection"             => "Upgrade",
       "Sec-WebSocket-Key"      => "dGhlIHNhbXBsZSBub25jZQ==",
@@ -279,6 +307,7 @@ describe HTTP::WebSocketHandler do
     it "uses the first matched Sec-WebSocket-Protocol in upgrade response for '#{test_case[:client_protocols]}'" do
       io = IO::Memory.new
       headers = HTTP::Headers{
+        "Host"                   => "example.com",
         "Upgrade"                => "WebSocket",
         "Connection"             => "Upgrade",
         "Sec-WebSocket-Key"      => "dGhlIHNhbXBsZSBub25jZQ==",
@@ -307,6 +336,7 @@ describe HTTP::WebSocketHandler do
   it "excludes Sec-WebSocket-Protocol in upgrade response if no protocol is provided to handler" do
     io = IO::Memory.new
     headers = HTTP::Headers{
+      "Host"                   => "example.com",
       "Upgrade"                => "WebSocket",
       "Connection"             => "Upgrade",
       "Sec-WebSocket-Key"      => "dGhlIHNhbXBsZSBub25jZQ==",

--- a/spec/std/http/server/handlers/websocket_handler_spec.cr
+++ b/spec/std/http/server/handlers/websocket_handler_spec.cr
@@ -115,6 +115,28 @@ describe HTTP::WebSocketHandler do
     io.to_s.should eq("HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nContent-Length: 16\r\n\r\n400 Bad Request\n")
   end
 
+  it "returns bad request if the request method is not GET" do
+    io = IO::Memory.new
+
+    headers = HTTP::Headers{
+      "Host"                  => "example.com",
+      "Upgrade"               => "websocket",
+      "Connection"            => "Upgrade",
+      "Sec-WebSocket-Key"     => "dGhlIHNhbXBsZSBub25jZQ==",
+      "Sec-WebSocket-Version" => "13",
+    }
+    request = HTTP::Request.new("POST", "/", headers: headers)
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+
+    handler = HTTP::WebSocketHandler.new { }
+    handler.call context
+
+    response.close
+
+    io.to_s.should eq("HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nContent-Length: 16\r\n\r\n400 Bad Request\n")
+  end
+
   it "returns upgrade required if Sec-WebSocket-Version is missing" do
     io = IO::Memory.new
 

--- a/src/http/server/handlers/websocket_handler.cr
+++ b/src/http/server/handlers/websocket_handler.cr
@@ -37,6 +37,11 @@ class HTTP::WebSocketHandler
       return
     end
 
+    unless context.request.headers.has_key?("Host")
+      response.respond_with_status(:bad_request)
+      return
+    end
+
     version = context.request.headers["Sec-WebSocket-Version"]?
     unless version == WebSocket::Protocol::VERSION
       response.status = :upgrade_required

--- a/src/http/server/handlers/websocket_handler.cr
+++ b/src/http/server/handlers/websocket_handler.cr
@@ -27,6 +27,11 @@ class HTTP::WebSocketHandler
 
     response = context.response
 
+    unless context.request.method == "GET"
+      response.respond_with_status(:bad_request)
+      return
+    end
+
     version = context.request.headers["Sec-WebSocket-Version"]?
     unless version == WebSocket::Protocol::VERSION
       response.status = :upgrade_required

--- a/src/http/server/handlers/websocket_handler.cr
+++ b/src/http/server/handlers/websocket_handler.cr
@@ -32,6 +32,11 @@ class HTTP::WebSocketHandler
       return
     end
 
+    unless context.request.version == "HTTP/1.1"
+      response.respond_with_status(:bad_request)
+      return
+    end
+
     version = context.request.headers["Sec-WebSocket-Version"]?
     unless version == WebSocket::Protocol::VERSION
       response.status = :upgrade_required


### PR DESCRIPTION
`HTTP::WebSocketHandler` completed the opening handshake for any request carrying the right `Upgrade`/`Connection` headers. e.g. a plain `curl -X POST` with those headers received `101 Switching Protocols`, violating RFC 6455 §4.1/§4.2.1.

Following the direction in https://github.com/crystal-lang/crystal/issues/17231#issuecomment-5294618529, this adds three validations to `#call`:

- The request method must be `GET`
- The request version must be `HTTP/1.1` (`HTTP::Server` itself accepts HTTP/1.0, but WebSocket requires 1.1)
- A `Host` header must be present (§4.2.1)

Each failure responds with `400 Bad Request` via `respond_with_status`, matching the existing handling of a missing `Sec-WebSocket-Key` header.

`#websocket_upgrade_request?` is intentionally left as a header-only check: it detects upgrade requests, and an upgrade request with a wrong method is handled (with an error) rather than falling through.

Each validation is a separate commit with its spec. Existing spec fixtures gained a `Host` header so they keep exercising their original scenarios. The client side (`WebSocket::Protocol.new`) already sends `GET` + HTTP/1.1 + `Host`, so no client-facing change.

> Noted but out of scope (happy to follow up if desired)
> 
> - `Sec-WebSocket-Key` is only checked for presence, not that it decodes to 16 bytes (§4.2.1 item 5)
> - The `Host` check is presence-only; an empty value still passes


Fixes #17231
Thanks!