### PR TITLE
Split MSVC CI third-party libraries onto own workflow

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -15,205 +15,22 @@ env:
   CI_LLVM_LDFLAGS: "psapi.lib shell32.lib ole32.lib uuid.lib advapi32.lib ws2_32.lib ntdll.lib"
 
 jobs:
-  x86_64-windows-libs:
-    runs-on: windows-2025-vs2026
-    steps:
-      - name: Disable CRLF line ending substitution
-        run: |
-          git config --global core.autocrlf false
-
-      - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-
-      - name: Download Crystal source
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Cache libraries
-        id: cache-libs
-        uses: actions/cache@v6
-        with:
-          path: | # openssl and llvm take much longer to build so they are cached separately
-            libs/pcre2-8.lib
-            libs/iconv.lib
-            libs/gc.lib
-            libs/ffi.lib
-            libs/z.lib
-            libs/mpir.lib
-            libs/yaml.lib
-            libs/xml2.lib
-            libs/libxml_VERSION
-          key: win-libs-${{ hashFiles('.github/workflows/win.yml', 'etc/win-ci/*.ps1') }}-msvc
-      - name: Set up Cygwin
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        uses: cygwin/cygwin-install-action@3f0a3f9f988f7e96b8c18098ae05eaec175f5b52 # v6
-        with:
-          packages: make
-          install-dir: C:\cygwin64
-          add-to-path: false
-      - name: Build libgc
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.12 -AtomicOpsVersion 7.10.0
-      - name: Build libpcre2
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.47
-      - name: Build libiconv
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version 1.19
-      - name: Build libffi
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.5.1
-      - name: Build zlib
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1
-      - name: Build mpir
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-mpir.ps1 -BuildTree deps\mpir
-      - name: Build libyaml
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version 0.2.5
-      - name: Build libxml2
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.15.3
-
-      - name: Cache OpenSSL
-        id: cache-openssl
-        uses: actions/cache@v6
-        with:
-          path: |
-            libs/crypto.lib
-            libs/ssl.lib
-            libs/openssl_VERSION
-          key: win-openssl-libs-3.4.1-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}-msvc
-      - name: Set up NASM
-        if: steps.cache-openssl.outputs.cache-hit != 'true'
-        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
-      - name: Build OpenSSL
-        if: steps.cache-openssl.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.5.0
-
-  x86_64-windows-dlls:
-    runs-on: windows-2025-vs2026
-    steps:
-      - name: Disable CRLF line ending substitution
-        run: |
-          git config --global core.autocrlf false
-
-      - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-
-      - name: Download Crystal source
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Cache libraries
-        id: cache-dlls
-        uses: actions/cache@v6
-        with:
-          path: | # openssl and llvm take much longer to build so they are cached separately
-            libs/pcre2-8-dynamic.lib
-            libs/iconv-dynamic.lib
-            libs/gc-dynamic.lib
-            libs/ffi-dynamic.lib
-            libs/z-dynamic.lib
-            libs/mpir-dynamic.lib
-            libs/yaml-dynamic.lib
-            libs/xml2-dynamic.lib
-            dlls/pcre2-8.dll
-            dlls/iconv-2.dll
-            dlls/gc.dll
-            dlls/libffi-8.dll
-            dlls/zlib1.dll
-            dlls/mpir.dll
-            dlls/yaml.dll
-            dlls/libxml2.dll
-          key: win-dlls-${{ hashFiles('.github/workflows/win.yml', 'etc/win-ci/*.ps1') }}-msvc
-      - name: Set up Cygwin
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        uses: cygwin/cygwin-install-action@3f0a3f9f988f7e96b8c18098ae05eaec175f5b52 # v6
-        with:
-          packages: make
-          install-dir: C:\cygwin64
-          add-to-path: false
-      - name: Build libgc
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.12 -AtomicOpsVersion 7.10.0 -Dynamic
-      - name: Build libpcre2
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.47 -Dynamic
-      - name: Build libiconv
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version 1.19 -Dynamic
-      - name: Build libffi
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.4.7 -Dynamic
-      - name: Build zlib
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1 -Dynamic
-      - name: Build mpir
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-mpir.ps1 -BuildTree deps\mpir -Dynamic
-      - name: Build libyaml
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version 0.2.5 -Dynamic
-      - name: Build libxml2
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.15.3 -Dynamic
-
-      - name: Cache OpenSSL
-        id: cache-openssl-dlls
-        uses: actions/cache@v6
-        with:
-          path: |
-            libs/crypto-dynamic.lib
-            libs/ssl-dynamic.lib
-            dlls/libcrypto-3-x64.dll
-            dlls/libssl-3-x64.dll
-          key: win-openssl-dlls-3.4.1-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}-msvc
-      - name: Set up NASM
-        if: steps.cache-openssl-dlls.outputs.cache-hit != 'true'
-        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
-      - name: Build OpenSSL
-        if: steps.cache-openssl-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.4.1 -Dynamic
-
-  x86_64-windows-llvm-dlls:
-    runs-on: windows-2025-vs2026
-    steps:
-      - name: Disable CRLF line ending substitution
-        run: |
-          git config --global core.autocrlf false
-
-      - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-
-      - name: Download Crystal source
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Cache LLVM
-        id: cache-llvm-dlls
-        uses: actions/cache@v6
-        with:
-          path: |
-            libs/llvm_VERSION
-            libs/llvm-dynamic.lib
-            dlls/LLVM-C.dll
-          key: llvm-dlls-${{ env.CI_LLVM_VERSION }}-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}-msvc
-      - name: Build LLVM
-        if: steps.cache-llvm-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-llvm.ps1 -BuildTree deps\llvm -Version ${{ env.CI_LLVM_VERSION }} -TargetsToBuild ${{ env.CI_LLVM_TARGETS }} -Dynamic
+  x86_64-windows-deps:
+    name: Build dependencies
+    uses: ./.github/workflows/win_build_libs.yml
+    with:
+      arch: x86_64
+      runs-on: windows-2025-vs2026
+      llvm_version: "20.1.7"
+      llvm_targets: "X86;AArch64"
 
   x86_64-windows-release:
