### PR TITLE
Do not use relative requires for the standard library

### DIFF
--- a/samples/compiler/formatter_example.cr
+++ b/samples/compiler/formatter_example.cr
@@ -1,8 +1,7 @@
 # This is a small sample on how to use a Crystal's
 # formatter programmatically.
 
-# Use `require "compiler/crystal/formatter"` in your programs
-require "../../src/compiler/crystal/formatter"
+require "compiler/crystal/formatter"
 
 source = "[ 1 , 2 , 3].map { | x |  x.to_s  }"
 result = Crystal.format(source)

--- a/samples/compiler/transformer_example.cr
+++ b/samples/compiler/transformer_example.cr
@@ -4,8 +4,7 @@
 # Here we transform all number literals with their char
 # equivalent using `chr`.
 
-# Use `require "compiler/crystal/syntax"` in your programs
-require "../../src/compiler/crystal/syntax"
+require "compiler/crystal/syntax"
 
 class Charify < Crystal::Transformer
   def transform(node : Crystal::NumberLiteral)

--- a/samples/compiler/visitor_example.cr
+++ b/samples/compiler/visitor_example.cr
@@ -3,8 +3,7 @@
 #
 # Here we count the number of NumberLiterals in a program.
 
-# Use `require "compiler/crystal/syntax"` in your programs
-require "../../src/compiler/crystal/syntax"
+require "compiler/crystal/syntax"
 
 class Counter < Crystal::Visitor
   getter count

--- a/scripts/generate_grapheme_break_specs.cr
+++ b/scripts/generate_grapheme_break_specs.cr
@@ -7,7 +7,7 @@
 # http://www.unicode.org/Public/x.y.z/ucd/auxiliary/GraphemeBreakTest.txt
 
 require "http/client"
-require "../src/compiler/crystal/formatter"
+require "compiler/crystal/formatter"
 
 UCD_ROOT = "http://www.unicode.org/Public/#{Unicode::VERSION}/ucd/"
 

--- a/scripts/generate_unicode_data.cr
+++ b/scripts/generate_unicode_data.cr
@@ -6,7 +6,7 @@
 
 require "http/client"
 require "ecr"
-require "../src/compiler/crystal/formatter"
+require "compiler/crystal/formatter"
 
 UCD_ROOT = "http://www.unicode.org/Public/#{Unicode::VERSION}/ucd/"
 

--- a/scripts/generate_windows_zone_names.cr
+++ b/scripts/generate_windows_zone_names.cr
@@ -6,7 +6,7 @@
 
 require "http/client"
 require "xml"
-require "../src/compiler/crystal/formatter"
+require "compiler/crystal/formatter"
 require "ecr"
 
 # CLDR-18479 Update CLDR data to TZDB 2025b. (#4593)

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "../../../src/compiler/crystal/formatter"
+require "compiler/crystal/formatter"
 
 private def assert_format(input, output = input, strict = false, flags = nil, file = __FILE__, line = __LINE__, focus = false)
   it "formats #{input.inspect}", file, line, focus: focus do

--- a/spec/std/crystal/pointer_pairing_heap_spec.cr
+++ b/spec/std/crystal/pointer_pairing_heap_spec.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "../../../src/crystal/pointer_pairing_heap"
+require "crystal/pointer_pairing_heap"
 
 private struct Node
   getter key : Int32

--- a/spec/std/openssl/digest_spec.cr
+++ b/spec/std/openssl/digest_spec.cr
@@ -1,6 +1,6 @@
 require "spec"
 require "../spec_helper"
-require "../../../src/openssl"
+require "openssl"
 
 describe OpenSSL::Digest do
   [

--- a/spec/support/syntax.cr
+++ b/spec/support/syntax.cr
@@ -1,5 +1,5 @@
 require "spec"
-require "../../src/compiler/crystal/syntax"
+require "compiler/crystal/syntax"
 
 include Crystal
 


### PR DESCRIPTION
There is no requirement that the specs and the scripts must use the repository's local version of the standard library at all times, that is the job of the `CRYSTAL_PATH` environment variable or the `bin/crystal` wrapper. Any external installation of Crystal should be capable of running most of those files, as long as no new features were added to the local standard library. For example, doing `crystal spec/std/openssl/digest_spec.cr` (not `bin/crystal`) would previously fail due to:

```
There was a problem expanding macro 'macro_2178713921360'

Code in C:\msys64\ucrt64\share\crystal\src\openssl\lib_crypto.cr:7:1

 7 | {% begin %}
     ^
Called macro defined in C:\msys64\ucrt64\share\crystal\src\openssl\lib_crypto.cr:7:1

 7 | {% begin %}

Which expanded to:

 >  9 | 
 > 10 |     
 > 11 |       LIBRESSL_VERSION = "0.0.0"
              ^---------------
Error: already initialized constant LibCrypto::LIBRESSL_VERSION
```

because both the local `lib_crypto.cr` and the global `lib_crypto.cr` are required.