### PR TITLE
Optimize `String#split` when separator is an ASCII character

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -4380,7 +4380,6 @@ class String
 
   private def split_byte_index(separator : UInt8, limit = nil, *, remove_empty = false, &block : Int32, Int32 -> _) : Nil
     last_byte_offset = 0
-    single_byte_optimizable = single_byte_optimizable?
 
     scan_byte_index(separator) do |index|
       piece_bytesize = index - last_byte_offset

--- a/src/string.cr
+++ b/src/string.cr
@@ -4129,23 +4129,19 @@ class String
       return
     end
 
-    yielded = 0
-    byte_offset = 0
+    single_byte_optimizable = single_byte_optimizable?
 
-    reader = Char::Reader.new(self)
-    reader.each do |char|
-      if char == separator
-        piece_bytesize = reader.pos - byte_offset
-        yield String.new(to_unsafe + byte_offset, piece_bytesize) unless remove_empty && piece_bytesize == 0
-        yielded += 1
-        byte_offset = reader.pos + reader.current_char_width
-        break if limit && yielded + 1 == limit
+    if separator.ascii?
+      split_byte_index(separator.ord.to_u8!, limit, remove_empty: remove_empty) do |index, count|
+        piece_size = single_byte_optimizable ? count : 0
+        yield unsafe_byte_slice_string(index, count, piece_size)
+      end
+    else
+      split_byte_index(separator, limit, remove_empty: remove_empty) do |index, count|
+        piece_size = single_byte_optimizable ? count : 0
+        yield unsafe_byte_slice_string(index, count, piece_size)
       end
     end
-
-    piece_bytesize = bytesize - byte_offset
-    return if remove_empty && piece_bytesize == 0
-    yield String.new(to_unsafe + byte_offset, piece_bytesize)
   end
 
   # Makes an `Array` by splitting the string on *separator* (and removing instances of *separator*).
@@ -4218,11 +4214,23 @@ class String
       return
     end
 
+    separator_bytesize = separator.bytesize
+    single_byte_optimizable = single_byte_optimizable?
+
+    # separator is an ASCII character
+    if separator_bytesize == 1
+      byte = separator.to_unsafe[0]
+      if byte < 0x80
+        split_byte_index(byte, limit, remove_empty: remove_empty) do |index, count|
+          piece_size = single_byte_optimizable ? count : 0
+          yield unsafe_byte_slice_string(index, count, piece_size)
+        end
+        return
+      end
+    end
+
     yielded = 0
     byte_offset = 0
-    separator_bytesize = separator.bytesize
-
-    single_byte_optimizable = single_byte_optimizable?
 
     i = 0
     stop = bytesize - separator.bytesize + 1
@@ -4368,6 +4376,49 @@ class String
       yield self[yielded..-1]
       yielded += 1
     end
+  end
+
+  private def split_byte_index(separator : UInt8, limit = nil, *, remove_empty = false, &block : Int32, Int32 -> _) : Nil
+    last_byte_offset = 0
+    single_byte_optimizable = single_byte_optimizable?
+
+    scan_byte_index(separator) do |index|
+      piece_bytesize = index - last_byte_offset
+      unless remove_empty && piece_bytesize == 0
+        yield last_byte_offset, piece_bytesize
+      end
+
+      last_byte_offset = index + 1
+      if limit
+        limit -= 1
+        break if limit <= 1
+      end
+    end
+
+    piece_bytesize = bytesize - last_byte_offset
+    unless remove_empty && piece_bytesize == 0
+      yield last_byte_offset, piece_bytesize
+    end
+  end
+
+  private def split_byte_index(separator : Char, limit = nil, *, remove_empty = false, &block : Int32, Int32 -> _) : Nil
+    yielded = 0
+    byte_offset = 0
+
+    reader = Char::Reader.new(self)
+    reader.each do |char|
+      if char == separator
+        piece_bytesize = reader.pos - byte_offset
+        yield byte_offset, piece_bytesize unless remove_empty && piece_bytesize == 0
+        yielded += 1
+        byte_offset = reader.pos + reader.current_char_width
+        break if limit && yielded + 1 == limit
+      end
+    end
+
+    piece_bytesize = bytesize - byte_offset
+    return if remove_empty && piece_bytesize == 0
+    yield byte_offset, piece_bytesize
   end
 
   # Returns an array of the string split into lines.
@@ -4955,6 +5006,18 @@ class String
       matches << match
     end
     matches
