### PR TITLE
Fix `HTTP::Request#form_params?` to ignore invalid content-type

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -821,12 +821,8 @@ module HTTP
 
       it "ignores invalid content-type" do
         request = Request.new("POST", "/form", HTTP::Headers{"Content-Type" => "//"}, HTTP::Params.encode({"test" => "foobar"}))
-        expect_raises(MIME::Error, "Invalid '/'") do
-          request.form_params?
-        end
-        expect_raises(MIME::Error, "Invalid '/'") do
-          request.form_params
-        end
+        request.form_params?.should be_nil
+        request.form_params.size.should eq(0)
       end
     end
 

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -87,8 +87,8 @@ class HTTP::Request
   def form_params? : HTTP::Params?
     @form_params ||= begin
       if (body = self.body) && (ct = headers["Content-Type"]?)
-        mt = MIME::MediaType.parse(ct)
-        if mt.media_type == "application/x-www-form-urlencoded"
+        mt = MIME::MediaType.parse?(ct)
+        if mt && mt.media_type == "application/x-www-form-urlencoded"
           if charset = mt["charset"]?
             body.set_encoding(charset)
           end


### PR DESCRIPTION
Follow-up to #16934