### PR TITLE
Reject `HTTP::Client::Response` with invalid `Content-Encoding`

### DIFF
--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -347,6 +347,28 @@ class HTTP::Client::Response
       response.headers["content-length"]?.should be_nil
     end
 
+    it "rejects response with unsupported Content-Encoding" do
+      expect_raises Exception, "Unexpected end of http request" do
+        Response.from_io(IO::Memory.new(<<-HTTP))
+          HTTP/1.1 200 OK
+          Content-Encoding: br
+
+          foobar
+          HTTP
+      end
+    end
+
+    it "rejects response with unknown Content-Encoding" do
+      expect_raises Exception, "Unexpected end of http request" do
+        Response.from_io(IO::Memory.new(<<-HTTP))
+          HTTP/1.1 200 OK
+          Content-Encoding: foo
+
+          foobar
+          HTTP
+      end
+    end
+
     describe "success?" do
       it "returns true for the 2xx" do
         response = Response.new(:ok)

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -61,13 +61,18 @@ module HTTP
           encoding = headers["Content-Encoding"]?
           {% if flag?(:without_zlib) %}
             case encoding
+            when Nil
+              # nothing
             when "gzip", "deflate"
               raise "Can't decompress because `-D without_zlib` was passed at compile time"
             else
               # not a format we support
+              return HTTP::Status::UNSUPPORTED_MEDIA_TYPE
             end
           {% else %}
             case encoding
+            when Nil
+              # nothing
             when "gzip"
               body = Compress::Gzip::Reader.new(body, sync_close: true)
               headers.delete("Content-Encoding")
@@ -78,6 +83,7 @@ module HTTP
               headers.delete("Content-Length")
             else
               # not a format we support
+              return HTTP::Status::UNSUPPORTED_MEDIA_TYPE
             end
           {% end %}
         end


### PR DESCRIPTION
When the client encounters an unsupported `Content-Encoding`, it should not simply ignore it. That leads to gibberish. It's an error if the response uses a `Content-Encoding` that we didn't specify in `Accept-Encoding`.

Custom encodings with manual decompression are still supported by explicitly setting the `Accept-Encoding` header and/or disabling `Client#compress`.