-    needs: [x86_64-windows-libs, x86_64-windows-dlls, x86_64-windows-llvm-dlls]
+    needs: [x86_64-windows-deps]
     uses: ./.github/workflows/win_build_portable.yml
     with:
       release: true
       llvm_version: "20.1.7"
-      llvm_targets: "X86,AArch64"
+      llvm_targets: "X86;AArch64"
       llvm_ldflags: "psapi.lib shell32.lib ole32.lib uuid.lib advapi32.lib ws2_32.lib ntdll.lib"
 
   x86_64-windows-test:

--- a/.github/workflows/win_arm64.yml
+++ b/.github/workflows/win_arm64.yml
@@ -13,217 +13,23 @@ concurrency:
 
 env:
   SPEC_SPLIT_DOTS: 160
+  CI_SSL_VERSION: "3.5.0"
   CI_LLVM_VERSION: "22.1.8"
   CI_LLVM_TARGETS: "X86,AArch64"
   CI_LLVM_LDFLAGS: "psapi.lib shell32.lib ole32.lib uuid.lib advapi32.lib ws2_32.lib ntdll.lib"
 
 jobs:
-  aarch64-windows-libs:
-    runs-on: windows-11-vs2026-arm
-    steps:
-      - name: Disable CRLF line ending substitution
-        run: |
-          git config --global core.autocrlf false
-
-      - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-        with:
-          arch: arm64
-
-      - name: Download Crystal source
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Cache libraries
-        id: cache-libs
-        uses: actions/cache@v6
-        with:
-          path: | # openssl and llvm take much longer to build so they are cached separately
-            libs/pcre2-8.lib
-            libs/iconv.lib
-            libs/gc.lib
-            libs/ffi.lib
-            libs/z.lib
-            libs/mpir.lib
-            libs/yaml.lib
-            libs/xml2.lib
-            libs/libxml_VERSION
-          key: win-libs-msvc-aarch64-${{ hashFiles('.github/workflows/win_arm64.yml', 'etc/win-ci/*.ps1') }}
-      - name: Set up Cygwin
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        uses: cygwin/cygwin-install-action@3f0a3f9f988f7e96b8c18098ae05eaec175f5b52 # v6
-        with:
-          packages: make
-          install-dir: C:\cygwin64
-          add-to-path: false
-      - name: Build libgc
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.12 -AtomicOpsVersion 7.10.0
-      - name: Build libpcre2
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.47
-      - name: Build libiconv
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version 1.19
-      - name: Build libffi
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.5.1
-      - name: Build zlib
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1
-      - name: Build mpir
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-mpir.ps1 -BuildTree deps\mpir
-      - name: Build libyaml
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version 0.2.5
-      - name: Build libxml2
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.15.3
-
-      - name: Cache OpenSSL
-        id: cache-openssl
-        uses: actions/cache@v6
-        with:
-          path: |
-            libs/crypto.lib
-            libs/ssl.lib
-            libs/openssl_VERSION
-          key: win-openssl-libs-3.5.0-msvc-aarch64-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
-      - name: Set up NASM
-        if: steps.cache-openssl.outputs.cache-hit != 'true'
-        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
-      - name: Build OpenSSL
-        if: steps.cache-openssl.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.5.0 -UseClangCl
-
-  aarch64-windows-dlls:
-    runs-on: windows-11-vs2026-arm
-    steps:
-      - name: Disable CRLF line ending substitution
-        run: |
-          git config --global core.autocrlf false
-
-      - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-        with:
-          arch: arm64
-
-      - name: Download Crystal source
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Cache libraries
-        id: cache-dlls
-        uses: actions/cache@v6
-        with:
-          path: | # openssl and llvm take much longer to build so they are cached separately
-            libs/pcre2-8-dynamic.lib
-            libs/iconv-dynamic.lib
-            libs/gc-dynamic.lib
-            libs/ffi-dynamic.lib
-            libs/z-dynamic.lib
-            libs/mpir-dynamic.lib
-            libs/yaml-dynamic.lib
-            libs/xml2-dynamic.lib
-            dlls/pcre2-8.dll
-            dlls/iconv-2.dll
-            dlls/gc.dll
-            dlls/libffi-8.dll
-            dlls/zlib1.dll
-            dlls/mpir.dll
-            dlls/yaml.dll
-            dlls/libxml2.dll
-          key: win-dlls-msvc-aarch64-${{ hashFiles('.github/workflows/win_arm64.yml', 'etc/win-ci/*.ps1') }}
-      - name: Set up Cygwin
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        uses: cygwin/cygwin-install-action@3f0a3f9f988f7e96b8c18098ae05eaec175f5b52 # v6
-        with:
-          packages: make
-          install-dir: C:\cygwin64
-          add-to-path: false
-      - name: Build libgc
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.12 -AtomicOpsVersion 7.10.0 -Dynamic
-      - name: Build libpcre2
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.47 -Dynamic
-      - name: Build libiconv
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version 1.19 -Dynamic
-      - name: Build libffi
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.4.7 -Dynamic
-      - name: Build zlib
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1 -Dynamic
-      - name: Build mpir
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-mpir.ps1 -BuildTree deps\mpir -Dynamic
-      - name: Build libyaml
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version 0.2.5 -Dynamic
-      - name: Build libxml2
-        if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.15.3 -Dynamic
-
-      - name: Cache OpenSSL
-        id: cache-openssl-dlls
-        uses: actions/cache@v6
-        with:
-          path: |
-            libs/crypto-dynamic.lib
-            libs/ssl-dynamic.lib
-            dlls/libcrypto-3-arm64.dll
-            dlls/libssl-3-arm64.dll
-          key: win-openssl-dlls-3.5.0-msvc-aarch64-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
-      - name: Set up NASM
-        if: steps.cache-openssl-dlls.outputs.cache-hit != 'true'
-        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
-      - name: Build OpenSSL
-        if: steps.cache-openssl-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.5.0 -UseClangCl -Dynamic
-
-  aarch64-windows-llvm-dlls:
-    runs-on: windows-11-vs2026-arm
-    steps:
-      - name: Disable CRLF line ending substitution
-        run: |
-          git config --global core.autocrlf false
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.14'
-
-      - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-        with:
-          arch: arm64
-
-      - name: Download Crystal source
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Cache LLVM
-        id: cache-llvm-dlls
-        uses: actions/cache@v6
-        with:
-          path: |
-            libs/llvm_VERSION
-            libs/llvm-dynamic.lib
-            dlls/LLVM-C.dll
-          key: llvm-dlls-${{ env.CI_LLVM_VERSION }}-msvc-aarch64-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}
-
-      - name: Build LLVM
-        if: steps.cache-llvm-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-llvm.ps1 -BuildTree deps\llvm -Version ${{ env.CI_LLVM_VERSION }} -TargetsToBuild ${{ env.CI_LLVM_TARGETS }} -UseClangCl -Dynamic
+  aarch64-windows-deps:
+    name: Build dependencies
+    uses: ./.github/workflows/win_build_libs.yml
+    with:
+      arch: aarch64
+      runs-on: windows-11-vs2026-arm
+      llvm_version: "22.1.8"
+      llvm_targets: "X86;AArch64"
 
   aarch64-windows-release:
-    needs: [aarch64-windows-libs, aarch64-windows-dlls, aarch64-windows-llvm-dlls]
+    needs: [aarch64-windows-deps]
     runs-on: windows-11-vs2026-arm
     steps:
       - name: Disable CRLF line ending substitution
@@ -260,7 +66,7 @@ jobs:
             libs/yaml.lib
             libs/xml2.lib
             libs/libxml_VERSION
-          key: win-libs-msvc-aarch64-${{ hashFiles('.github/workflows/win_arm64.yml', 'etc/win-ci/*.ps1') }}
+          key: libs-aarch64-windows-msvc-${{ hashFiles('.github/workflows/win_build_libs.yml', 'etc/win-ci/*.ps1') }}
           fail-on-cache-miss: true
       - name: Restore OpenSSL
         uses: actions/cache/restore@v6
@@ -269,7 +75,7 @@ jobs:
             libs/crypto.lib
             libs/ssl.lib
             libs/openssl_VERSION
-          key: win-openssl-libs-3.5.0-msvc-aarch64-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
+          key: libs-openssl-${{ env.CI_SSL_VERSION }}-aarch64-windows-msvc-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
           fail-on-cache-miss: true
       - name: Restore DLLs
         uses: actions/cache/restore@v6
@@ -291,7 +97,7 @@ jobs:
             dlls/mpir.dll
             dlls/yaml.dll
             dlls/libxml2.dll
