### PR TITLE
Fix `HTTP::Request#content_length=` return value

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -217,11 +217,11 @@ module HTTP
     describe "#content_length=" do
       it "accepts valid values" do
         req = Request.new("GET", "/")
-        (req.content_length = 1234).should eq 1234_i64
+        (req.content_length = 1234).should eq 1234
         req.content_length.should eq 1234
         req.headers["Content-Length"].should eq "1234"
 
-        (req.content_length = 0).should eq 0_i64
+        (req.content_length = 0).should eq 0
         req.content_length.should eq 0
         req.headers["Content-Length"].should eq "0"
 

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -217,15 +217,15 @@ module HTTP
     describe "#content_length=" do
       it "accepts valid values" do
         req = Request.new("GET", "/")
-        req.content_length = 1234
+        (req.content_length = 1234).should eq 1234_i64
         req.content_length.should eq 1234
         req.headers["Content-Length"].should eq "1234"
 
-        req.content_length = 0
+        (req.content_length = 0).should eq 0_i64
         req.content_length.should eq 0
         req.headers["Content-Length"].should eq "0"
 
-        req.content_length = UInt64::MAX
+        (req.content_length = UInt64::MAX).should eq UInt64::MAX
         req.content_length.should eq UInt64::MAX
         req.headers["Content-Length"].should eq UInt64::MAX.to_s
       end

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -116,8 +116,9 @@ class HTTP::Request
     @method == "HEAD"
   end
 
-  def content_length=(length : Int) : String
+  def content_length=(length : Int) : Int
     headers["Content-Length"] = length.to_s
+    length
   end
 
   def content_length


### PR DESCRIPTION
Setters should always return the input value, so that they behave like assignments (https://github.com/crystal-lang/crystal/issues/7707).