### PR TITLE
Use clang-cl to build OpenSSL for ARM64 MSVC CI

### DIFF
--- a/.github/workflows/win_arm64.yml
+++ b/.github/workflows/win_arm64.yml
@@ -96,7 +96,7 @@ jobs:
         uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
       - name: Build OpenSSL
         if: steps.cache-openssl.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.5.0
+        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.5.0 -UseClangCl
 
   aarch64-windows-dlls:
     runs-on: windows-11-vs2026-arm
@@ -184,7 +184,7 @@ jobs:
         uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
       - name: Build OpenSSL
         if: steps.cache-openssl-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.5.0 -Dynamic
+        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.5.0 -UseClangCl -Dynamic
 
   aarch64-windows-llvm-dlls:
     runs-on: windows-11-vs2026-arm

--- a/etc/win-ci/build-openssl.ps1
+++ b/etc/win-ci/build-openssl.ps1
@@ -1,6 +1,7 @@
 param(
     [Parameter(Mandatory)] [string] $BuildTree,
     [Parameter(Mandatory)] [string] $Version,
+    [switch] $UseClangCl,
     [switch] $Dynamic
 )
 
@@ -14,7 +15,15 @@ Run-InDirectory $BuildTree {
     Replace-Text Configurations\10-main.conf '/Zi /Fdossl_static.pdb' ''
     Replace-Text Configurations\10-main.conf '"/nologo /debug"' '"/nologo /debug:none"'
 
-    $platform = if ($arch -eq "ARM 64-bit Processor") { "VC-WIN64-ARM" } else { "VC-WIN64A" }
+    $platform = if ($arch -eq "ARM 64-bit Processor") {
+        if ($UseClangCl) {
+            "VC-CLANG-WIN64-CLANGASM-ARM"
+        } else {
+            "VC-WIN64-ARM"
+        }
+    } else {
+        "VC-WIN64A"
+    }
 
     if ($Dynamic) {
         perl Configure "$platform" no-tests


### PR DESCRIPTION
Adds an extra parameter to `etc\win-ci\build-openssl.ps1` for choosing clang-cl instead of MSVC as the compiler, which presumably fixes bad code optimization by MSVC, similar to LLVM in #17154. Additionally it serves as an ARM64 assembler since NASM can only handle x86.

(OpenSSL does not have a platform string for using clang-cl on x86-64.)