### PR TITLE
Fix `HTTP.parse_headers_and_body` to not raise with `without_zlib`

### DIFF
--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -63,8 +63,6 @@ module HTTP
             case encoding
             when Nil
               # nothing
-            when "gzip", "deflate"
-              raise "Can't decompress because `-D without_zlib` was passed at compile time"
             else
               # not a format we support
               return HTTP::Status::UNSUPPORTED_MEDIA_TYPE


### PR DESCRIPTION
Receiving an unsupported `Content-Type` is a simple protocol error, not an exceptional application state.