### PR TITLE
Fix `Time::Location.load?` for Android

### DIFF
--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -348,7 +348,7 @@ class Time::Location
       end
 
       {% if flag?(:android) %}
-        if location = load_android(name, Crystal::System::Time.android_tzdata_sources)
+        if location = load_android(name, Crystal::System::Time.android_tzdata_sources) { |source| yield source }
           return location
         end
       {% end %}

--- a/src/time/location/loader.cr
+++ b/src/time/location/loader.cr
@@ -70,7 +70,7 @@ class Time::Location
         read_android_tzdata(file, false) do |location_name, location|
           @@location_cache[location_name] = {time: mtime, location: location}
         end
-        @@location_cache[name].try &.[:location]
+        @@location_cache[name]?.try &.[:location]
       end
     end
   end


### PR DESCRIPTION
The blockless `Time::Location.load_android` overload raises on missing timezone names, as does `#[]` for the timezone location cache. This fixes `spec/std/time/location_spec.cr:236` on Android.