### PR TITLE
Add syntax highlighting to compiler diagnostics

### DIFF
--- a/spec/compiler-cli/diagnostic_color_spec.cr
+++ b/spec/compiler-cli/diagnostic_color_spec.cr
@@ -1,0 +1,145 @@
+require "./spec_helper"
+require "json"
+
+private def capture_with_redirected_stdout_and_tty_stderr(args : Array(String), stdout_path = "/dev/null")
+  pending! "requires Linux util-linux script" unless {{ flag?(:linux) }}
+
+  script = Process.find_executable("script") || pending! "requires util-linux script"
+  version = Process.capture_result(script, "--version")
+  pending! "requires util-linux script" unless version.status.success? && version.output.includes?("util-linux")
+
+  command = "#{Process.quote_posix(args)} > #{Process.quote_posix(stdout_path)}"
+  Process.capture_result(
+    script,
+    "-q",
+    "-e",
+    "-c",
+    command,
+    "/dev/null",
+    env: {"TERM" => "xterm", "NO_COLOR" => nil}
+  )
+end
+
+describe "compiler diagnostic colors" do
+  it "keeps diagnostics captured over a non-TTY ANSI-free" do
+    result = Process.capture_result(
+      crystal,
+      "build",
+      "--no-codegen",
+      "--error-trace",
+      fixture_path("overload-error.cr")
+    )
+
+    result.should be_failure(1)
+    result.error.should contain("Overloads are:")
+    result.error.should_not contain("\e[")
+  end
+
+  it "propagates disabled color to semantic diagnostics" do
+    result = Process.capture_result(
+      crystal,
+      "build",
+      "--no-codegen",
+      fixture_path("semantic-color-hint-error.cr")
+    )
+
+    result.should be_failure(1)
+    result.error.should contain("modules cannot be instantiated")
+    result.error.should_not contain("\e[")
+  end
+
+  it "keeps stderr diagnostics colored when only stdout is redirected" do
+    result = capture_with_redirected_stdout_and_tty_stderr([
+      crystal,
+      "build",
+      "--no-codegen",
+      fixture_path("semantic-color-hint-error.cr"),
+    ])
+
+    result.should be_failure(1)
+    result.output.should contain("\e[36mWidget\e[39m")
+    result.output.should contain("\e[33;1m (modules cannot be instantiated)\e[39;22m")
+  end
+
+  it "forces --no-color when stderr is a TTY" do
+    result = capture_with_redirected_stdout_and_tty_stderr([
+      crystal,
+      "build",
+      "--no-codegen",
+      "--no-color",
+      fixture_path("semantic-color-hint-error.cr"),
+    ])
+
+    result.should be_failure(1)
+    result.output.should contain("modules cannot be instantiated")
+    result.output.should_not contain("\e[")
+  end
+
+  it "keeps redirected hierarchy output ANSI-free while stderr is a TTY" do
+    with_tempfile("hierarchy-output.txt") do |output_path|
+      result = capture_with_redirected_stdout_and_tty_stderr([
+        crystal,
+        "tool",
+        "hierarchy",
+        "-e",
+        "Widget",
+        fixture_path("hierarchy-color.cr"),
+      ], output_path)
+
+      result.should be_success
+      output = File.read(output_path)
+      output.should contain("Widget")
+      output.should_not contain("\e[")
+    end
+  end
+
+  it "propagates disabled color to macro_run diagnostics" do
+    result = Process.capture_result(
+      crystal,
+      "build",
+      "--no-codegen",
+      fixture_path("macro-run-semantic-color-hint-error.cr")
+    )
+
+    result.should be_failure(1)
+    result.error.should contain("modules cannot be instantiated")
+    result.error.should_not contain("\e[")
+  end
+
+  it "keeps JSON diagnostics ANSI-free and valid" do
+    result = Process.capture_result(
+      crystal,
+      "build",
+      "--no-codegen",
+      "--format",
+      "json",
+      fixture_path("overload-error.cr")
+    )
+
+    result.should be_failure(1)
+    parsed = JSON.parse(result.error).as_a
+    parsed.should_not be_empty
+    parsed.any? { |frame| frame["message"].as_s.includes?("Overloads are:") }.should be_true
+    parsed.each do |frame|
+      frame["message"].as_s.should_not contain("\e[")
+    end
+  end
+
+  it "forces JSON diagnostics ANSI-free when stderr is a TTY" do
+    result = capture_with_redirected_stdout_and_tty_stderr([
+      crystal,
+      "build",
+      "--no-codegen",
+      "--format",
+      "json",
+      fixture_path("semantic-color-hint-error.cr"),
+    ])
+
+    result.should be_failure(1)
+    parsed = JSON.parse(result.output).as_a
+    parsed.any? { |frame| frame["message"].as_s.includes?("modules cannot be instantiated") }.should be_true
+    parsed.each do |frame|
+      frame["message"].as_s.should_not contain("\e[")
+    end
+  end
+end

--- a/spec/compiler-cli/fixtures/hierarchy-color.cr
+++ b/spec/compiler-cli/fixtures/hierarchy-color.cr
@@ -1,0 +1,3 @@
+class Widget
+  @answer = 42
+end

--- a/spec/compiler-cli/fixtures/macro-run-semantic-color-hint-error.cr
+++ b/spec/compiler-cli/fixtures/macro-run-semantic-color-hint-error.cr
@@ -1,0 +1,1 @@
+{{ run("./semantic-color-hint-error.cr") }}

--- a/spec/compiler-cli/fixtures/overload-error.cr
+++ b/spec/compiler-cli/fixtures/overload-error.cr
@@ -1,0 +1,9 @@
+class Widget
+  def convert(value : Int32 | Float64)
+  end
+
+  def convert(value : String)
+  end
+end
+
+Widget.new.convert(true)

--- a/spec/compiler-cli/fixtures/semantic-color-hint-error.cr
+++ b/spec/compiler-cli/fixtures/semantic-color-hint-error.cr
@@ -1,0 +1,4 @@
+module Widget
+end
+
+Widget.allocate

