### PR TITLE
Override `Channel#tap(&)` to reinstate original behaviour

### DIFF
--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -898,4 +898,11 @@ describe "buffered" do
     ch = Channel(Int32).new(10)
     ch.pretty_inspect.should eq("#<Channel(Int32):0x#{ch.object_id.to_s(16)}>")
   end
+
+  it "#tap" do
+    ch = Channel(Nil).new
+    ch.tap do |c|
+      c.should be(ch)
+    end.should be(ch)
+  end
 end

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -318,6 +318,14 @@ class Channel(T)
     nil
   end
 
+  # Overrides `Iterator#tap` to restore the original implementation of `Object#tap`.
+  def tap(&) : self
+    # FIXME: This method is a workaround and should be removed once we have cleared the `Iterator` interface.
+
+    yield self
+    self
+  end
+
   # :nodoc:
   def send_select_action(value : T)
     SendAction.new(self, value)


### PR DESCRIPTION
`Iterator#tap(&)` overrides `Object#tap(&)` with an entirely different implementation.
With the recent introduction of `Iterator` as an ancestor of `Channel` (#16916), it inherited this overridden method. That's a breaking change for code that depends on `Channel#tap` having the behaviour of `Object#tap`.

This patch is an immediate fix for the regression bug.

Fixes #17295