### PR TITLE
Fix `HTTP::Request#body=` return value

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -181,6 +181,15 @@ module HTTP
     end
 
     describe "#body=" do
+      it "returns the value" do
+        req = Request.new("GET", "/")
+        (req.body = "foo").should eq "foo"
+        (req.body = "foo".to_slice).should eq "foo".to_slice
+        io = IO::Memory.new
+        (req.body = io).should be io
+        (req.body = nil).should be_nil
+      end
+
       it "keeps content-length header in sync" do
         # BUG: The following specs all demonstrate incorrect behaviour.
         req = Request.new("GET", "/", body: "foo")

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -137,7 +137,6 @@ class HTTP::Request
   end
 
   def body=(@body : IO) : IO
-    body
   end
 
   def body=(@body : Nil) : Nil

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -127,14 +127,17 @@ class HTTP::Request
   def body=(body : String) : String
     @body = IO::Memory.new(body)
     self.content_length = body.bytesize
+    body
   end
 
-  def body=(body : Bytes) : String
+  def body=(body : Bytes) : Bytes
     @body = IO::Memory.new(body)
     self.content_length = body.size
+    body
   end
 
   def body=(@body : IO) : IO
+    body
   end
 
   def body=(@body : Nil) : Nil


### PR DESCRIPTION
Setters should always return the input value, so that they behave like assignments (#7707).
The `HTTP::Request#body=(body : String) : String` overloads is particularly confusing because the return type matches, but the returned value is not the body string, but the string representation of the content length, through `#content_length=` 🤦

The `IO` overload is unaffected, but it might be good to explicitly state the return value there as well.

This is technically a breaking change. Any code relying on `#body=(String)` to return the stringified content length would break. This seems very unlikely though because the behaviour is totally unexpected.