-          key: win-dlls-msvc-aarch64-${{ hashFiles('.github/workflows/win_arm64.yml', 'etc/win-ci/*.ps1') }}
+          key: dlls-aarch64-windows-msvc-${{ hashFiles('.github/workflows/win_build_libs.yml', 'etc/win-ci/*.ps1') }}
           fail-on-cache-miss: true
       - name: Restore OpenSSL DLLs
         uses: actions/cache/restore@v6
@@ -301,7 +107,7 @@ jobs:
             libs/ssl-dynamic.lib
             dlls/libcrypto-3-arm64.dll
             dlls/libssl-3-arm64.dll
-          key: win-openssl-dlls-3.5.0-msvc-aarch64-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
+          key: dlls-openssl-${{ env.CI_SSL_VERSION }}-aarch64-windows-msvc-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
           fail-on-cache-miss: true
       - name: Restore LLVM DLLs
         uses: actions/cache/restore@v6
@@ -310,7 +116,7 @@ jobs:
             libs/llvm_VERSION
             libs/llvm-dynamic.lib
             dlls/LLVM-C.dll
-          key: llvm-dlls-${{ env.CI_LLVM_VERSION }}-msvc-aarch64-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}
+          key: dlls-llvm-${{ env.CI_LLVM_VERSION }}-aarch64-windows-msvc-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}
           fail-on-cache-miss: true
 
       - name: Set up environment
