### PR TITLE
fix: distinguish Process chdir failures from missing executables

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -477,6 +477,24 @@ describe Process do
       value.should eq "#{parent}#{newline}"
     end
 
+    {% unless flag?(:win32) %}
+      it "raises if chdir doesn't exist" do
+        expect_raises(File::NotFoundError, "Error while changing directory: 'doesnotexist'") do
+          Process.run(*exit_code_command(0), chdir: "doesnotexist")
+        end
+      end
+
+      it "raises if command doesn't exist with a valid chdir" do
+        expect_raises(File::NotFoundError, "Error executing process: 'foobarbaz'") do
+          Process.run("foobarbaz", chdir: Dir.current)
+        end
+      end
+
+      it "runs a command with a valid chdir" do
+        Process.run(*exit_code_command(0), chdir: Dir.current).success?.should be_true
+      end
+    {% end %}
+
     pending_win32 "disallows passing arguments to nowhere" do
       expect_raises ArgumentError, /args.+@/ do
         Process.run("foo bar", {"baz"}, shell: true)

--- a/src/crystal/system/unix/spawn.cr
+++ b/src/crystal/system/unix/spawn.cr
@@ -2,6 +2,10 @@ require "c/signal"
 require "c/unistd"
 
 struct Crystal::System::Process
+  private SPAWN_ERROR_EXCEPTION = 0_u8
+  private SPAWN_ERROR_EXEC      = 1_u8
+  private SPAWN_ERROR_CHDIR     = 2_u8
+
   def self.spawn(prepared_args, shell, env, clear_env, input, output, error, chdir, &)
     r, w = FileDescriptor.system_pipe
 
@@ -11,13 +15,9 @@ struct Crystal::System::Process
     if !pid
       LibC.close(r)
       begin
-        self.try_replace(prepared_args, envp, input, output, error, chdir)
-        byte = 1_u8
-        errno = Errno.value.to_i32
-        FileDescriptor.write_fully(w, pointerof(byte))
-        FileDescriptor.write_fully(w, pointerof(errno))
+        self.try_replace(prepared_args, envp, input, output, error, chdir, w)
       rescue ex
-        byte = 0_u8
+        byte = SPAWN_ERROR_EXCEPTION
         message = ex.inspect_with_backtrace
         FileDescriptor.write_fully(w, pointerof(byte))
         FileDescriptor.write_fully(w, message.to_slice)
@@ -31,22 +31,27 @@ struct Crystal::System::Process
     reader_pipe = IO::FileDescriptor.new(r)
 
     begin
-      case reader_pipe.read_byte
+      case byte = reader_pipe.read_byte
       when nil
         # Pipe was closed, no error
-      when 0
+      when SPAWN_ERROR_EXCEPTION
         # Error message coming
         message = reader_pipe.gets_to_end
         raise RuntimeError.new("Error executing process: '#{prepared_args[0]}': #{message}")
-      when 1
+      when SPAWN_ERROR_EXEC, SPAWN_ERROR_CHDIR
         # Errno coming
         # can't use IO#read_bytes(Int32) because we skipped system/network
         # endianness check when writing the integer while read_bytes would;
         # we thus read it in the same as order as written
         buf = uninitialized StaticArray(UInt8, 4)
         reader_pipe.read_fully(buf.to_slice)
-        raise_exception_from_errno(prepared_args[0], Errno.new(buf.unsafe_as(Int32))) do |errno, command|
-          yield errno, command
+        errno = Errno.new(buf.unsafe_as(Int32))
+        if byte == SPAWN_ERROR_CHDIR
+          raise ::File::Error.from_os_error("Error while changing directory", errno, file: chdir.not_nil!)
+        else
+          raise_exception_from_errno(prepared_args[0], errno) do |errno, command|
+            yield errno, command
+          end
         end
       else
         raise RuntimeError.new("BUG: Invalid error response received from subprocess")
@@ -92,17 +97,25 @@ struct Crystal::System::Process
   # This method is similar to `.replace` (used for `Process.exec`) with some
   # differences because we're limited in what we can do in the pre-exec phase
   # between `fork` and `exec`.
-  private def self.try_replace(prepared_args, envp, input, output, error, chdir)
+  private def self.try_replace(prepared_args, envp, input, output, error, chdir, error_fd)
     reopen_io(input, ORIGINAL_STDIN)
     reopen_io(output, ORIGINAL_STDOUT)
     reopen_io(error, ORIGINAL_STDERR)
 
     if chdir
       if 0 != LibC.chdir(chdir)
+        write_spawn_error(error_fd, SPAWN_ERROR_CHDIR)
         return
       end
     end
 
     execvpe(*prepared_args, envp)
+    write_spawn_error(error_fd, SPAWN_ERROR_EXEC)
+  end
+
+  private def self.write_spawn_error(fd, spawn_error : UInt8)
+    errno = Errno.value.to_i32
+    FileDescriptor.write_fully(fd, pointerof(spawn_error))
+    FileDescriptor.write_fully(fd, pointerof(errno))
   end
 end


### PR DESCRIPTION
Extend the Unix spawn error response so the child identifies whether the reported errno came from changing directory or from executing the command. Decode that operation marker in the parent and raise the existing directory-change `File::Error` form with the `chdir` path when `LibC.chdir` failed, while preserving the existing callback and command-focused handling for `execvpe` failures. Keep the protocol private to `Crystal::System::Process` and avoid changing the public `Process` API.

On Unix, `Process.run` with a nonexistent `chdir` path raises `File::NotFoundError` as though the executable were missing. The forked child currently reports only an errno through the spawn error pipe, so identical `ENOENT` results from `chdir` and `execvpe` are indistinguishable in the parent. This produces an error naming the command instead of the invalid working directory. `Process.exec` and `Dir.cd` already expose the intended directory-specific `Error while changing directory` behavior.

Running an existing command with a nonexistent `chdir` path raises `File::NotFoundError` whose message identifies the directory and says `Error while changing directory`.
Running a nonexistent command with a valid `chdir` path still raises the existing command-focused `Error executing process` error, proving the two `ENOENT` sources remain distinct.
A normal command with a valid `chdir` continues to execute successfully, guarding the no-error branch of the spawn pipe protocol.

# Pull Request

Not applicable to this change.

Fixes #17313
