### PR TITLE
Fix: `sem_open` fails with `ENAMETOOLONG` on macOS [fixup #17226]

### DIFF
--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -291,7 +291,7 @@ module Crystal::System::Thread
       # maybe leaking a semaphore name); it will be destroyed when we close it,
       # at worst on exec or when the process exits
       LibC.pthread_threadid_np(@system_handle, out tid)
-      sem_name = "/crystal-thread-#{LibC.getpid}-#{tid}"
+      sem_name = "/CRYSTAL/#{tid}" # limited to PSNAMLEN chars (31)
       @semaphore = LibC.sem_open(sem_name, LibC::O_CREAT | LibC::O_EXCL, 0o644, 0)
       raise RuntimeError.from_errno("sem_open") if @semaphore == Pointer(LibC::SemT).new(-1.to_u64!) # LibC::SEM_FAILED
       LibC.sem_unlink(sem_name)


### PR DESCRIPTION
The named semaphore name is limited to `SEM_NAME_LEN` characters on macOS. The constant is never defined but macOS uses `PSNAMLEN` internally (31). It appears that [we can reach the limit](https://github.com/crystal-lang/crystal/actions/runs/32012884200/job/95336063541).

The thread id is unique system-wide so we can drop the process id from the name. The thread id is an usigned long so it takes at most 20 chars, which leaves us with 11 chars for disambiguation. It's now hardcoded to the `/CRYSTAL/` prefix (9 chars).

NOTE: Another app might be able to mess with an app if it can guess the semaphore name... we create it soon after the thread has started, so the time window is short, but we could replace `CRYSTAL` with a random number, like `Random::Secure.rand(9999999)` to make the issue impossible (especially with a retry).