### PR TITLE
Fix `Range#size` overflow on max integer value

### DIFF
--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -732,6 +732,11 @@ describe "Range" do
       it { (-Int32::MAX..-Int32::MAX).size.should eq(1) }
       it { (-Int32::MAX...-Int32::MAX).size.should eq(0) }
 
+      it { (0...Int32::MAX).size.should eq(Int32::MAX) }
+      it { expect_raises(OverflowError) { (0..Int32::MAX).size } }
+      it { expect_raises(OverflowError) { (Int32::MIN...Int32::MAX).size } }
+      it { expect_raises(OverflowError) { (Int32::MIN..Int32::MAX).size } }
+
       it { (5_u8..12_u8).size.should eq(8) }
       it { (5_u8...12_u8).size.should eq(7) }
       it { (5_u8..4_u8).size.should eq(0) }

--- a/src/range.cr
+++ b/src/range.cr
@@ -497,14 +497,14 @@ struct Range(B, E)
     if b.is_a?(Int) && e.is_a?(Int)
       return 0 if e < b
 
-      # Convert `e` to `Int32` in order to ensure that `e &- b` doesn't get
+      # Convert `e` to `Int32` in order to ensure that `e - b` doesn't get
       # truncated due to the smaller type of `e`.
       if e.is_a?(UInt8 | Int8 | UInt16 | Int16)
         e = e.to_i32!
       end
 
-      diff = (e &- b).to_i32.abs
-      diff &+= 1 unless @exclusive
+      diff = (e - b).to_i32.abs
+      diff += 1 unless @exclusive
       diff
     else
       if b.nil? || e.nil?


### PR DESCRIPTION
# Pull Request

We thank you for helping improve Crystal. In order to ease the reviewing process, we invite you to read the [guidelines](https://github.com/crystal-lang/crystal/blob/master/CONTRIBUTING.md#making-good-pull-requests) and ask you to consider the following points before submitting a PR:

1. We prefer to discuss the underlying issue _prior_ to discussing the code. Therefore, we kindly ask you to refer to an existing issue, or an existing discussion in a public space with members of the Core Team (forum, Gitter, Discord, ...). In few cases, we acknowledge that this might not be necessary, for instance when refactoring code or small bug fixes. In this case, the PR must include the same information an issue would have: a clear explanation of the issue, reproducible code, etc.

2. Focus the PR to the referred issue, and restraint from adding unrelated changes/additions. We do welcome another PR if you fixed another issue.

3. If your change is big, consider breaking it into several smaller PRs. In general, the smaller the change, the quicker we can review it.

4. ⚠️ Please do not amend previous commits and force push to the PR branch. This makes reviews much harder because reference to previous state is hidden.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/crystal-lang/crystal/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

Fixes #17201