+  end
+
+  # Yields the byte indices of all occurrences of *search* in the string.
+  # Used by the `Char` and `String` overloads of `#split`.
+  #
+  # *offset* must be within `0..bytesize` and *search* should be an ASCII code
+  # point.
+  private def scan_byte_index(search : UInt8, offset = 0, & : Int32 ->) : Nil
+    while index = byte_index(search, offset)
+      yield index
+      offset = index + 1
+    end
   end
 
   # Yields each character in the string to the block.


### PR DESCRIPTION
Directly loops over the bytes instead of using a `Char::Reader` if possible. Here is an example benchmark:

```crystal
require "benchmark"

class String
  def split_old(separator : Char, limit = nil, *, remove_empty = false, &block : String -> _)
    # existing implementation
  end
end

N = ENV["N"]?.try(&.split(',').map(&.to_i)) || [100] # number of parts
M = ENV["M"]?.try(&.split(',').map(&.to_i)) || [100] # bytesize per part

N.each do |n|
  M.each do |m|
    str = Array.new(n, "A" * m).join("-")
    x = ""

    Benchmark.ips do |b|
      b.report("old (M=#{m}, N=#{n})") do
        str.split_old('-') { |v| x = v }
      end

      b.report("new (M=#{m}, N=#{n})") do
        str.split('-') { |v| x = v }
      end
    end
  end
end
```

Before:

| µs | M=1 | M=3 | M=10 | M=30 | M=100 | M=300 | M=1000 |
|-|-|-|-|-|-|-|-|
| **N=1** | 0.01795 | 0.03121 | 0.04207 | 0.06639 | 0.17747 | 0.45472 | 1.33 |
| **N=3** | 0.06437 | 0.10493 | 0.11074 | 0.1892 | 0.53371 | 1.34 | 4.04 |
| **N=10** | 0.20666 | 0.36975 | 0.38249 | 0.64866 | 1.76 | 4.56 | 13.53 |
| **N=30** | 0.6221 | 1.05 | 1.18 | 1.91 | 5.3 | 13.81 | 41.7 |
| **N=100** | 2.09 | 3.6 | 3.8 | 6.53 | 18.85 | 46.23 | 151.27 |
| **N=300** | 7.01 | 12.43 | 13.76 | 21.11 | 60.17 | 121.46 | 297.94 |
| **N=1000** | 15.24 | 24.98 | 26.85 | 47.52 | 135.47 | 350.83 | 862.48 |

After:

| µs | M=1 | M=3 | M=10 | M=30 | M=100 | M=300 | M=1000 |
|-|-|-|-|-|-|-|-|
| **N=1** | 0.02045 | 0.03288 | 0.04336 | 0.05949 | 0.12421 | 0.30634 | 0.8613 |
| **N=3** | 0.07085 | 0.11048 | 0.11998 | 0.16179 | 0.37935 | 0.91362 | 2.77 |
| **N=10** | 0.24071 | 0.36782 | 0.37169 | 0.51972 | 1.27 | 3.13 | 8.8 |
| **N=30** | 0.68648 | 1.11 | 1.14 | 1.58 | 3.86 | 9.77 | 27.93 |
| **N=100** | 2.22 | 3.67 | 3.77 | 5.46 | 13.05 | 31.87 | 101.02 |
| **N=300** | 7.64 | 13.37 | 12.73 | 18.09 | 44.73 | 77.76 | 154.51 |
| **N=1000** | 16.72 | 25.94 | 26.54 | 36.54 | 84.59 | 210.64 | 391.68 |

The new implementation is faster by:

| Factor | M=1 | M=3 | M=10 | M=30 | M=100 | M=300 | M=1000 |
|-|-|-|-|-|-|-|-|
| **N=1** | 0.878× | 0.949× | 0.970× | 1.116× | 1.429× | 1.484× | 1.544× |
| **N=3** | 0.909× | 0.950× | 0.923× | 1.169× | 1.407× | 1.467× | 1.458× |
| **N=10** | 0.859× | 1.005× | 1.029× | 1.248× | 1.386× | 1.457× | 1.538× |
| **N=30** | 0.906× | 0.946× | 1.035× | 1.209× | 1.373× | 1.414× | 1.493× |
| **N=100** | 0.941× | 0.981× | 1.008× | 1.196× | 1.444× | 1.451× | 1.497× |
| **N=300** | 0.918× | 0.930× | 1.081× | 1.167× | 1.345× | 1.562× | 1.928× |
| **N=1000** | 0.911× | 0.963× | 1.012× | 1.300× | 1.601× | 1.666× | 2.202× |

Although the code itself does not depend on #17303, the benchmark was run with that patch applied as well, since most of the speed improvement occurs through `LibC.memchr` (i.e. `Bytes#index(UInt8)`).