### PR TITLE
Use `Time::Span#to_seconds` etc.

### DIFF
--- a/src/crystal/event_loop/kqueue.cr
+++ b/src/crystal/event_loop/kqueue.cr
@@ -174,7 +174,7 @@ class Crystal::EventLoop::Kqueue < Crystal::EventLoop::Polling
       # Cannot use `::Time.instant` here because it could be mocked.
       t = time.duration_since(Crystal::System::Time.instant)
 
-      data = t.total_nanoseconds.to_i64!
+      data = t.to_nanoseconds.to_i64!
       {% unless LibC.has_constant?(:NOTE_NSECONDS) %}
         # legacy BSD (and DragonFly) only have millisecond precision, so we
         # round up to the next millisecond.

--- a/src/crystal/event_loop/libevent/event.cr
+++ b/src/crystal/event_loop/libevent/event.cr
@@ -21,7 +21,7 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
 
     def add(timeout : Time::Span) : Nil
       timeval = LibC::Timeval.new(
-        tv_sec: LibC::TimeT.new(timeout.total_seconds),
+        tv_sec: LibC::TimeT.new(timeout.to_seconds),
         tv_usec: timeout.nanoseconds // 1_000
       )
       LibEvent2.event_add(@event, pointerof(timeval))

--- a/src/crystal/system/win32/thread.cr
+++ b/src/crystal/system/win32/thread.cr
@@ -103,7 +103,7 @@ module Crystal::System::Thread
   {% end %}
 
   def self.sleep(time : ::Time::Span) : Nil
-    milliseconds = time.total_milliseconds.to_i.clamp(1..)
+    milliseconds = time.to_milliseconds.to_i.clamp(1..)
     GC.syscall do
       LibC.Sleep(milliseconds)
     end

--- a/src/crystal/system/win32/thread_condition_variable.cr
+++ b/src/crystal/system/win32/thread_condition_variable.cr
@@ -24,7 +24,7 @@ class Thread
 
     def wait(mutex : Thread::Mutex, time : Time::Span, & : ->)
       ret, error = 0, WinError::ERROR_SUCCESS
-      timeout = time.total_milliseconds
+      timeout = time.to_milliseconds
 
       GC.syscall do
         ret = LibC.SleepConditionVariableCS(self, mutex, timeout)


### PR DESCRIPTION
Directly use integer duration for `Time::Span` in order to avoid float conversions from `#total_seconds` etc.

Follow-up to #17190
