### PR TITLE
Add `Crystal::LRUCache`

### DIFF
--- a/spec/std/crystal/lru_cache_spec.cr
+++ b/spec/std/crystal/lru_cache_spec.cr
@@ -1,0 +1,48 @@
+require "spec"
+require "crystal/lru_cache"
+
+# LRUCache generic over K, V
+describe Crystal::LRUCache do
+  describe "#fetch" do
+    it "returns value for existing key and moves it to head" do
+      cache = Crystal::LRUCache(Int32, String).new(3)
+      cache.put(1, "a")
+      cache.put(2, "b")
+      cache.put(3, "c")
+      cache.fetch(2) { nil }.should eq("b") # key 2 should be most recently used
+      cache.put(4, "d")                     # should evict key 1
+      cache.fetch(1) { nil }.should be_nil, "Expected key 1 to have been evicted."
+      cache.fetch(2) { nil }.should eq("b")
+      cache.fetch(3) { nil }.should eq("c")
+      cache.fetch(4) { nil }.should eq("d")
+    end
+
+    it "yields and returns yielded value when key is missing" do
+      cache = Crystal::LRUCache(Int32, String).new(5)
+      cache.put(1, "one")
+      cache.fetch(2) { "default" }.should eq("default")
+      cache.fetch(2) { nil }.should be_nil
+    end
+  end
+
+  describe "#put" do
+    it "updates existing key and moves it to head" do
+      cache = Crystal::LRUCache(Int32, String).new(2)
+      cache.put(1, "first")
+      cache.put(2, "second")
+      cache.put(1, "updated") # key 1 should be most recently used
+      cache.put(3, "third")   # should evict key 2
+      cache.fetch(2) { nil }.should be_nil, "Expected key 2 to have been evicted"
+      cache.fetch(1) { nil }.should eq("updated")
+      cache.fetch(3) { nil }.should eq("third")
+    end
+  end
+
+  it "works correctly with capacity 1" do
+    cache = Crystal::LRUCache(Int32, String).new(1)
+    cache.put(1, "a")
+    cache.put(2, "b") # should evict 1
+    cache.fetch(1) { "not found" }.should eq("not found")
+    cache.fetch(2) { "not found" }.should eq("b")
+  end
+end

--- a/src/crystal/lru_cache.cr
+++ b/src/crystal/lru_cache.cr
@@ -1,0 +1,87 @@
+class Crystal::LRUCache(K, V)
+  private class Node(K, V)
+    property key : K
+    property value : V
+    property? prev : Node(K, V)?
+    property? next : Node(K, V)?
+
+    def initialize(@key : K, @value : V)
+    end
+  end
+
+  @hash : Hash(K, Node(K, V))
+  @head : Node(K, V)? # most recently used
+  @tail : Node(K, V)? # least recently used
+
+  def initialize(@capacity : Int32 = 1024)
+    @hash = Hash(K, Node(K, V)).new
+  end
+
+  def size : Int32
+    @hash.size
+  end
+
+  def fetch?(key : K) : V?
+    fetch(key) { nil }
+  end
+
+  def fetch(key : K, & : -> U) : V | U forall U
+    if node = @hash[key]?
+      move_to_head(node)
+      node.value
+    else
+      yield
+    end
+  end
+
+  def put(key : K, value : V) : Nil
+    if node = @hash[key]?
+      node.value = value
+      move_to_head(node)
+    elsif @hash.size < @capacity
+      # fill to capacity
+      node = Node.new(key, value)
+      add_to_head(node)
+      @tail ||= node
+      @hash[key] = node
+    else
+      # evict tail
+      node = @tail.not_nil!
+      @hash.delete(node.key)
+
+      # recycle node
+      node.key = key
+      node.value = value
+      @hash[key] = node
+      move_to_head(node)
+    end
+  end
+
+  private def add_to_head(node)
+    node.prev = nil
+    node.next = @head
+    if head = @head
+      head.prev = node
+    end
+    @head = node
+  end
+
+  private def move_to_head(node)
+    return if @head == node
+
+    # detach node
+    if prev = node.prev?
+      prev.next = node.next?
+    end
+    if next_ = node.next?
+      next_.prev = node.prev?
+    end
+
+    if node == @tail
+      # set new tail
+      @tail = node.prev?
+    end
+
+    add_to_head(node)
+  end
+end


### PR DESCRIPTION
Implements a LRU cache, akas least-recently-used cache.

The design is what's regularly used: a hashmap for fast accesses by key, and a linked-list of nodes to know the most recently used (head) and least recently used (tail) so we can quickly move a key to the head and evict the tail just as quickly.

It relies on individually allocated nodes. We could do better with the unordered hash from #16497 and a custom entry struct that would already have the prev/next properties. Yet, the total number of nodes is bounded to the maximum capacity of the cache, and the evicted node is recycled for the key. Once filled, it won't allocate anymore.

Kept internal for the time being.
Meant to optimize #17283.

_Assisted by gpt-oss._