### PR TITLE
Print compiler progress in TTY by default (plus `--no-progress` flag)

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -572,8 +572,8 @@ class Crystal::Command
         @progress_tracker.stats = true
       end
 
-      opts.on("-p", "--progress", "Enable progress output") do
-        @progress_tracker.progress = true
+      opts.on("-n", "--no-progress", "Disable progress output") do
+        @progress_tracker.progress = false
       end
 
       opts.on("-t", "--time", "Enable execution time output") do

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -572,7 +572,11 @@ class Crystal::Command
         @progress_tracker.stats = true
       end
 
-      opts.on("-n", "--no-progress", "Disable progress output") do
+      opts.on("-p", "--progress", "Enable progress output") do
+        @progress_tracker.progress = true
+      end
+
+      opts.on("--no-progress", "Disable progress output") do
         @progress_tracker.progress = false
       end
 

--- a/src/compiler/crystal/progress_tracker.cr
+++ b/src/compiler/crystal/progress_tracker.cr
@@ -5,7 +5,7 @@ module Crystal
     STAGE_PADDING = 34
 
     property? stats = false
-    property? progress = true
+    property? progress : Bool = STDOUT.tty?
 
     getter current_stage = 1
     getter current_stage_name : String?

--- a/src/compiler/crystal/progress_tracker.cr
+++ b/src/compiler/crystal/progress_tracker.cr
@@ -5,7 +5,7 @@ module Crystal
     STAGE_PADDING = 34
 
     property? stats = false
-    property? progress = false
+    property? progress = true
 
     getter current_stage = 1
     getter current_stage_name : String?


### PR DESCRIPTION
Addressing #16256 :
- Enabled progress indicator by default on build
- Changed `--progress` to `--no-progress` (used to disable the build progress indicator)

Currently `-n` is used as the short version for `--no-progress`. Maybe only the long option should be kept if `-n` is needed for something more relevant.