--- a/spec/compiler/diagnostic_syntax_highlighter_spec.cr
+++ b/spec/compiler/diagnostic_syntax_highlighter_spec.cr
@@ -1,0 +1,381 @@
+require "../spec_helper"
+
+private ANSI_ESCAPE = /\e\[[0-9;]*m/
+
+private def strip_diagnostic_ansi(value : String) : String
+  value.gsub(ANSI_ESCAPE, "")
+end
+
+private def normalize_colored_line_markers(value : String) : String
+  value.gsub(/^ > (?=[1-3] \|)/m, "   ")
+end
+
+private def render_diagnostic(error : Crystal::CodeError, color : Bool) : String
+  error.color = color
+  error.to_s
+end
+
+private def capture_type_error(code : String, *, filename = nil) : Crystal::TypeException
+  expect_raises(Crystal::TypeException) do
+    semantic(code, filename: filename)
+  end
+end
+
+describe "compiler diagnostic syntax highlighting" do
+  it "fails open when diagnostic highlight spans are invalid" do
+    text = "answer = 42"
+    invalid_highlights = [
+      [Crystal::DiagnosticMessage::Highlight.new(-1, 1, :syntax)],
+      [Crystal::DiagnosticMessage::Highlight.new(0, -1, :syntax)],
+      [Crystal::DiagnosticMessage::Highlight.new(text.bytesize + 1, 0, :syntax)],
+      [Crystal::DiagnosticMessage::Highlight.new(text.bytesize - 1, 2, :syntax)],
+      [
+        Crystal::DiagnosticMessage::Highlight.new(5, 1, :syntax),
+        Crystal::DiagnosticMessage::Highlight.new(3, 1, :syntax),
+      ],
+      [
+        Crystal::DiagnosticMessage::Highlight.new(0, 6, :syntax),
+        Crystal::DiagnosticMessage::Highlight.new(5, 1, :syntax),
+      ],
+    ]
+
+    invalid_highlights.each do |highlights|
+      Crystal::DiagnosticMessage.new(text, highlights).render(true).should eq(text)
+    end
+  end
+
+  it "fails open when numbered source metadata is inconsistent" do
+    source = "answer = 42"
+    numbered_source = Crystal.with_line_numbers(source)
+    invalid_highlights = [
+      Crystal::DiagnosticMessage::Highlight.new(
+        0,
+        numbered_source.bytesize,
+        :blue,
+        numbered_source: source
+      ),
+      Crystal::DiagnosticMessage::Highlight.new(
+        0,
+        numbered_source.bytesize,
+        :syntax,
+        numbered_source: "different = 1"
+      ),
+    ]
+
+    invalid_highlights.each do |highlight|
+      Crystal::DiagnosticMessage.new(numbered_source, [highlight]).render(true).should eq(numbered_source)
+    end
+  end
+
+  it "renders non-syntax spans without changing plain text" do
+    text = "first second"
+    message = Crystal::DiagnosticMessage.new(text, [
+      Crystal::DiagnosticMessage::Highlight.new(0, 5, :blue),
+      Crystal::DiagnosticMessage::Highlight.new(6, 6, :yellow_bold),
+    ])
+
+    message.render(false).should eq(text)
+    message.render(true).should eq("\e[34mfirst\e[39m \e[33;1msecond\e[39;22m")
+  end
+
+  it "highlights raw source before adding line numbers" do
+    source = <<-CRYSTAL
+      text = <<-TEXT
+        hello
+      TEXT
+      answer = 42
+      CRYSTAL
+    numbered_source = Crystal.with_line_numbers(source)
+    highlight = Crystal::DiagnosticMessage::Highlight.new(
+      0,
+      numbered_source.bytesize,
+      :syntax,
+      numbered_source: source
+    )
+    message = Crystal::DiagnosticMessage.new(numbered_source, [highlight])
+
+    highlighted = message.render(true)
+
+    strip_diagnostic_ansi(highlighted).should eq(numbered_source)
+    highlighted.should contain("\e[93m  hello\e[39m")
+    highlighted.should contain("\e[93mTEXT\e[39m")
+    highlighted.should contain("answer \e[91m=\e[39m \e[35m42\e[39m")
+  end
+
+  it "highlights overload signatures without changing the raw message or JSON" do
+    error = capture_type_error <<-CRYSTAL
+      class Widget
+        def convert(value : Int32 | Float64)
+        end
+
+        def convert(value : String)
+        end
+      end
+
+      Widget.new.convert(true)
+      CRYSTAL
+
+    raw_message = error.message.should_not be_nil
+    raw_message.should contain("Widget#convert(value : Int32 | Float64)")
+    raw_message.should_not contain("\e[")
+    error.to_json.should_not contain("\e[")
+
+    plain = render_diagnostic(error, false)
+    highlighted = render_diagnostic(error, true)
+
+    strip_diagnostic_ansi(highlighted).should eq(plain)
+    highlighted.should contain("\e[36mWidget\e[39m#convert(value : \e[36mInt32\e[39m \e[91m|\e[39m \e[36mFloat64\e[39m)")
+    highlighted.should_not contain("\e[90m#convert")
+  end
+
+  it "highlights top-level overload signatures" do
+    error = capture_type_error <<-CRYSTAL
+      def diagnostic_convert(value : Int32)
+      end
+
+      def diagnostic_convert(value : String)
+      end
+
+      diagnostic_convert(true)
+      CRYSTAL
+
+    highlighted = render_diagnostic(error, true)
+
+    highlighted.should contain("diagnostic_convert(value : \e[36mInt32\e[39m)")
+    highlighted.should_not contain("\e[90m")
+  end
+
+  it "highlights ordinary source excerpts using the surrounding lexical context" do
+    source = <<-CRYSTAL
+      text = <<-TEXT
+        total: 42
+      TEXT
+      answer = 42 + "two"
+      CRYSTAL
+
+    with_tempfile("diagnostic-source.cr") do |path|
+      File.write(path, source)
+
+      error = Crystal::TypeException.new("incompatible values", 4, 1, path, 6)
+      plain = render_diagnostic(error, false)
+      highlighted = render_diagnostic(error, true)
+
+      strip_diagnostic_ansi(highlighted).should eq(plain)
+      highlighted.should contain("\e[35m42\e[39m")
+      highlighted.should contain(%(\e[93m"two"\e[39m))
+
+      contextual_error = Crystal::TypeException.new("incompatible values", 2, 3, path, 5)
+      contextual = render_diagnostic(contextual_error, true)
+
+      contextual.should contain("\e[93mtotal: 42\e[39m")
+      contextual.should_not contain("total: \e[35m42\e[39m")
+    end
+  end
+
+  it "highlights macro definitions and multiline expansions without coloring line numbers as source" do
+    definition = <<-CRYSTAL
+      macro broken
+        nil
+      end
+
+      broken
+      CRYSTAL
+    expansion = <<-CRYSTAL
+      text = <<-TEXT
+        hello
+      TEXT
+      answer = 42
+      CRYSTAL
+
+    with_tempfile("diagnostic-macro.cr") do |path|
+      File.write(path, definition)
+      a_macro = Crystal::Macro.new("broken").at(Crystal::Location.new(path, 1, 1)).as(Crystal::Macro)
+      virtual_file = Crystal::VirtualFile.new(a_macro, expansion, Crystal::Location.new(path, 5, 1))
+      error = Crystal::TypeException.new("bad expansion", 4, 10, virtual_file, 2)
+
+      plain = render_diagnostic(error, false)
+      highlighted = render_diagnostic(error, true)
+
+      normalize_colored_line_markers(strip_diagnostic_ansi(highlighted)).should eq(plain)
+      highlighted.should contain("Called macro defined in")
+      highlighted.should contain("Which expanded to:")
+      highlighted.should contain("\e[91mmacro\e[39m broken")
+      highlighted.should contain("answer \e[91m=\e[39m \e[35m42\e[39m")
+      highlighted.should contain("\e[93m  hello\e[39m")
+      highlighted.should contain("\e[93mTEXT\e[39m")
+      highlighted.should match(/\e\[39m\n(?:\e\[2m)? > 3 \| (?:\e\[22m)?\e\[93m/)
+    end
+  end
+
+  it "uses surrounding lexical context for macro definition locations" do
+    definition = <<-CRYSTAL
+      text = <<-TEXT
+        macro broken
+      TEXT
+      CRYSTAL
+
+    with_tempfile("diagnostic-contextual-macro.cr") do |path|
+      File.write(path, definition)
+      a_macro = Crystal::Macro.new("broken").at(Crystal::Location.new(path, 2, 3)).as(Crystal::Macro)
+      virtual_file = Crystal::VirtualFile.new(a_macro, "nil", Crystal::Location.new(path, 1, 1))
+      error = Crystal::TypeException.new("bad expansion", 1, 1, virtual_file, 1)
+
+      highlighted = render_diagnostic(error, true)
+
+      highlighted.should contain("\e[93mmacro broken\e[39m")
+      highlighted.should_not contain("\e[91mmacro\e[39m broken")
+    end
+  end
+
+  it "bounds highlighted macro expansions without losing multiline context" do
+    definition = <<-CRYSTAL
+      macro broken
+        nil
+      end
+
+      broken
+      CRYSTAL
+    expansion_lines = [
+      "text = <<-TEXT",
+      "  hello",
+      "  world",
+      "TEXT",
+    ]
+    expansion_lines.concat(Array.new(5_001, %(unterminated = ")))
+    expansion = expansion_lines.join('\n')
+
+    with_tempfile("diagnostic-bounded-macro.cr") do |path|
+      File.write(path, definition)
+      a_macro = Crystal::Macro.new("broken").at(Crystal::Location.new(path, 1, 1)).as(Crystal::Macro)
+      virtual_file = Crystal::VirtualFile.new(a_macro, expansion, Crystal::Location.new(path, 5, 1))
+      error = Crystal::TypeException.new("bad expansion", 3, 3, virtual_file, 2)
+      error.error_trace = false
+
+      highlighted = render_diagnostic(error, true)
+
+      highlighted.should contain("\e[93m  hello\e[39m")
+      highlighted.should contain("\e[93m  world\e[39m")
+      highlighted.should_not contain("unterminated")
+    end
+  end
+
+  it "highlights source excerpts in specialized method and nil traces" do
+    source = %(answer = 42 + "two"\n)
+
+    with_tempfile("diagnostic-trace.cr") do |path|
+      File.write(path, source)
+      node = parse(source, filename: path)
+      method_error = Crystal::MethodTraceException.new(nil, [node] of Crystal::ASTNode, nil, true)
+      nil_reason = Crystal::NilReason.new("@answer", :used_before_initialized, [node] of Crystal::ASTNode)
+      nil_error = Crystal::MethodTraceException.new(nil, [] of Crystal::ASTNode, nil_reason, true)
+
+      {method_error, nil_error}.each do |error|
+        plain = render_diagnostic(error, false)
+        highlighted = render_diagnostic(error, true)
+
+        strip_diagnostic_ansi(highlighted).should eq(plain)
+        highlighted.should contain("\e[35m42\e[39m")
+        highlighted.should contain(%(\e[93m"two"\e[39m))
+      end
+    end
+  end
+
+  it "uses surrounding lexical context in specialized method and nil traces" do
+    source = <<-CRYSTAL
+      text = <<-TEXT
+        total: 42
+      TEXT
+      CRYSTAL
+
+    with_tempfile("diagnostic-contextual-trace.cr") do |path|
+      File.write(path, source)
+      location = Crystal::Location.new(path, 2, 3)
+      node = Crystal::NumberLiteral.new("42").at(location).as(Crystal::ASTNode)
+      method_error = Crystal::MethodTraceException.new(nil, [node], nil, true)
+      nil_reason = Crystal::NilReason.new("@answer", :used_before_initialized, [node])
+      nil_error = Crystal::MethodTraceException.new(nil, [] of Crystal::ASTNode, nil_reason, true)
+
+      {method_error, nil_error}.each do |error|
+        highlighted = render_diagnostic(error, true)
+        highlighted.should contain("\e[93m  total: 42\e[39m")
+        highlighted.should_not contain("total: \e[35m42\e[39m")
+      end
+    end
+  end
+
+  it "highlights every ordinary source frame in a nested semantic trace" do
+    source = <<-CRYSTAL
+      def inner(value : Int32)
+      end
+
+      def outer(flag : Bool)
+        inner("bad")
+      end
+
+      outer(true)
+      CRYSTAL
+
+    with_tempfile("diagnostic-nested-trace.cr") do |path|
+      File.write(path, source)
+      error = capture_type_error(source, filename: path)
+      error.error_trace = true
+
+      plain = render_diagnostic(error, false)
+      highlighted = render_diagnostic(error, true)
+
+      strip_diagnostic_ansi(highlighted).should eq(plain)
+      highlighted.should contain(%(inner(\e[93m"bad"\e[39m)))
+      highlighted.should contain("outer(\e[35mtrue\e[39m)")
+    end
+  end
+
+  it "highlights syntax-error source excerpts" do
+    source = "answer = 42; end\n"
+
+    with_tempfile("diagnostic-syntax-error.cr") do |path|
+      File.write(path, source)
+      error = expect_raises(Crystal::SyntaxException) do
+        parse(source, filename: path)
+      end
+
+      plain = render_diagnostic(error, false)
+      highlighted = render_diagnostic(error, true)
+
+      strip_diagnostic_ansi(highlighted).should eq(plain)
+      highlighted.should contain("\e[35m42\e[39m")
+      highlighted.should contain("\e[91mend\e[39m")
+    end
+  end
+
+  it "highlights specialized method_missing expansions while keeping serialization ANSI-free" do
+    error = capture_type_error <<-CRYSTAL
+      class Widget
+        macro method_missing(call)
+          def other
+            text = <<-TEXT
+              hello
+            TEXT
+            42
+          end
+        end
+      end
+
+      Widget.new.missing
+      CRYSTAL
+
+    raw_message = error.message.should_not be_nil
+    raw_message.should contain("The method_missing macro expanded to:")
+    raw_message.should_not contain("\e[")
+    error.to_json.should_not contain("\e[")
+
+    plain = render_diagnostic(error, false)
+    highlighted = render_diagnostic(error, true)
+
+    strip_diagnostic_ansi(highlighted).should eq(plain)
+    highlighted.should contain("\e[91mdef\e[39m \e[92mother\e[39m")
+    highlighted.should match(/\e\[93m\s+hello\e\[39m/)
+    highlighted.should match(/\e\[93m\s*TEXT\e\[39m/)
+    highlighted.should contain("\e[35m42\e[39m")
+    highlighted.should contain("\e[91mend\e[39m")
+  end
+end

--- a/spec/std/colorize_spec.cr
+++ b/spec/std/colorize_spec.cr
@@ -32,6 +32,24 @@ private class ColorizeTTY < IO
 end
 
 describe "colorize" do
+  it ".reset with an explicit setting" do
+    enabled = IO::Memory.new
+    Colorize.reset(enabled, enabled: true)
+    enabled.to_s.should eq("\e[0m")
+
+    disabled = IO::Memory.new
+    Colorize.reset(disabled, enabled: false)
+    disabled.to_s.should be_empty
+  end
+
+  it "reports whether an object is enabled" do
+    object = Colorize.with.toggle(false)
+    object.enabled?.should be_false
+
+    object.toggle(true)
+    object.enabled?.should be_true
+  end
+
   it ".default_enabled?" do
     io = IO::Memory.new
     tty = ColorizeTTY.new

--- a/spec/std/crystal/syntax_highlighter/colorize_spec.cr
+++ b/spec/std/crystal/syntax_highlighter/colorize_spec.cr
@@ -25,6 +25,15 @@ private def it_highlights!(code, expected = code, *, file = __FILE__, line = __L
   end
 end
 
+private def assert_terminal_carriage_returns(rendered : Array(String), source : Array(String), *, file = __FILE__, line = __LINE__)
+  source.each_with_index do |source_line, index|
+    next unless source_line.ends_with?('\r')
+
+    rendered[index].should end_with("\r"), file: file, line: line
+    rendered[index].should_not contain("\r\e["), file: file, line: line
+  end
+end
+
 describe Crystal::SyntaxHighlighter::Colorize do
   describe ".highlight" do
     it_highlights %(foo = bar("baz\#{PI + 1}") # comment), %(foo \e[91m=\e[39m bar(\e[93m"baz\#{\e[39m\e[36mPI\e[39m \e[91m+\e[39m \e[35m1\e[39m\e[93m}"\e[39m) \e[90m# comment\e[39m)
@@ -172,5 +181,135 @@ describe Crystal::SyntaxHighlighter::Colorize do
     it_highlights! "\"foo"
     it_highlights! "%w[foo"
     it_highlights! "%i[foo"
+  end
+
+  describe ".highlight_lines!" do
+    it "highlights physical lines independently" do
+      source = ["foo = <<-TXT", "body", "TXT", "bar = 1"]
+      highlighted = Crystal::SyntaxHighlighter::Colorize.highlight_lines!(source)
+
+      highlighted.should eq([
+        "foo \e[91m=\e[39m \e[93m<<-TXT\e[39m",
+        "\e[93mbody\e[39m",
+        "\e[93mTXT\e[39m",
+        "bar \e[91m=\e[39m \e[35m1\e[39m",
+      ])
+      highlighted.map { |line| line.gsub(/\e\[[0-9;]*m/, "") }.should eq(source)
+
+      Crystal::SyntaxHighlighter::Colorize.highlight_lines!(%(answer = 42 + "two")).should eq([
+        %(answer \e[91m=\e[39m \e[35m42\e[39m \e[91m+\e[39m \e[93m"two"\e[39m),
+      ])
+    end
+
+    it "stops after an inclusive line boundary" do
+      source = ["foo = <<-TXT", "body", "still unterminated"]
+      highlighted = Crystal::SyntaxHighlighter::Colorize.highlight_lines!(source, 1)
+
+      highlighted.should eq([
+        "foo \e[91m=\e[39m \e[93m<<-TXT\e[39m",
+        "\e[93mbody\e[39m",
+        "still unterminated",
+      ])
+    end
+
+    it "does not let a malformed suffix suppress a bounded result" do
+      source = ["foo = 1", "bar = 2", "broken = \""]
+      highlighted = Crystal::SyntaxHighlighter::Colorize.highlight_lines!(source, 1)
+
+      highlighted[0].should contain("\e[35m1\e[39m")
+      highlighted[1].should contain("\e[35m2\e[39m")
+      highlighted[2].should eq(source[2])
+    end
+
+    it "isolates fallback after a lexer error" do
+      source = ["bad = \"unterminated", "answer = 42"]
+      highlighted = Crystal::SyntaxHighlighter::Colorize.highlight_lines!(source)
+
+      highlighted[1].should eq("answer \e[91m=\e[39m \e[35m42\e[39m")
+    end
+
+    it "preserves literal escapes and fully resets their terminal state" do
+      literal_escape = "\e[44;1m"
+      source = ["foo = <<-TXT", "body #{literal_escape}", "TXT"]
+      highlighted = Crystal::SyntaxHighlighter::Colorize.highlight_lines!(source)
+
+      highlighted[1].should contain(literal_escape)
+      highlighted[1].should end_with("\e[0m")
+      highlighted[2].should eq("\e[93mTXT\e[39m")
+
+      uncolored = Crystal::SyntaxHighlighter::Colorize.highlight_lines!(["plain#{literal_escape}", "following"])
+      uncolored[0].should contain(literal_escape)
+      uncolored[0].should end_with("\e[0m")
+      uncolored[1].should eq("following")
+    end
+
+    it "fully restores a base background and mode on each line" do
+      highlighted = Crystal::SyntaxHighlighter::Colorize.highlight_lines!(
+        "1\n2",
+        colorize: ::Colorize.with.on_blue.bold.toggle(true)
+      )
+
+      highlighted.should eq([
+        "\e[35;44;1m1\e[39;49;22m",
+        "\e[35;44;1m2\e[39;49;22m",
+      ])
+
+      Crystal::SyntaxHighlighter::Colorize.highlight_lines!(
+        %("x\#{foo}"),
+        colorize: ::Colorize.with.on_blue.bold.toggle(true)
+      ).should eq([
+        %(\e[93;44;1m"x\#{\e[39;49;22m\e[44;1mfoo\e[49;22m\e[93;44;1m}"\e[39;49;22m),
+      ])
+    end
+
+    it "does not emit escapes when its base style is disabled" do
+      highlighted = Crystal::SyntaxHighlighter::Colorize.highlight_lines!(
+        "1\n2",
+        colorize: ::Colorize.with.toggle(false)
+      )
+
+      highlighted.should eq(["1", "2"])
+    end
+
+    it "preserves CRLF bytes in normal and fallback rendering" do
+      sources = [
+        "answer = 1\r\nnext = 2\r\n",
+        "bad = \"unterminated\r\nanswer = 42\r",
+      ]
+
+      sources.each do |source|
+        source_lines = source.split('\n', remove_empty: false)
+
+        rendered = Crystal::SyntaxHighlighter::Colorize.highlight_lines!(source)
+        rendered.map { |line| line.gsub(/\e\[[0-9;]*m/, "") }.join('\n').should eq(source)
+        assert_terminal_carriage_returns(rendered, source_lines)
+
+        rendered = Crystal::SyntaxHighlighter::Colorize.highlight_lines!(source_lines)
+        rendered.map { |line| line.gsub(/\e\[[0-9;]*m/, "") }.should eq(source_lines)
+        assert_terminal_carriage_returns(rendered, source_lines)
+      end
+
+      literal_escape = "\e[44;1m"
+      rendered = Crystal::SyntaxHighlighter::Colorize.highlight_lines!([
+        "foo = <<-TXT\r",
+        "body #{literal_escape}\r",
+        "TXT\r",
+      ])
+      rendered[1].should end_with("\e[0m\r")
+      rendered[2].should eq("\e[93mTXT\e[39m\r")
+    end
+
+    it "restores a styled base after a literal escape on the previous line" do
+      literal_escape = "\e[44;1m"
+      highlighted = Crystal::SyntaxHighlighter::Colorize.highlight_lines!([
+        "foo = <<-TXT",
+        "body #{literal_escape}",
+        "TXT",
+      ], colorize: ::Colorize.with.red.on_blue.bold.toggle(true))
+
+      highlighted[1].should contain(literal_escape)
+      highlighted[1].should end_with("\e[0m")
+      highlighted[2].should eq("\e[93;44;1mTXT\e[39;49;22m")
+    end
   end
 end

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -168,8 +168,11 @@ module Colorize
   #   io << " default"
   # end
   # ```
-  def self.reset(io = STDOUT)
-    io << "\e[0m" if enabled?
+  #
+  # *enabled* can explicitly control whether the reset sequence is emitted.
+  # By default it follows `.enabled?`.
+  def self.reset(io = STDOUT, *, enabled : Bool = enabled?)
+    io << "\e[0m" if enabled
   end
 
   # Helper method to use colorize with `IO`.
@@ -440,6 +443,11 @@ struct Colorize::Object(T)
 
   def on(color : Symbol)
     back color
+  end
+
+  # Returns whether colors and text decoration are enabled on this object.
+  def enabled? : Bool
+    @enabled
   end
 
   # Enables or disables colors and text decoration on this object.

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -78,6 +78,7 @@ class Crystal::Command
 
   def initialize(@options : Array(String))
     @color = Colorize.default_enabled?(STDOUT, STDERR)
+    @diagnostic_color = Colorize.default_enabled?(STDERR)
     @error_trace = false
     @progress_tracker = ProgressTracker.new
   end
@@ -183,7 +184,11 @@ class Crystal::Command
   rescue ex : Crystal::CodeError
     report_warnings
 
-    ex.color = @color
+    ex.color = if compiler = @compiler
+                 compiler.color?
+               else
+                 @diagnostic_color
+               end
     ex.error_trace = @error_trace
     if @config.try(&.output_format) == "json"
       STDERR.puts ex.to_json
@@ -271,6 +276,7 @@ class Crystal::Command
   private def hierarchy
     config, result = compile_no_codegen "tool hierarchy", hierarchy: true, top_level: true
     @progress_tracker.stage("Tool (hierarchy)") do
+      result.program.color = @color
       Crystal.print_hierarchy result.program, STDOUT, config.hierarchy_exp, config.output_format
     end
   end
@@ -538,6 +544,7 @@ class Crystal::Command
 
       opts.on("--no-color", "Disable colored output") do
         @color = false
+        @diagnostic_color = false
         compiler.color = false
       end
 
@@ -663,6 +670,11 @@ class Crystal::Command
     unless output_format.in?(allowed_formats)
       abort! "You have input an invalid format: #{output_format}. Supported formats: #{allowed_formats.join(", ")}", :USAGE_ERROR
     end
+    if output_format == "json"
+      @color = false
+      @diagnostic_color = false
+      compiler.color = false
+    end
 
     abort! "maximum number of threads cannot be lower than 1", :USAGE_ERROR if compiler.n_threads < 1
 
@@ -733,6 +745,7 @@ class Crystal::Command
     end
     opts.on("--no-color", "Disable colored output") do
       @color = false
+      @diagnostic_color = false
       compiler.color = false
     end
     target_specific_opts(opts, compiler)
@@ -812,8 +825,8 @@ class Crystal::Command
 
   private def print_error(msg)
     # This is for the case where the main command is wrong
-    @color = false if ARGV.includes?("--no-color") || !Colorize.default_enabled?(STDOUT, STDERR)
-    Crystal.print_error(msg, @color)
+    @diagnostic_color = false if ARGV.includes?("--no-color") || !Colorize.default_enabled?(STDERR)
+    Crystal.print_error(msg, @diagnostic_color)
   end
 
   private def self.crystal_opts
@@ -865,6 +878,8 @@ class Crystal::Command
   end
 
   private def new_compiler
-    @compiler = Compiler.new
+    @compiler = Compiler.new.tap do |compiler|
+      compiler.color = @diagnostic_color
+    end
   end
 end

--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -86,6 +86,7 @@ class Crystal::Command
 
       opts.on("--no-color", "Disable colored output") do
         @color = false
+        @diagnostic_color = false
         compiler.color = false
       end
 

--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -43,6 +43,7 @@ class Crystal::Command
 
       opts.on("--no-color", "Disable colored output") do
         @color = false
+        @diagnostic_color = false
       end
 
       opts.on("--show-backtrace", "Show backtrace on a bug (used only for debugging)") do

--- a/src/compiler/crystal/command/repl.cr
+++ b/src/compiler/crystal/command/repl.cr
@@ -26,6 +26,7 @@ class Crystal::Command
 
       opts.on("--no-color", "Disable colored output") do
         @color = false
+        @diagnostic_color = false
         repl.program.color = false
       end
 

--- a/src/compiler/crystal/diagnostic/syntax_highlighter.cr
+++ b/src/compiler/crystal/diagnostic/syntax_highlighter.cr
@@ -1,0 +1,88 @@
+require "../exception"
+require "../../../crystal/syntax_highlighter/colorize"
+
+module Crystal::DiagnosticSyntaxHighlighter
+  def self.highlight(source : String, color : Bool) : String
+    return source unless color
+
+    Crystal::SyntaxHighlighter::Colorize.highlight!(source)
+  end
+
+  def self.highlight_lines(source : Array(String), color : Bool, *, through_line : Int32? = nil) : Array(String)
+    return source unless color
+
+    Crystal::SyntaxHighlighter::Colorize.highlight_lines!(source, through_line)
+  end
+
+  def self.highlight_line(source : Array(String), line_index : Int32, displayed_line : String, color : Bool) : String
+    return displayed_line unless color
+    return highlight(displayed_line, true) unless source[line_index]?
+
+    contextual_source = source.dup
+    contextual_source[line_index] = displayed_line
+    highlight_lines(contextual_source, true, through_line: line_index)[line_index]? || highlight(displayed_line, true)
+  end
+end
+
+class Crystal::DiagnosticMessage
+  def render(color : Bool) : String
+    return text unless color
+    return text unless valid_highlights?
+
+    String.build(text.bytesize) do |io|
+      cursor = 0
+      highlights.each do |highlight|
+        io << text.byte_slice(cursor, highlight.offset - cursor)
+        fragment = text.byte_slice(highlight.offset, highlight.size)
+
+        case highlight.kind
+        in .syntax?
+          if numbered_source = highlight.numbered_source
+            highlighted_source = DiagnosticSyntaxHighlighter.highlight_lines(numbered_source.lines, true)
+            io << Crystal.with_line_numbers(highlighted_source)
+          else
+            io << DiagnosticSyntaxHighlighter.highlight(fragment, true)
+          end
+        in .blue?
+          io << fragment.colorize.toggle(true).blue
+        in .yellow_bold?
+          io << fragment.colorize.toggle(true).yellow.bold
+        end
+
+        cursor = highlight.offset + highlight.size
+      end
+      io << text.byte_slice(cursor, text.bytesize - cursor)
+    end
+  end
+
+  private def valid_highlights? : Bool
+    cursor = 0
+    highlights.all? do |highlight|
+      offset = highlight.offset
+      size = highlight.size
+      valid = offset >= cursor && size >= 0 && offset <= text.bytesize && size <= text.bytesize - offset
+      if valid && (numbered_source = highlight.numbered_source)
+        valid = highlight.kind.syntax? &&
+                text.byte_slice(offset, size) == Crystal.with_line_numbers(numbered_source)
+      end
+      cursor = offset + size if valid
+      valid
+    end
+  end
+end
+
+class Crystal::CodeError
+  def syntax_highlight(source : String) : String
+    DiagnosticSyntaxHighlighter.highlight(source, color?)
+  end
+
+  def syntax_highlight_line(source : Array(String), line_index : Int32, displayed_line : String) : String
+    DiagnosticSyntaxHighlighter.highlight_line(source, line_index, displayed_line, color?)
+  end
+end
+
+module Crystal::ErrorFormat
+  private def syntax_highlight_lines(source : Array(String), *, through_line : Int32? = nil) : Array(String)
+    DiagnosticSyntaxHighlighter.highlight_lines(source, color?, through_line: through_line)
+  end
+end

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -3,6 +3,34 @@ require "./error"
 require "colorize"
 
 module Crystal
+  # A compiler error message with source fragments that should be highlighted
+  # when rendered with color. The stored text always remains ANSI-free.
+  class DiagnosticMessage
+    enum HighlightKind
+      Syntax
+      Blue
+      YellowBold
+    end
+
+    record Highlight,
+      offset : Int32,
+      size : Int32,
+      kind : HighlightKind,
+      numbered_source : String? = nil
+
+    getter text : String
+    getter highlights : Array(Highlight)
+
+    def initialize(@text : String, @highlights : Array(Highlight))
+    end
+
+    # Overridden in `diagnostic/syntax_highlighter` when the full compiler is
+    # loaded.
+    def render(color : Bool) : String
+      @text
+    end
+  end
+
   # Base class for all errors related to specific user code.
   abstract class CodeError < Error
     property? color = false
@@ -56,6 +84,17 @@ module Crystal
 
     def with_color
       Colorize.with.toggle(@color)
+    end
+
+    # Overridden in `diagnostic/syntax_highlighter` when the full compiler is
+    # loaded.
+    def syntax_highlight(source : String) : String
+      source
+    end
+
+    # :ditto:
+    def syntax_highlight_line(source : Array(String), line_index : Int32, displayed_line : String) : String
+      displayed_line
     end
 
     def replace_leading_tabs_with_spaces(line)
@@ -141,8 +180,10 @@ module Crystal
         # `column_number`.
         final_column_number = (column_number - space_delta).clamp(0..)
 
+        highlighted_line = syntax_highlight_line(lines, line_number - 1, lstripped_line.chomp)
+
         io << "\n\n"
-        io << colorize(decorator).dim << colorize(lstripped_line.chomp).bold
+        io << colorize(decorator).dim << colorize(highlighted_line).bold
         append_error_indicator(io, decorator.size, final_column_number, size || 0)
       end
     end
@@ -220,7 +261,8 @@ module Crystal
       if lines && line_number
         io << "\n\n"
         io << colorize(line_number_decorator(line_number)).dim
-        io << lines[line_number - 1].lstrip
+        displayed_line = lines[line_number - 1].lstrip.chomp
+        io << syntax_highlight_line(lines, line_number - 1, displayed_line)
       end
     end
 
@@ -228,13 +270,17 @@ module Crystal
       min_leading_white_space =
         source.min_of? { |line| leading_white_space(line) } || 0
 
-      if min_leading_white_space > 0
-        source = source.map do |line|
-          replace_leading_tabs_with_spaces(line).lchop(" " * min_leading_white_space)
-        end
-      end
+      source = remove_indentation(source, min_leading_white_space)
 
       {source, min_leading_white_space}
+    end
+
+    private def remove_indentation(source, size)
+      return source unless size > 0
+
+      source.map do |line|
+        replace_leading_tabs_with_spaces(line).lchop(" " * size)
+      end
     end
 
     private def leading_white_space(line)
@@ -251,17 +297,37 @@ module Crystal
       line_number = @line_number
       if @error_trace || !line_number
         source, _ = minimize_indentation(source.lines)
+        source = syntax_highlight_lines(source)
         io << Crystal.with_line_numbers(source, line_number, @color)
       else
-        to_index = line_number.clamp(0..source.lines.size)
+        # Materialize only the lines up to the reported one, plus one more so
+        # the highlighter sees its terminating newline; the rest of a large
+        # expansion is never displayed.
+        source_lines = [] of String
+        source.each_line do |line|
+          source_lines << line
+          break if source_lines.size > line_number
+        end
+        source = source_lines
+        to_index = line_number.clamp(0..source.size)
         from_index = {0, to_index - MACRO_LINES_TO_SHOW}.max
-        source_slice = source.lines[from_index...to_index]
+        source_slice = source[from_index...to_index]
         source_slice, spaces_removed = minimize_indentation(source_slice)
+        if @color
+          source = remove_indentation(source, spaces_removed)
+          source_slice = syntax_highlight_lines(source, through_line: to_index - 1)[from_index...to_index]
+        end
 
         io << Crystal.with_line_numbers(source_slice, line_number, @color, from_index + 1)
         offset = OFFSET_FROM_LINE_NUMBER_DECORATOR + line_number.to_s.size - spaces_removed
         append_error_indicator(io, offset, @column_number, @size)
       end
+    end
+
+    # Overridden in `diagnostic/syntax_highlighter` when the full compiler is
+    # loaded.
+    private def syntax_highlight_lines(source : Array(String), *, through_line : Int32? = nil) : Array(String)
+      source
     end
 
     def append_where_macro_expanded(io, filename : VirtualFile)

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -139,6 +139,8 @@ class Crystal::Program
   # compilation.
   def host_compiler
     @host_compiler ||= Compiler.new.tap do |host_compiler|
+      host_compiler.color = color?
+
       if compiler = self.compiler
         # When cross-compiling, the host compiler shouldn't copy the config for
         # the target compiler and use the system defaults instead.

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -132,11 +132,12 @@ class Crystal::Call
       owner_trace = inner_exception
     end
 
+    highlights = [] of DiagnosticMessage::Highlight
     message = String.build do |msg|
       no_overload_matches_message(msg, full_name(owner, def_name), defs, args, arg_types, named_args_types)
 
       msg << "Overloads are:"
-      append_matches(defs, arg_types, msg)
+      append_matches(defs, arg_types, msg, highlights)
 
       if matches
         cover = matches.cover
@@ -161,9 +162,13 @@ class Crystal::Call
               else
                 signature_args = missing_types.join ", "
               end
-              msg << "\n - #{full_name(owner, def_name)}(#{signature_args}"
-              msg << ", &block" if block
-              msg << ')'
+              signature = String.build do |signature|
+                signature << full_name(owner, def_name) << '(' << signature_args
+                signature << ", &block" if block
+                signature << ')'
+              end
+              msg << "\n - "
+              append_highlighted_signature(msg, highlights, signature, owner)
             end
 
             if missing.size > MAX_RENDERED_OVERLOADS
@@ -174,7 +179,7 @@ class Crystal::Call
       end
     end
 
-    raise message, owner_trace
+    raise DiagnosticMessage.new(message, highlights), owner_trace
   end
 
   private def check_block_mismatch(call_errors, owner, def_name)
@@ -380,16 +385,17 @@ class Crystal::Call
   end
 
   private def raise_no_overload_matches(node, defs, arg_types, inner_exception, &)
+    highlights = [] of DiagnosticMessage::Highlight
     error_message = String.build do |str|
       yield str
 
       str.puts
       str.puts
       str << "Overloads are:"
-      append_matches(defs, arg_types, str)
+      append_matches(defs, arg_types, str, highlights)
     end
 
-    node.raise(error_message, inner_exception)
+    node.raise(DiagnosticMessage.new(error_message, highlights), inner_exception)
   end
 
   record WrongNumberOfArguments
@@ -674,7 +680,8 @@ class Crystal::Call
     end
     all_arguments_sizes.uniq!.sort!
 
-    raise(String.build do |str|
+    highlights = [] of DiagnosticMessage::Highlight
+    error_message = String.build do |str|
       if single_message = single_def_error_message(defs, named_args_types)
         str << single_message
         str << '\n'
@@ -698,8 +705,9 @@ class Crystal::Call
         str << ")\n"
       end
       str << "Overloads are:"
-      append_matches(defs, arg_types, str)
-    end, inner: inner_exception)
+      append_matches(defs, arg_types, str, highlights)
+    end
+    raise DiagnosticMessage.new(error_message, highlights), inner: inner_exception
   end
 
   def convert_to_logical_operator(def_name)
@@ -795,16 +803,17 @@ class Crystal::Call
     end
   end
 
-  def append_matches(defs, arg_types, str, *, matched_def = nil, argument_name = nil)
+  def append_matches(defs, arg_types, str, highlights, *, matched_def = nil, argument_name = nil)
     defs.each do |a_def|
       next if a_def.abstract?
       str << "\n - "
-      append_def_full_name a_def.owner, a_def, arg_types, str
+      signature = def_full_name(a_def.owner, a_def, arg_types)
+      append_highlighted_signature(str, highlights, signature, a_def.owner)
       if defs.size > 1 && a_def.same?(matched_def)
-        str << colorize(" (trying this one)").blue
+        append_highlight(str, highlights, " (trying this one)", :blue)
       end
       if a_def.args.any? { |arg| arg.default_value && arg.external_name == argument_name }
-        str << colorize(" (did you mean this one?)").yellow.bold
+        append_highlight(str, highlights, " (did you mean this one?)", :yellow_bold)
       end
     end
   end
@@ -819,6 +828,32 @@ class Crystal::Call
 
   def append_def_full_name(owner, a_def, arg_types, str)
     Call.append_def_full_name(owner, a_def, arg_types, str)
+  end
+
+  private def append_highlighted_signature(str, highlights, signature, owner)
+    offset = str.bytesize
+    str << signature
+    append_signature_highlights(highlights, offset, signature, owner.to_s)
+  end
+
+  private def append_signature_highlights(highlights, offset, signature, receiver)
+    prefix = "#{receiver}#"
+    unless signature.starts_with?(prefix)
+      highlights << DiagnosticMessage::Highlight.new(offset, signature.bytesize, :syntax)
+      return
+    end
+
+    # `Type#method` is diagnostic notation, not Crystal syntax. Keep the `#`
+    # separator outside both fragments so it isn't parsed as a comment.
+    highlights << DiagnosticMessage::Highlight.new(offset, receiver.bytesize, :syntax)
+    method_offset = offset + prefix.bytesize
+    highlights << DiagnosticMessage::Highlight.new(method_offset, signature.bytesize - prefix.bytesize, :syntax)
+  end
+
+  private def append_highlight(str, highlights, value, kind : DiagnosticMessage::HighlightKind)
+    offset = str.bytesize
+    str << value
+    highlights << DiagnosticMessage::Highlight.new(offset, value.bytesize, kind)
   end
 
   def self.append_def_full_name(owner, a_def, arg_types, str)

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -10,6 +10,7 @@ module Crystal
     getter line_number : Int32?
     getter column_number : Int32
     getter size : Int32
+    @diagnostic_message : DiagnosticMessage? = nil
 
     def color=(@color : Bool)
       inner.try &.color=(color)
@@ -39,14 +40,19 @@ module Crystal
     def initialize(message, @line_number, @column_number : Int32, @filename, @size, @inner = nil)
       @error_trace = true
 
+      if message.is_a?(DiagnosticMessage)
+        @diagnostic_message = message
+        message = message.text
+      end
+
       super(message)
     end
 
-    def self.new(message : String)
+    def self.new(message : String | DiagnosticMessage)
       new message, nil, 0, nil, 0
     end
 
-    def self.new(message : String, location : Location)
+    def self.new(message : String | DiagnosticMessage, location : Location)
       ex = new message, location.line_number, location.column_number, location.filename, 0
       wrap_macro_expression(ex, location)
     end
@@ -99,9 +105,9 @@ module Crystal
       # If the inner exception has no location it means that they came from virtual nodes.
       # In that case, get the deepest error message and only show that.
       if inner && !inner.has_location?
-        msg = deepest_error_message.to_s
+        msg = deepest_rendered_error_message
       else
-        msg = @message.to_s
+        msg = rendered_message
       end
 
       error_message_lines = msg.lines
@@ -159,6 +165,22 @@ module Crystal
         inner.deepest_error_message
       else
         @message
+      end
+    end
+
+    private def rendered_message
+      @diagnostic_message.try(&.render(@color)) || @message.to_s
+    end
+
+    protected def deepest_rendered_error_message
+      if inner = @inner
+        if inner.is_a?(TypeException)
+          inner.deepest_rendered_error_message
+        else
+          inner.deepest_error_message.to_s
+        end
+      else
+        rendered_message
       end
     end
   end
@@ -265,7 +287,8 @@ module Crystal
       name_size = node.name_size
 
       io << "    "
-      io << replace_leading_tabs_with_spaces(line.chomp)
+      displayed_line = replace_leading_tabs_with_spaces(line.chomp)
+      io << syntax_highlight_line(lines, line_number - 1, displayed_line)
       io.puts
 
       return unless name_location

--- a/src/compiler/crystal/semantic/method_missing.cr
+++ b/src/compiler/crystal/semantic/method_missing.cr
@@ -117,14 +117,23 @@ module Crystal
     end
 
     private def raise_wrong_method_missing_expansion(msg, expanded_macro, original_call)
+      highlights = [] of DiagnosticMessage::Highlight
       str = String.build do |io|
         io << "wrong method_missing expansion\n\n"
         io << "The method_missing macro expanded to:\n\n"
-        io << Crystal.with_line_numbers(expanded_macro)
+        numbered_expansion = Crystal.with_line_numbers(expanded_macro)
+        expansion_offset = io.bytesize
+        io << numbered_expansion
+        highlights << DiagnosticMessage::Highlight.new(
+          expansion_offset,
+          numbered_expansion.bytesize,
+          :syntax,
+          numbered_source: expanded_macro
+        )
         io << "\n\n"
         io << "However, " << msg
       end
-      original_call.raise str
+      original_call.raise DiagnosticMessage.new(str, highlights)
     end
   end
 

--- a/src/compiler/crystal/tools/flags.cr
+++ b/src/compiler/crystal/tools/flags.cr
@@ -13,6 +13,7 @@ class Crystal::Command
 
       opts.on("--no-color", "Disable colored output") do
         @color = false
+        @diagnostic_color = false
       end
     end
 

--- a/src/compiler/requires.cr
+++ b/src/compiler/requires.cr
@@ -1,6 +1,7 @@
 require "./crystal/annotatable"
 require "./crystal/program"
 require "./crystal/*"
+require "./crystal/diagnostic/syntax_highlighter"
 require "./crystal/semantic/*"
 require "./crystal/macros/*"
 require "./crystal/codegen/*"

--- a/src/crystal/syntax_highlighter/colorize.cr
+++ b/src/crystal/syntax_highlighter/colorize.cr
@@ -11,7 +11,7 @@ require "../syntax_highlighter"
 #
 # code = %(foo = bar("baz\#{PI + 1}") # comment)
 # colorized = Crystal::SyntaxHighlighter::Colorize.highlight(code)
-# colorized # => "foo \e[91m=\e[0m bar(\e[93m\"baz\#{\e[0;36mPI\e[0;93m \e[0;91m+\e[0;93m \e[0;35m1\e[0;93m}\"\e[0m) \e[90m# comment\e[0m"
+# colorized # => "foo \e[91m=\e[39m bar(\e[93m\"baz\#{\e[39m\e[36mPI\e[39m \e[91m+\e[39m \e[35m1\e[39m\e[93m}\"\e[39m) \e[90m# comment\e[39m"
 # ```
 class Crystal::SyntaxHighlighter::Colorize < Crystal::SyntaxHighlighter
   # Highlights *code* and writes the result to *io*.
@@ -34,6 +34,31 @@ class Crystal::SyntaxHighlighter::Colorize < Crystal::SyntaxHighlighter
     highlight(code)
   rescue
     code
+  end
+
+  # Highlights each physical line in *source* independently.
+  #
+  # The returned array has the same number of elements as `source.split('\n',
+  # remove_empty: false)`. Every highlighted line restores the terminal style
+  # before its end, so a prefix such as a line number can be inserted before
+  # any line without inheriting a style.
+  #
+  # *through_line* is a zero-based, inclusive line index. When present,
+  # highlighting stops after that line and subsequent lines are returned
+  # unchanged.
+  #
+  # If lexing fails, completed lines remain highlighted and each remaining line
+  # in the requested range is highlighted in isolation.
+  def self.highlight_lines!(source : String, through_line : Int32? = nil, *, colorize : ::Colorize::Object(String) = ::Colorize.with.toggle(true)) : Array(String)
+    source_lines = source.split('\n', remove_empty: false)
+    render_lines(source_lines, through_line, colorize)
+  end
+
+  # :ditto:
+  def self.highlight_lines!(source : Array(String), through_line : Int32? = nil, *, colorize : ::Colorize::Object(String) = ::Colorize.with.toggle(true)) : Array(String)
+    return source.dup if source.empty?
+
+    render_lines(source, through_line, colorize)
   end
 
   # Creates a new instance of a Colorize syntax highlighter.
@@ -89,5 +114,186 @@ class Crystal::SyntaxHighlighter::Colorize < Crystal::SyntaxHighlighter
     else
       @io << token
     end
+  end
+
+  private class LineLimitReached < Exception
+  end
+
+  # Renders each highlighted physical line as its own string, carrying the
+  # active syntax style across line breaks.
+  private class LineRenderer < Crystal::SyntaxHighlighter::Colorize
+    getter lines = [] of String
+
+    @foreground : ::Colorize::Color?
+    @source_escape_on_line : Bool
+
+    def initialize(@through_line : Int32, colorize : ::Colorize::Object(String))
+      @segments = [] of {IO::Memory, ::Colorize::Color?}
+      @line_colorize = colorize
+      @foreground = nil
+      @source_escape_on_line = false
+      super(IO::Memory.new, colorize)
+    end
+
+    def finish : Nil
+      @lines << render_line
+    end
+
+    def render(type : TokenType, value : String)
+      foreground = colors[type]? || @foreground
+      parts = value.split('\n', remove_empty: false)
+
+      parts.each_with_index do |part, index|
+        @source_escape_on_line ||= part.includes?('\e')
+        append(part, foreground) unless part.empty?
+        finish_line if index < parts.size - 1
+      end
+    end
+
+    def render_delimiter(&)
+      with_foreground(colors[TokenType::STRING]) { yield }
+    end
+
+    def render_interpolation(&)
+      render :INTERPOLATION, "\#{"
+      with_foreground(::Colorize::ColorANSI::Default) { yield }
+      render :INTERPOLATION, "}"
+    end
+
+    def render_string_array(&)
+      with_foreground(colors[TokenType::STRING]) { yield }
+    end
+
+    private def append(value : String, foreground : ::Colorize::Color?) : Nil
+      if previous = @segments.last?
+        if previous[1] == foreground
+          previous[0] << value
+          return
+        end
+      end
+
+      segment = IO::Memory.new
+      segment << value
+      @segments << {segment, foreground}
+    end
+
+    private def render_line : String
+      String.build do |io|
+        @segments.each do |segment, foreground|
+          if foreground
+            @line_colorize.fore(foreground).surround(io) do
+              segment.to_s(io)
+            end
+          else
+            segment.to_s(io)
+          end
+        end
+
+        # Source escapes are opaque to the renderer. A full reset prevents one
+        # from leaking a background or mode into the following physical line.
+        ::Colorize.reset(io, enabled: true) if @source_escape_on_line
+      end
+    ensure
+      @segments.clear
+      @source_escape_on_line = false
+    end
+
+    private def finish_line : Nil
+      @lines << render_line
+      raise LineLimitReached.new if @lines.size > @through_line
+    end
+
+    private def with_foreground(foreground : ::Colorize::Color?, &)
+      previous_foreground = @foreground
+      @foreground = foreground
+      yield
+    ensure
+      @foreground = previous_foreground
+    end
+  end
+
+  private def self.render_lines(source_lines : Array(String), through_line : Int32?, colorize : ::Colorize::Object(String)) : Array(String)
+    result = source_lines.dup
+    return result unless colorize.enabled?
+
+    last_line = source_lines.size - 1
+    requested_line = through_line || last_line
+    return result if requested_line < 0
+
+    requested_line = last_line if requested_line > last_line
+    source = build_source(source_lines, requested_line, requested_line < last_line)
+    renderer = LineRenderer.new(requested_line, colorize)
+    failed = false
+
+    begin
+      renderer.highlight(source)
+      renderer.finish
+    rescue LineLimitReached
+      # The requested line was rendered; stopping early is not a failure.
+    rescue
+      failed = true
+    end
+
+    renderer.lines.each_with_index do |line, index|
+      result[index] = restore_terminal_carriage_returns(line, source_lines[index]) if index <= requested_line
+    end
+
+    if failed
+      renderer.lines.size.upto(requested_line) do |index|
+        result[index] = highlight_line!(source_lines[index], colorize)
+      end
+    end
+
+    result
+  end
+
+  private def self.highlight_line!(source : String, colorize : ::Colorize::Object(String)) : String
+    carriage_return_offset = terminal_carriage_return_offset(source)
+    code = source.byte_slice(0, carriage_return_offset)
+    highlighted = begin
+      String.build do |io|
+        new(io, colorize).highlight(code)
+      end
+    rescue
+      code
+    end
+
+    String.build do |io|
+      io << highlighted
+      ::Colorize.reset(io, enabled: true) if code.includes?('\e')
+      append_terminal_carriage_returns(io, source, carriage_return_offset)
+    end
+  end
+
+  private def self.build_source(source_lines : Array(String), last_line : Int32, append_newline : Bool) : String
+    String.build do |io|
+      0.upto(last_line) do |index|
+        line = source_lines[index]
+        io.write(line.to_slice[0, terminal_carriage_return_offset(line)])
+        io << '\n' if index < last_line || append_newline
+      end
+    end
+  end
+
+  private def self.restore_terminal_carriage_returns(rendered : String, source : String) : String
+    carriage_return_offset = terminal_carriage_return_offset(source)
+    return rendered if carriage_return_offset == source.bytesize
+
+    String.build(rendered.bytesize + source.bytesize - carriage_return_offset) do |io|
+      io << rendered
+      append_terminal_carriage_returns(io, source, carriage_return_offset)
+    end
+  end
+
+  private def self.append_terminal_carriage_returns(io : IO, source : String, offset : Int32) : Nil
+    io.write(source.to_slice[offset, source.bytesize - offset])
+  end
+
+  private def self.terminal_carriage_return_offset(source : String) : Int32
+    offset = source.bytesize
+    while offset > 0 && source.to_unsafe[offset - 1] === '\r'
+      offset -= 1
+    end
+    offset
   end
 end


### PR DESCRIPTION
Four-ish years ago I wrote this patch against Crystal to make it easier for me to visually parse exceptions, particularly where there were a large number of method signatures. I found it very, very useful. I, however, never got around to making a PR for Crystal itself of that work, though I mentioned it in a discussion of this functionality in issue #11755.

Fast forward to a few weeks ago, and Margaret apparently found the issue and poked me about it.

So I resurrected the old code, updated it for today's Crystal, and added thorough specs to cover the functionality. I have been running it locally for a couple of weeks. It looks like this:

<img width="840" height="224" alt="image" src="https://github.com/user-attachments/assets/65595bee-5b51-42df-9a07-61b4b977cf32" />

It colorizes source excerpts, overload signatures, and macro expansions in compiler error messages when diagnostics are written to a terminal, and it keys diagnostic color to stderr so ANSI escapes never leak into redirected, --no-color, or JSON output. So, it fixes #11755 