### PR TITLE
Fix `File#sendfile` should not move `#pos`

### DIFF
--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -227,6 +227,8 @@ describe Socket, tags: "network" do
         server.bind("127.0.0.1", port)
         server.listen
 
+        pos = file.pos
+
         spawn do
           client = server.not_nil!.accept
           client.sendfile(file, offset, count)
@@ -238,7 +240,7 @@ describe Socket, tags: "network" do
         socket.connect("localhost", port)
         string = socket.gets_to_end
 
-        file.pos.should eq 0
+        file.pos.should eq(pos), "`Socket#sendfile` should not affect `File#pos`, but it moved by #{file.pos - pos}"
 
         string
       ensure

--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -236,7 +236,11 @@ describe Socket, tags: "network" do
 
         socket = Socket.tcp(:inet)
         socket.connect("localhost", port)
-        socket.gets_to_end
+        string = socket.gets_to_end
+
+        file.pos.should eq 0
+
+        string
       ensure
         server.try(&.close)
         socket.try(&.close)

--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -273,7 +273,6 @@ describe Socket, tags: "network" do
 
         received = sendfile_test.call(file, 17, 11)
         received.should eq(" World\nHell")
-        file.pos.should eq(buf.size), "expected Socket#sendfile to not affect File#pos"
       end
     end
 
@@ -285,7 +284,6 @@ describe Socket, tags: "network" do
 
         received = sendfile_test.call(file, 3, 10)
         received.should eq("lo World\nH")
-        file.pos.should eq(buf.size), "expected Socket#sendfile to not affect File#pos"
       end
     end
   end

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -595,12 +595,18 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
     # can't send more than 2,147,483,646 bytes at once
     len = LibC::DWORD.new(count.clamp(..(Int32::MAX - 1)))
 
+    file_handle = LibC::HANDLE.new(fd)
+
+    # store the current file pointer because TransmitFile may advance the file
+    # pointer in some cases (e.g. offset == file.pos).
+    LibC.SetFilePointerEx(file_handle, 0, out original_pos, IO::Seek::Current)
+
     Crystal::System::IOCP::WSAOverlappedOperation.run(@iocp.handle, socket.fd) do |operation|
       operation.@overlapped.union.offset.offset = LibC::DWORD.new!(offset)
       operation.@overlapped.union.offset.offsetHigh = LibC::DWORD.new!(offset >> 32)
 
       ret = Crystal::System::Socket.transmit_file
-        .call(socket.fd, LibC::HANDLE.new(fd), len, LibC::DWORD.new(0), operation.to_unsafe, Pointer(Void).null, LibC::DWORD.new(flags))
+        .call(socket.fd, file_handle, len, LibC::DWORD.new(0), operation.to_unsafe, Pointer(Void).null, LibC::DWORD.new(flags))
       return len.to_i64 if ret == 1
 
       error = WinError.wsa_value
@@ -617,6 +623,8 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
           raise IO::Error.from_os_error("TransmitFile", error, target: socket)
         end
       end
+    ensure
+      LibC.SetFilePointerEx(file_handle, original_pos, nil, IO::Seek::Set)
     end.to_i64
   end
 


### PR DESCRIPTION
The API docs state:
> Doesn't directly read from *file* so the current file position (`IO#pos`) doesn't change.

This is currently broken on Windows.
