### PR TITLE
Validate `HTTP::Request#method`

### DIFF
--- a/spec/std/http/http_spec.cr
+++ b/spec/std/http/http_spec.cr
@@ -92,4 +92,31 @@ describe HTTP do
       end
     end
   end
+
+  describe ".validate_token" do
+    it "accepts valid token" do
+      HTTP.validate_token("foo").should eq "foo"
+      HTTP.validate_token("foo-bar+baz").should eq "foo-bar+baz"
+    end
+
+    it "rejects empty token" do
+      expect_raises(ArgumentError, "Invalid HTTP token") do
+        HTTP.validate_token("")
+      end
+    end
+
+    it "rejects invalid tokens" do
+      expect_raises(ArgumentError, "Invalid HTTP token") do
+        HTTP.validate_token("foo bar")
+      end
+
+      expect_raises(ArgumentError, "Invalid HTTP token") do
+        HTTP.validate_token("foo(bar)")
+      end
+
+      expect_raises(ArgumentError, "Invalid HTTP token") do
+        HTTP.validate_token("foo@bar")
+      end
+    end
+  end
 end

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -28,11 +28,10 @@ module HTTP
         end
 
         it "rejects invalid methods" do
-          # BUG: The following specs all demonstrate incorrect behaviour.
-          Request.new("GET /", "/").method.should eq "GET /"
-          Request.new("GET\n", "/").method.should eq "GET\n"
-          Request.new("GET\r", "/").method.should eq "GET\r"
-          Request.new("", "/").method.should eq ""
+          expect_raises(ArgumentError, "Invalid HTTP method") { Request.new "GET /", "/" }
+          expect_raises(ArgumentError, "Invalid HTTP method") { Request.new "GET\n", "/" }
+          expect_raises(ArgumentError, "Invalid HTTP method") { Request.new "GET\r", "/" }
+          expect_raises(ArgumentError, "Invalid HTTP method") { Request.new "", "/" }
         end
       end
 
@@ -116,16 +115,11 @@ module HTTP
       end
 
       it "rejects invalid methods" do
-        # BUG: The following specs all demonstrate incorrect behaviour.
         req = Request.new("GET", "/")
-        req.method = "GET /"
-        req.method.should eq "GET /"
-        req.method = "GET\n"
-        req.method.should eq "GET\n"
-        req.method = "GET\r"
-        req.method.should eq "GET\r"
-        req.method = ""
-        req.method.should eq ""
+        expect_raises(ArgumentError, "Invalid HTTP method") { req.method = "GET /" }
+        expect_raises(ArgumentError, "Invalid HTTP method") { req.method = "GET\n" }
+        expect_raises(ArgumentError, "Invalid HTTP method") { req.method = "GET\r" }
+        expect_raises(ArgumentError, "Invalid HTTP method") { req.method = "" }
       end
     end
 

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -452,34 +452,34 @@ module HTTP
   # :nodoc:
   VALID_TOKEN_CHAR_MAP = {% begin %}
     {%
-      table = (0x00..0xFF).map { 0 }
-      table['!'.ord] = 1
-      table['#'.ord] = 1
-      table['$'.ord] = 1
-      table['%'.ord] = 1
-      table['&'.ord] = 1
-      table['\''.ord] = 1
-      table['*'.ord] = 1
-      table['+'.ord] = 1
-      table['-'.ord] = 1
-      table['.'.ord] = 1
-      table['^'.ord] = 1
-      table['_'.ord] = 1
-      table['`'.ord] = 1
-      table['|'.ord] = 1
-      table['~'.ord] = 1
+      table = (0x00..0xFF).map { 0_u8 }
+      table['!'.ord] = 1_u8
+      table['#'.ord] = 1_u8
+      table['$'.ord] = 1_u8
+      table['%'.ord] = 1_u8
+      table['&'.ord] = 1_u8
+      table['\''.ord] = 1_u8
+      table['*'.ord] = 1_u8
+      table['+'.ord] = 1_u8
+      table['-'.ord] = 1_u8
+      table['.'.ord] = 1_u8
+      table['^'.ord] = 1_u8
+      table['_'.ord] = 1_u8
+      table['`'.ord] = 1_u8
+      table['|'.ord] = 1_u8
+      table['~'.ord] = 1_u8
       ('0'.ord..'9'.ord).each do |i|
-        table[i] = 1
+        table[i] = 1_u8
       end
       ('A'.ord..'Z'.ord).each do |i|
-        table[i] = 1
+        table[i] = 1_u8
       end
       ('a'.ord..'z'.ord).each do |i|
-        table[i] = 1
+        table[i] = 1_u8
       end
     %}
     {% if compare_versions(Crystal::VERSION, "1.16.0") >= 0 %}
