### PR TITLE
Fix IPv6 address passed to `OpenSSL::SSL::Socket::Client.new` for OpenSSL 4.0

### DIFF
--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -840,7 +840,7 @@ class HTTP::Client
       if tls = @tls
         tcp_socket = io
         begin
-          io = OpenSSL::SSL::Socket::Client.new(tcp_socket, context: tls, sync_close: true, hostname: @host.rchop('.'))
+          io = OpenSSL::SSL::Socket::Client.new(tcp_socket, context: tls, sync_close: true, hostname: hostname.rchop('.'))
         rescue exc
           # don't leak the TCP socket when the SSL connection failed
           tcp_socket.close


### PR DESCRIPTION
When an `HTTP::Client` has an IPv6 address as its hostname, it currently passes something like `"[::1]"` as the `hostname` argument to `OpenSSL::SSL::Socket::Client.new`, which then uses it to configure an `X509_VERIFY_PARAM`:

https://github.com/crystal-lang/crystal/blob/f3c7a36d792e765dbc76021eaa0198c47bd0ddc2/src/openssl/ssl/socket.cr#L17-L26

Since `[::1]` with the square brackets is not a valid IP address, `LibCrypto.x509_verify_param_set1_host` is called. Previously OpenSSL would somehow accept it, but this is not a compliant DNS name either, according to [ITU-T Rec. X.509](https://www.itu.int/rec/T-REC-X.509) 10/2019, Section 9.3.2.1:

> the `dNSName` alternative shall be a fully qualified domain name (FQDN). The domain name shall be in the syntax as specified by section 2.3.1 of IETF RFC 5890 meaning that a domain name is a sequence of labels in the letters, digits, hyphen (LDH) format separated by dots.
>
> A label may be in one of two formats:
>
> a) All characters in the label are from the Basic Latin collection as defined by ISO/IEC 10646 (i.e., having code points in the ranges 002D, 0030-0039, 0041-005A and 0061-007A) and it does not start with "xn--". The maximum length is 63 octets.
>
> b) It is an A-label as defined in IETF RFC 5890, i.e., it starts with the "xn--" and is an U-label converted to valid ASCII characters as in item a) using the Punycode algorithm defined by IETF RFC 3492. The converted string shall be maximum 59 octets. To be valid, it shall be possible for an A-label to be converted to a valid U-label. The U-label is as also defined in IETF RFC 5890.

Since OpenSSL 4.0.0, specifically https://github.com/openssl/openssl/commit/f584ae959cbc36a297fefa6b677d830709dfc747, this host name is properly validated, thus the following test fails when `address.address` is `[::1]`:

https://github.com/crystal-lang/crystal/blob/f3c7a36d792e765dbc76021eaa0198c47bd0ddc2/spec/std/http/server/server_spec.cr#L381-L396

We already strip the square brackets when constructing the inner `TCPSocket`. This PR strips them for the `OpenSSL::SSL::Socket::Client` as well, so that `LibCrypto.x509_verify_param_set1_ip_asc` is actually called.