### PR TITLE
Fix typos in doc comments

### DIFF
--- a/src/int.cr
+++ b/src/int.cr
@@ -196,7 +196,7 @@ struct Int
   #
   # This uses floored division.
   #
-  # See `Int#/` for more details.
+  # See `Int#//` for more details.
   def %(other : Int)
     {% begin %}
       if other == 0

--- a/src/process.cr
+++ b/src/process.cr
@@ -483,7 +483,7 @@ class Process
   # *command* is either a path to the executable to run, or the name of an
   # executable which is then looked up by the operating system.
   # The lookup uses the `PATH` variable of the current process environment
-  # (i.e. `ENV["PATH"]).
+  # (i.e. `ENV["PATH"]`).
   # In order to resolve to a specific executable, provide a path instead of
   # only a command name. `Process.find_executable` can help with looking up a
   # command in a custom `PATH`.


### PR DESCRIPTION
* a missing backquote in `process.cr`
* doc for modulo `%` in `int.cr` refers the detail-oriented reader to `Int#/`, which has no docs. `Int#//` seems to be the intended target