### PR TITLE
Fix: invalid resize when writing `IO::Memory` to itself

### DIFF
--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -81,6 +81,11 @@ describe IO::Memory do
       io.to_s.should eq "ABCDEF\0ABCDEF"
     end
 
+    it "can't append to itself when read-only" do
+      io = IO::Memory.new(Bytes[1, 2, 3], writable: false)
+      expect_raises(IO::Error, "Read-only stream") { io << io }
+    end
+
     {% if flag?(:without_iconv) %}
       pending "encoding"
     {% else %}

--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -73,6 +73,14 @@ describe IO::Memory do
       io.@capacity.should_not eq old_capacity
     end
 
+    it "appends to itself even when messing with pos" do
+      io = IO::Memory.new(8)
+      io << "ABCDEF"
+      io.pos = 7
+      io.to_s(io)
+      io.to_s.should eq "ABCDEF\0ABCDEF"
+    end
+
     {% if flag?(:without_iconv) %}
       pending "encoding"
     {% else %}

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -433,8 +433,7 @@ class IO::Memory < IO
     if io == self
       # When appending to itself, we need to pull the resize up before taking
       # pointer to the buffer. It would become invalid when a resize happens during `#write`.
-      new_bytesize = bytesize * 2
-      resize_to_capacity(new_bytesize) if @capacity < new_bytesize
+      increase_capacity_by(bytesize)
     end
     if encoding = @encoding
       {% if flag?(:without_iconv) %}


### PR DESCRIPTION
Closes #17236 
Closes #17237