### PR TITLE
Close `HTTP::Client` on `IO::Error` during request

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -484,7 +484,7 @@ module HTTP
     end
 
     it "closes if an IO::Error occurs while the request is in-flight (non-yielding)" do
-      server = HTTP::Server.new {}
+      server = HTTP::Server.new { }
 
       client_for server do |client|
         client.get "/"
@@ -497,7 +497,7 @@ module HTTP
     end
 
     it "closes if an IO::Error occurs while the request is in-flight (yielding)" do
-      server = HTTP::Server.new {}
+      server = HTTP::Server.new { }
 
       client_for server do |client|
         client.get "/"

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -483,6 +483,36 @@ module HTTP
       end
     end
 
+    it "closes if an IO::Error occurs while the request is in-flight (non-yielding)" do
+      server = HTTP::Server.new do |context|
+        context.response.headers["Connection"] = "keep-alive"
+      end
+
+      client_for server do |client|
+        client.get "/", headers: HTTP::Headers{"Connection" => "keep-alive"}
+        client.@io.not_nil!.close
+        expect_raises(IO::Error) { client.get "/" }
+
+        client.@io.should be_nil
+        client.get "/"
+      end
+    end
+
+    it "closes if an IO::Error occurs while the request is in-flight (yielding)" do
+      server = HTTP::Server.new do |context|
+        context.response.headers["Connection"] = "keep-alive"
+      end
+
+      client_for server do |client|
+        client.get "/", headers: HTTP::Headers{"Connection" => "keep-alive"}
+        client.@io.not_nil!.close
+        expect_raises(IO::Error) { client.get "/" { } }
+
+        client.@io.should be_nil
+        client.get "/"
+      end
+    end
+
     it "doesn't read the body if request was HEAD" do
       resp_get = test_server("localhost", 0, 0.seconds) do |server|
         client = Client.new("localhost", server.local_address.port)

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -484,12 +484,10 @@ module HTTP
     end
 
     it "closes if an IO::Error occurs while the request is in-flight (non-yielding)" do
-      server = HTTP::Server.new do |context|
-        context.response.headers["Connection"] = "keep-alive"
-      end
+      server = HTTP::Server.new {}
 
       client_for server do |client|
-        client.get "/", headers: HTTP::Headers{"Connection" => "keep-alive"}
+        client.get "/"
         client.@io.not_nil!.close
         expect_raises(IO::Error) { client.get "/" }
 
@@ -499,12 +497,10 @@ module HTTP
     end
 
     it "closes if an IO::Error occurs while the request is in-flight (yielding)" do
-      server = HTTP::Server.new do |context|
-        context.response.headers["Connection"] = "keep-alive"
-      end
+      server = HTTP::Server.new {}
 
       client_for server do |client|
-        client.get "/", headers: HTTP::Headers{"Connection" => "keep-alive"}
+        client.get "/"
         client.@io.not_nil!.close
         expect_raises(IO::Error) { client.get "/" { } }
 

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -591,6 +591,9 @@ class HTTP::Client
     raise IO::EOFError.new("Unexpected end of http response") unless response
 
     handle_response(response)
+  rescue ex : IO::Error
+    close
+    raise ex
   end
 
   private def exec_internal_single(request, implicit_compression = false)
@@ -650,6 +653,9 @@ class HTTP::Client
     raise user_exception if user_exception
 
     raise IO::EOFError.new("Unexpected end of http response")
+  rescue ex : IO::Error
+    close
+    raise ex
   end
 
   # Determine whether we should retry a request after an IO error happened,


### PR DESCRIPTION
Previously, an `HTTP::Client` that encountered an `IO::Error` during a request would be stuck in an unusable state for the rest of its life. This commit closes the client in that case and restarts with a new TCP connection on the next request.

Fixes #17311