### PR TITLE
Fix `Content-Encoding: deflate`

### DIFF
--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -339,7 +339,7 @@ class HTTP::Client::Response
 
     it "deletes Content-Encoding and Content-Length headers after deflate decompression" do
       body = String.build do |io|
-        Compress::Deflate::Writer.open(io, &.print("hello"))
+        Compress::Zlib::Writer.open(io, &.print("hello"))
       end
       response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Encoding: deflate\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"))
       response.body.should eq("hello")

--- a/spec/std/http/server/handlers/compress_handler_spec.cr
+++ b/spec/std/http/server/handlers/compress_handler_spec.cr
@@ -39,7 +39,7 @@ describe HTTP::CompressHandler do
     body = response2.body
 
     io2 = IO::Memory.new(body)
-    flate = Compress::Deflate::Reader.new(io2)
+    flate = Compress::Zlib::Reader.new(io2)
     flate.gets_to_end.should eq("Hello")
   end
 

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -1,6 +1,6 @@
 require "mime/media_type"
 {% if !flag?(:without_zlib) %}
-  require "compress/deflate"
+  require "compress/zlib"
   require "compress/gzip"
 {% end %}
 
@@ -73,7 +73,7 @@ module HTTP
               headers.delete("Content-Encoding")
               headers.delete("Content-Length")
             when "deflate"
-              body = Compress::Deflate::Reader.new(body, sync_close: true)
+              body = Compress::Zlib::Reader.new(body, sync_close: true)
               headers.delete("Content-Encoding")
               headers.delete("Content-Length")
             else

--- a/src/http/server/handlers/compress_handler.cr
+++ b/src/http/server/handlers/compress_handler.cr
@@ -1,5 +1,5 @@
 {% if !flag?(:without_zlib) %}
-  require "compress/deflate"
+  require "compress/zlib"
   require "compress/gzip"
 {% end %}
 
@@ -57,7 +57,7 @@ class HTTP::CompressHandler
         elsif request_headers.includes_word?("Accept-Encoding", "deflate")
           @context.response.headers["Content-Encoding"] = "deflate"
           @context.response.headers.delete("Content-Length")
-          @io = Compress::Deflate::Writer.new(@io, sync_close: true)
+          @io = Compress::Zlib::Writer.new(@io, sync_close: true)
         end
       end
     end


### PR DESCRIPTION
Per [RFC 9110 & 8.4.1.2], the `deflate` coding is a data stream compressed with `deflate` wrapped in a `zlib` data format. This corresponds to the `Compress::Zlib` implementation.
However, the HTTP compress/decompress implementation used `Compress::Deflate`, which misses the `zlib` wrapper and thus is incompatible with standard-compliant implementations.

Resolves #5221

[RFC 9110 & 8.4.1.2]: https://httpwg.org/specs/rfc9110.html#deflate.coding