### PR TITLE
Refactor `Socket::IPAddress` interface index conversion

### DIFF
--- a/spec/std/socket/address_spec.cr
+++ b/spec/std/socket/address_spec.cr
@@ -158,16 +158,17 @@ describe Socket::IPAddress do
     end
 
     it "fails interface name lookup for non-existent interfaces" do
-      exc_suff = {% if flag?(:windows) %}
-                   ""
-                 {% elsif flag?(:darwin) || flag?(:bsd) %}
-                   ": Device not configured"
-                 {% else %}
-                   ": No such device or address"
-                 {% end %}
-      expect_raises(Socket::Error, "Failed to look up interface name for index 333#{exc_suff}") do
+      err = expect_raises(Socket::Error, "Failed to look up interface name for index 333") do
         Socket::IPAddress.new("fe80::d00d:1%333", 0).link_local_interface
       end
+
+      {% if flag?(:win32) %}
+        err.os_error.should eq(WinError::ERROR_FILE_NOT_FOUND)
+      {% elsif flag?(:android) %}
+        err.os_error.should eq(Errno::ENODEV)
+      {% else %}
+        err.os_error.should eq(Errno::ENXIO)
+      {% end %}
     end
 
     it "interface name lookup returns nil in unsupported cases" do
@@ -201,9 +202,15 @@ describe Socket::IPAddress do
 
     it "fails on non-existent link-local zone interface" do
       # looking up an interface index obviously requires for said interface device to exist
-      expect_raises(Socket::Error, "IPv6 link-local zone interface 'zzzzzzzzzzzzzzz' not found (in address 'fe80::0f0f:abcd%zzzzzzzzzzzzzzz')") do
+      err = expect_raises(Socket::Error, "IPv6 link-local zone interface 'zzzzzzzzzzzzzzz' not found (in address 'fe80::0f0f:abcd%zzzzzzzzzzzzzzz')") do
         Socket::IPAddress.new("fe80::0f0f:abcd%zzzzzzzzzzzzzzz", port: 0)
       end
+
+      {% if flag?(:win32) %}
+        err.os_error.should eq(WinError::ERROR_INVALID_NAME)
+      {% else %}
+        err.os_error.should eq(Errno::ENODEV)
+      {% end %}
     end
   end
 

--- a/spec/std/socket/address_spec.cr
+++ b/spec/std/socket/address_spec.cr
@@ -208,6 +208,8 @@ describe Socket::IPAddress do
 
       {% if flag?(:win32) %}
         err.os_error.should eq(WinError::ERROR_INVALID_NAME)
+      {% elsif flag?(:darwin) || flag?(:bsd) %}
+        err.os_error.should eq(Errno::ENXIO)
       {% else %}
         err.os_error.should eq(Errno::ENODEV)
       {% end %}

--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -130,6 +130,12 @@ module Crystal::System::Socket
   # private def system_tcp_keepalive_count
 
   # private def system_tcp_keepalive_count=(val : Int)
+
+  # IPAddress:
+
+  # def self.network_interface_to_index(name : String, & : Errno | WinError | WasiError ->) : Int
+
+  # def self.network_interface_from_index(index : Int, & : Errno | WinError | WasiError ->) : String
 end
 
 {% if flag?(:wasi) %}

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -393,4 +393,20 @@ module Crystal::System::Socket
       ret.to_i64
     {% end %}
   end
+
+  def self.network_interface_to_index(name : String, & : Errno ->) : Int
+    zone_id = LibC.if_nametoindex(name)
+    return zone_id if zone_id != 0
+
+    yield Errno.value
+  end
+
+  def self.network_interface_from_index(index : Int, & : Errno ->) : String
+    buf = uninitialized UInt8[LibC::IF_NAMESIZE]
+    if result = LibC.if_indextoname(index, buf)
+      return String.new(buf.to_slice, truncate_at_null: true)
+    end
+
+    yield Errno.value
+  end
 end

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -404,7 +404,7 @@ module Crystal::System::Socket
   def self.network_interface_from_index(index : Int, & : Errno ->) : String
     buf = uninitialized UInt8[LibC::IF_NAMESIZE]
     if result = LibC.if_indextoname(index, buf)
-      return String.new(buf.to_slice, truncate_at_null: true)
+      return String.new(result)
     end
 
     yield Errno.value

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -204,4 +204,12 @@ module Crystal::System::Socket
   private def system_tcp_keepalive_count=(val : Int)
     raise NotImplementedError.new("Crystal::System::Socket#system_tcp_keepalive_count=")
   end
