### PR TITLE
Add support for `QUERY` method to `HTTP::Client`

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -58,7 +58,7 @@ module HTTP
     typeof(Client.new(URI.new))
     typeof(Client.new(URI.parse("http://www.example.com")))
 
-    {% for method in %w(get post put head delete patch options) %}
+    {% for method in %w(get post put head delete patch options query) %}
       typeof(Client.{{method.id}} "url")
       typeof(Client.new("host").{{method.id}}("uri"))
       typeof(Client.new("host").{{method.id}}("uri", headers: Headers {"Content-Type" => "text/plain"}))

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -962,6 +962,10 @@ module HTTP
       it "POST with body and Idempotency-Key header is not replayable" do
         HTTP::Request.new("POST", "/", HTTP::Headers{"Idempotency-Key" => "key"}, "body").replayable?.should be_false
       end
+
+      it "QUERY is replayable" do
+        HTTP::Request.new("QUERY", "/").replayable?.should be_true
+      end
     end
   end
 end

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -399,7 +399,7 @@ class HTTP::Client
     before_request << callback
   end
 
-  {% for method in %w(get post put head delete patch options) %}
+  {% for method in %w(get post put head delete patch options query) %}
     # Executes a {{method.id.upcase}} request.
     # The response will have its body as a `String`, accessed via `HTTP::Client::Response#body`.
     #

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -359,6 +359,8 @@ class HTTP::Request
   #
   # [idempotency]: https://httpwg.org/specs/rfc9110.html#idempotent.methods
   def replayable? : Bool
+    return true if @method == "QUERY"
+
     @body.nil? && @form_params.nil? && (
       @method.in?("GET", "HEAD", "OPTIONS", "TRACE") ||
         headers.has_key?("Idempotency-Key") || headers.has_key?("X-Idempotency-Key")


### PR DESCRIPTION
See [RFC 10008](https://datatracker.ietf.org/doc/rfc10008/)