-      Slice.literal({{ table.splat }})
+      Slice(UInt8).literal({{ table.splat }})
     {% else %}
       {{table}}.to_slice
     {% end %}

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -450,7 +450,7 @@ module HTTP
   end
 
   # :nodoc:
-  VALID_TOKEN_CHAR_MAP = {% begin %}
+  VALID_TOKEN_CHAR_MAP = {% if compare_versions(Crystal::VERSION, "1.11.0") >= 0 %}
     {%
       table = (0x00..0xFF).map { 0_u8 }
       table['!'.ord] = 1_u8
@@ -483,7 +483,34 @@ module HTTP
     {% else %}
       {{table}}.to_slice
     {% end %}
-  {% end %}
+  {% else %}
+                           table = Slice(UInt8).new(256)
+                           table[0x21] = 1
+                           table[0x23] = 1
+                           table[0x24] = 1
+                           table[0x25] = 1
+                           table[0x26] = 1
+                           table[0x27] = 1
+                           table[0x2a] = 1
+                           table[0x2b] = 1
+                           table[0x2d] = 1
+                           table[0x2e] = 1
+                           table[0x5e] = 1
+                           table[0x5f] = 1
+                           table[0x60] = 1
+                           table[0x7c] = 1
+                           table[0x7e] = 1
+                           (0x30..0x39).each do |i|
+                             table[i] = 1
+                           end
+                           (0x41..0x5a).each do |i|
+                             table[i] = 1
+                           end
+                           (0x61..0x7a).each do |i|
+                             table[i] = 1
+                           end
+                           table
+                         {% end %}
 
   def self.validate_token(string : String, message = "Invalid HTTP token") : String
     if string.empty? || string.to_slice.any? { |c| VALID_TOKEN_CHAR_MAP[c] == 0 }

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -448,6 +448,50 @@ module HTTP
       quote_string(string, io)
     end
   end
+
+  # :nodoc:
+  VALID_TOKEN_CHAR_MAP = {% begin %}
+    {%
+      table = (0x00..0xFF).map { 0 }
+      table['!'.ord] = 1
+      table['#'.ord] = 1
+      table['$'.ord] = 1
+      table['%'.ord] = 1
+      table['&'.ord] = 1
+      table['\''.ord] = 1
+      table['*'.ord] = 1
+      table['+'.ord] = 1
+      table['-'.ord] = 1
+      table['.'.ord] = 1
+      table['^'.ord] = 1
+      table['_'.ord] = 1
+      table['`'.ord] = 1
+      table['|'.ord] = 1
+      table['~'.ord] = 1
+      ('0'.ord..'9'.ord).each do |i|
+        table[i] = 1
+      end
+      ('A'.ord..'Z'.ord).each do |i|
+        table[i] = 1
+      end
+      ('a'.ord..'z'.ord).each do |i|
+        table[i] = 1
+      end
+    %}
+    {% if compare_versions(Crystal::VERSION, "1.16.0") >= 0 %}
+      Slice.literal({{ table.splat }})
+    {% else %}
+      {{table}}.to_slice
+    {% end %}
+  {% end %}
+
+  def self.validate_token(string : String, message = "Invalid HTTP token") : String
+    if string.empty? || string.to_slice.any? { |c| VALID_TOKEN_CHAR_MAP[c] == 0 }
+      raise ArgumentError.new(message)
+    end
+
+    string
+  end
 end
 
 require "./status"

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -15,7 +15,7 @@ require "socket"
 #
 # NOTE: To use `Request`, you must explicitly import it with `require "http/request"`
 class HTTP::Request
-  property method : String
+  getter method : String
   property headers : Headers
   getter body : IO?
   property version : String
@@ -64,9 +64,14 @@ class HTTP::Request
     new(method, resource, headers.try(&.dup), body, version, internal: nil)
   end
 
-  private def initialize(@method : String, @resource : String, headers : Headers? = nil, body : String | Bytes | IO | Nil = nil, @version = "HTTP/1.1", *, internal)
+  private def initialize(method : String, @resource : String, headers : Headers? = nil, body : String | Bytes | IO | Nil = nil, @version = "HTTP/1.1", *, internal)
+    @method = HTTP.validate_token(method, "Invalid HTTP method")
     @headers = headers || Headers.new
     self.body = body
+  end
+
+  def method=(method : String) : String
+    @method = HTTP.validate_token(method, "Invalid HTTP method")
   end
 
   # Returns a convenience wrapper around querying and setting cookie related


### PR DESCRIPTION
`HTTP::Request.new` and `#method=` should not allow arbitrary strings. This patch verifies that the given method is a valid HTTP token.
Invalid tokens would corrupt the HTTP message format.