+
+  def self.network_interface_to_index(name : String, & : WasiError ->) : Int
+    raise NotImplementedError.new("Crystal::System::Socket.network_interface_to_index")
+  end
+
+  def self.network_interface_from_index(index : Int, & : WasiError ->) : String
+    raise NotImplementedError.new("Crystal::System::Socket.network_interface_from_index")
+  end
 end

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -407,4 +407,29 @@ module Crystal::System::Socket
 
     event_loop.sendfile(self, file.fd, offset, count, 0)
   end
+
+  def self.network_interface_to_index(name : String, & : WinError ->) : Int
+    err = LibC.ConvertInterfaceNameToLuidW(System.to_wstr(name), out luid)
+    if err == 0
+      err = LibC.ConvertInterfaceLuidToIndex(pointerof(luid), out index)
+      if err == 0
+        return index
+      end
+    end
+
+    yield WinError.new(err)
+  end
+
+  def self.network_interface_from_index(index : Int, & : WinError ->) : String
+    err = LibC.ConvertInterfaceIndexToLuid(index, out luid)
+    if err == 0
+      buf = uninitialized LibC::WCHAR[LibC::IF_NAMESIZE]
+      err = LibC.ConvertInterfaceLuidToNameW(pointerof(luid), buf, buf.size)
+      if err == 0
+        return String.from_utf16(buf.to_slice, truncate_at_null: true)
+      end
+    end
+
+    yield WinError.new(err)
+  end
 end

--- a/src/lib_c/x86_64-windows-msvc/c/netioapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/netioapi.cr
@@ -9,4 +9,13 @@ lib LibC
 
   fun if_nametoindex(ifname : Char*) : UInt
   fun if_indextoname(ifindex : UInt, ifname : LibC::Char*) : LibC::Char*
+
+  alias NET_IFINDEX = ULong
+  alias NET_LUID = UInt64
+
+  fun ConvertInterfaceLuidToIndex(interfaceLuid : NET_LUID*, interfaceIndex : NET_IFINDEX*) : DWORD
+  fun ConvertInterfaceIndexToLuid(interfaceIndex : NET_IFINDEX, interfaceLuid : NET_LUID*) : DWORD
+
+  fun ConvertInterfaceLuidToNameW(interfaceLuid : NET_LUID*, interfaceName : LPWSTR, length : SizeT) : DWORD
+  fun ConvertInterfaceNameToLuidW(interfaceName : LPWSTR, interfaceLuid : NET_LUID*) : DWORD
 end

--- a/src/socket/address.cr
+++ b/src/socket/address.cr
@@ -134,8 +134,9 @@ class Socket
           if zone_id = zone.to_i?
             raise Error.new("Invalid IPv6 link-local zone index '#{zone}' in address '#{address}'") unless zone_id.positive?
           else
-            zone_id = LibC.if_nametoindex(zone).to_i
-            raise Error.new("IPv6 link-local zone interface '#{zone}' not found (in address '#{address}')") unless zone_id.positive?
+            zone_id = Crystal::System::Socket.network_interface_to_index(zone) do |os_error|
+              raise Error.from_os_error("IPv6 link-local zone interface '#{zone}' not found (in address '#{address}')", os_error)
+            end.to_i
           end
         end
         addr = v6(v6_fields, port.to_u16!, zone_id)
@@ -790,23 +791,12 @@ class Socket
     # This helper method exists to look up the interface name based on the
     # associated zone_id property.
     def link_local_interface : String | Nil
-      {% unless LibC.has_method?(:if_nametoindex) %}
-        raise NotImplementedError.new "Socket::Address.link_local_interface"
-      {% end %}
       return nil if @zone_id.zero?
       return nil unless (@family == Socket::Family::INET6 && link_local?)
-      buf = uninitialized StaticArray(UInt8, LibC::IF_NAMESIZE)
-      result = LibC.if_indextoname(@zone_id, buf)
-      if result.null?
-        message = "Failed to look up interface name for index #{@zone_id}"
-        {% if flag?(:windows) %}
-          # In windows it is not possible to determine an error code here
-          raise Error.new(message)
-        {% else %}
-          raise Error.from_errno(message)
-        {% end %}
+
+      Crystal::System::Socket.network_interface_from_index(@zone_id) do |os_error|
+        raise Error.from_os_error("Failed to look up interface name for index #{@zone_id}", os_error)
       end
-      String.new(buf.to_unsafe)
     end
 
     protected def self.endian_swap(x : Int::Primitive) : Int::Primitive


### PR DESCRIPTION
* Moves the bare `LibC` fun calls into class methods of `Crystal::System::Socket`.
* Rewrites the Windows implementation to use Win32 functions, which have proper error reporting.
* Checks for the underlying error code directly in specs, instead of the error messages.
* Fixes the specs on Android since apparently the kernel returns `ENODEV` in both directions.