### PR TITLE
`HTTP::Client::Request` support `Content-Encoding: x-gzip`

### DIFF
--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -337,6 +337,16 @@ class HTTP::Client::Response
       response.headers["content-length"]?.should be_nil
     end
 
+    it "deletes Content-Encoding and Content-Length headers after x-gzip decompression" do
+      body = String.build do |io|
+        Compress::Gzip::Writer.open(io, &.print("hello"))
+      end
+      response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Encoding: x-gzip\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"))
+      response.body.should eq("hello")
+      response.headers["content-encoding"]?.should be_nil
+      response.headers["content-length"]?.should be_nil
+    end
+
     it "deletes Content-Encoding and Content-Length headers after deflate decompression" do
       body = String.build do |io|
         Compress::Deflate::Writer.open(io, &.print("hello"))

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -68,7 +68,7 @@ module HTTP
             end
           {% else %}
             case encoding
-            when "gzip"
+            when "gzip", "x-gzip"
               body = Compress::Gzip::Reader.new(body, sync_close: true)
               headers.delete("Content-Encoding")
               headers.delete("Content-Length")


### PR DESCRIPTION
According to [RFC 1010 §8.4.1.3], recipients should consider `x-gzip` equivalent to `gzip`.
This patch achieves that.

We do not change the sender (`CompressHandler`) nor `Accept-Encoding`. They still only use and recognize `gzip`.

[RFC 1010 §8.4.1.3]: https://httpwg.org/specs/rfc9110.html#gzip.coding