@@ -345,6 +151,7 @@ jobs:
           cp libs/* crystal/lib/
           cp dlls/* crystal/
           cp README.md crystal/
+          cp LICENSE crystal/
 
       - name: Upload Crystal binaries
         uses: actions/upload-artifact@v7

--- a/.github/workflows/win_build_libs.yml
+++ b/.github/workflows/win_build_libs.yml
@@ -1,0 +1,251 @@
+name: Windows CI / Build Libraries
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      runs-on:
+        required: true
+        type: string
+      llvm_version:
+        required: true
+        type: string
+      llvm_targets:
+        required: true
+        type: string
+
+permissions: {}
+
+env:
+  CI_GC_VERSION: "8.2.12"
+  CI_ATOMIC_OPS_VERSION: "7.10.0"
+  CI_PCRE2_VERSION: "10.47"
+  CI_ICONV_VERSION: "1.19"
+  CI_FFI_VERSION: "3.5.1"
+  CI_Z_VERSION: "1.3.1"
+  CI_YAML_VERSION: "0.2.5"
+  CI_XML2_VERSION: "2.15.3"
+  CI_SSL_VERSION: "3.5.0"
+  CI_SSL_MAJOR: "3"
+  WIN_ARCH: ${{ inputs.arch == 'aarch64' && 'arm64' || 'x64' }}
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  windows-libs:
+    name: Static libraries
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Disable CRLF line ending substitution
+        run: |
+          git config --global core.autocrlf false
+
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          arch: ${{ env.WIN_ARCH }}
+
+      - name: Download Crystal source
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Cache libraries
+        id: cache-libs
+        uses: actions/cache@v6
+        with:
+          path: | # openssl and llvm take much longer to build so they are cached separately
+            libs/pcre2-8.lib
+            libs/iconv.lib
+            libs/gc.lib
+            libs/ffi.lib
+            libs/z.lib
+            libs/mpir.lib
+            libs/yaml.lib
+            libs/xml2.lib
+            libs/libxml_VERSION
+          key: libs-${{ inputs.arch }}-windows-msvc-${{ hashFiles('.github/workflows/win_build_libs.yml', 'etc/win-ci/*.ps1') }}
+
+      - name: Set up Cygwin
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        uses: cygwin/cygwin-install-action@3f0a3f9f988f7e96b8c18098ae05eaec175f5b52 # v6
+        with:
+          packages: make
+          install-dir: C:\cygwin64
+          add-to-path: false
+      - name: Build libgc
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version ${{ env.CI_GC_VERSION }} -AtomicOpsVersion ${{ env.CI_ATOMIC_OPS_VERSION }}
+      - name: Build libpcre2
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version ${{ env.CI_PCRE2_VERSION }}
+      - name: Build libiconv
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version ${{ env.CI_ICONV_VERSION }}
+      - name: Build libffi
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version ${{ env.CI_FFI_VERSION }}
+      - name: Build zlib
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version ${{ env.CI_Z_VERSION }}
+      - name: Build mpir
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-mpir.ps1 -BuildTree deps\mpir
+      - name: Build libyaml
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version ${{ env.CI_YAML_VERSION }}
+      - name: Build libxml2
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version ${{ env.CI_XML2_VERSION }}
+
+      - name: Cache OpenSSL
+        id: cache-openssl
+        uses: actions/cache@v6
+        with:
+          path: |
+            libs/crypto.lib
+            libs/ssl.lib
+            libs/openssl_VERSION
+          key: libs-openssl-${{ env.CI_SSL_VERSION }}-${{ inputs.arch }}-windows-msvc-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
+
+      - name: Set up NASM
+        if: steps.cache-openssl.outputs.cache-hit != 'true' && inputs.arch == 'x86_64'
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
+      - name: Build OpenSSL
+        if: steps.cache-openssl.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version ${{ env.CI_SSL_VERSION }} ${{ inputs.arch == 'aarch64' && '-UseClangCl' || '' }}
+
+  windows-dlls:
+    name: Dynamic libraries
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Disable CRLF line ending substitution
+        run: |
+          git config --global core.autocrlf false
+
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          arch: ${{ env.WIN_ARCH }}
+
+      - name: Download Crystal source
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Cache libraries
+        id: cache-dlls
+        uses: actions/cache@v6
+        with:
+          path: | # openssl and llvm take much longer to build so they are cached separately
+            libs/pcre2-8-dynamic.lib
+            libs/iconv-dynamic.lib
+            libs/gc-dynamic.lib
+            libs/ffi-dynamic.lib
+            libs/z-dynamic.lib
+            libs/mpir-dynamic.lib
+            libs/yaml-dynamic.lib
+            libs/xml2-dynamic.lib
+            dlls/pcre2-8.dll
+            dlls/iconv-2.dll
+            dlls/gc.dll
+            dlls/libffi-8.dll
+            dlls/zlib1.dll
+            dlls/mpir.dll
+            dlls/yaml.dll
+            dlls/libxml2.dll
+          key: dlls-${{ inputs.arch }}-windows-msvc-${{ hashFiles('.github/workflows/win_build_libs.yml', 'etc/win-ci/*.ps1') }}
+
+      - name: Set up Cygwin
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        uses: cygwin/cygwin-install-action@3f0a3f9f988f7e96b8c18098ae05eaec175f5b52 # v6
+        with:
+          packages: make
+          install-dir: C:\cygwin64
+          add-to-path: false
+      - name: Build libgc
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version ${{ env.CI_GC_VERSION }} -AtomicOpsVersion ${{ env.CI_ATOMIC_OPS_VERSION }} -Dynamic
+      - name: Build libpcre2
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version ${{ env.CI_PCRE2_VERSION }} -Dynamic
+      - name: Build libiconv
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version ${{ env.CI_ICONV_VERSION }} -Dynamic
+      - name: Build libffi
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version ${{ env.CI_FFI_VERSION }} -Dynamic
+      - name: Build zlib
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version ${{ env.CI_Z_VERSION }} -Dynamic
+      - name: Build mpir
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-mpir.ps1 -BuildTree deps\mpir -Dynamic
+      - name: Build libyaml
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version ${{ env.CI_YAML_VERSION }} -Dynamic
+      - name: Build libxml2
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version ${{ env.CI_XML2_VERSION }} -Dynamic
+
+      - name: Cache OpenSSL
+        id: cache-openssl-dlls
+        uses: actions/cache@v6
+        with:
+          path: |
+            libs/crypto-dynamic.lib
+            libs/ssl-dynamic.lib
+            dlls/libcrypto-${{ env.CI_SSL_MAJOR }}-${{ env.WIN_ARCH }}.dll
+            dlls/libssl-${{ env.CI_SSL_MAJOR }}-${{ env.WIN_ARCH }}.dll
+          key: dlls-openssl-${{ env.CI_SSL_VERSION }}-${{ inputs.arch }}-windows-msvc-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
+      - name: Set up NASM
+        if: steps.cache-openssl-dlls.outputs.cache-hit != 'true' && inputs.arch == 'x86_64'
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
+      - name: Build OpenSSL
+        if: steps.cache-openssl-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version ${{ env.CI_SSL_VERSION }} -Dynamic ${{ inputs.arch == 'aarch64' && '-UseClangCl' || '' }}
+
+  windows-llvm-dlls:
+    name: LLVM DLL
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Disable CRLF line ending substitution
+        run: |
+          git config --global core.autocrlf false
+
+      - name: Set up Python
+        if: inputs.arch == 'aarch64'
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          arch: ${{ env.WIN_ARCH }}
+
+      - name: Download Crystal source
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Cache LLVM
+        id: cache-llvm-dlls
+        uses: actions/cache@v6
+        with:
+          path: |
+            libs/llvm_VERSION
+            libs/llvm-dynamic.lib
+            dlls/LLVM-C.dll
+          key: dlls-llvm-${{ inputs.llvm_version }}-${{ inputs.arch }}-windows-msvc-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}
+
+      - name: Build LLVM
+        if: steps.cache-llvm-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-llvm.ps1 -BuildTree deps\llvm -Version "$env:INPUTS_LLVM_VERSION" -TargetsToBuild "$env:INPUTS_LLVM_TARGETS" -Dynamic ${{ inputs.arch == 'aarch64' && '-UseClangCl' || '' }}
+        env:
+          INPUTS_LLVM_VERSION: ${{ inputs.llvm_version }}
+          INPUTS_LLVM_TARGETS: ${{ inputs.llvm_targets }}

--- a/.github/workflows/win_build_portable.yml
+++ b/.github/workflows/win_build_portable.yml
@@ -18,6 +18,9 @@ on:
 
 permissions: {}
 
+env:
+  CI_SSL_VERSION: "3.5.0"
+
 jobs:
   build:
     runs-on: windows-2025-vs2026
@@ -53,7 +56,7 @@ jobs:
             libs/yaml.lib
             libs/xml2.lib
             libs/libxml_VERSION
-          key: win-libs-${{ hashFiles('.github/workflows/win.yml', 'etc/win-ci/*.ps1') }}-msvc
+          key: libs-x86_64-windows-msvc-${{ hashFiles('.github/workflows/win_build_libs.yml', 'etc/win-ci/*.ps1') }}
           fail-on-cache-miss: true
       - name: Restore OpenSSL
         uses: actions/cache/restore@v6
@@ -62,7 +65,7 @@ jobs:
             libs/crypto.lib
             libs/ssl.lib
             libs/openssl_VERSION
-          key: win-openssl-libs-3.4.1-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}-msvc
+          key: libs-openssl-${{ env.CI_SSL_VERSION }}-x86_64-windows-msvc-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
           fail-on-cache-miss: true
       - name: Restore DLLs
         uses: actions/cache/restore@v6
@@ -84,7 +87,7 @@ jobs:
             dlls/mpir.dll
             dlls/yaml.dll
             dlls/libxml2.dll
-          key: win-dlls-${{ hashFiles('.github/workflows/win.yml', 'etc/win-ci/*.ps1') }}-msvc
+          key: dlls-x86_64-windows-msvc-${{ hashFiles('.github/workflows/win_build_libs.yml', 'etc/win-ci/*.ps1') }}
           fail-on-cache-miss: true
       - name: Restore OpenSSL DLLs
         uses: actions/cache/restore@v6
@@ -94,7 +97,7 @@ jobs:
             libs/ssl-dynamic.lib
             dlls/libcrypto-3-x64.dll
             dlls/libssl-3-x64.dll
-          key: win-openssl-dlls-3.4.1-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}-msvc
+          key: dlls-openssl-${{ env.CI_SSL_VERSION }}-x86_64-windows-msvc-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
           fail-on-cache-miss: true
       - name: Restore LLVM DLLs
         uses: actions/cache/restore@v6
@@ -103,7 +106,7 @@ jobs:
             libs/llvm_VERSION
             libs/llvm-dynamic.lib
             dlls/LLVM-C.dll
-          key: llvm-dlls-${{ inputs.llvm_version }}-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}-msvc
+          key: dlls-llvm-${{ inputs.llvm_version }}-x86_64-windows-msvc-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}
           fail-on-cache-miss: true
 
       - name: Set up environment


### PR DESCRIPTION
This PR moves the build steps for the third-party dependencies of the MSVC CI into their own workflow file, aimed at deduplicating the x64 and ARM64 workflows. This separation is not strictly necessary as eventually a single matrix in `win.yml` would suffice, but it has the additional benefit of protecting the CI library caches from modifications to subsequent workflow steps.

It also upgrades the DLL versions of x64 libffi and OpenSSL to match their static library counterparts, since the DLLs have been falling behind for quite a while.