### PR TITLE
Document error behaviour for `Dir.mkdir` and `.mkdir_p`

### DIFF
--- a/src/dir.cr
+++ b/src/dir.cr
@@ -294,7 +294,7 @@ class Dir
   # intermediate directories. The linux-style permission mode can be specified,
   # with a default of 777 (0o777).
   #
-  # Does nothing if the directory already exists.
+  # Does nothing if the directories already exists.
   def self.mkdir_p(path : Path | String, mode : Int32 = 0o777) : Nil
     return if Dir.exists?(path)
 

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -294,7 +294,7 @@ class Dir
   # intermediate directories. The linux-style permission mode can be specified,
   # with a default of 777 (0o777).
   #
-  # Does nothing if the directories already exists.
+  # Does nothing if a directory already exists.
   def self.mkdir_p(path : Path | String, mode : Int32 = 0o777) : Nil
     return if Dir.exists?(path)
 

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -284,6 +284,7 @@ class Dir
   # Dir.mkdir("testdir")
   # Dir.exists?("testdir") # => true
   # ```
+  #
   # Throws if the directory already exists.
   def self.mkdir(path : Path | String, mode : Int32 = 0o777) : Nil
     Crystal::System::Dir.create(path.to_s, mode)
@@ -292,6 +293,8 @@ class Dir
   # Creates a new directory at the given path, including any non-existing
   # intermediate directories. The linux-style permission mode can be specified,
   # with a default of 777 (0o777).
+  #
+  # Does nothing if the directory already exists.
   def self.mkdir_p(path : Path | String, mode : Int32 = 0o777) : Nil
     return if Dir.exists?(path)
 

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -284,6 +284,7 @@ class Dir
   # Dir.mkdir("testdir")
   # Dir.exists?("testdir") # => true
   # ```
+  # Throws if the directory already exists.
   def self.mkdir(path : Path | String, mode : Int32 = 0o777) : Nil
     Crystal::System::Dir.create(path.to_s, mode)
   end

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -285,7 +285,7 @@ class Dir
   # Dir.exists?("testdir") # => true
   # ```
   #
-  # Throws if the directory already exists.
+  # Raises `File::AlreadyExistsError` if the directory already exists.
   def self.mkdir(path : Path | String, mode : Int32 = 0o777) : Nil
     Crystal::System::Dir.create(path.to_s, mode)
   end


### PR DESCRIPTION
Adds a small specification on the behaviour of both `Dir.mkdir` and `Dir.mkdir_p` when the directory already exists.