### PR TITLE
Fix validate mutations of `HTTP::Request#resource`

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -138,18 +138,20 @@ module HTTP
       end
 
       it "rejects invalid path" do
-        # BUG: The following specs all demonstrate incorrect behaviour.
         req = Request.new "GET", "/"
-        req.path = "foo\r"
-        req.path.should eq "foo\r"
-        req.path = "\r"
-        req.path.should eq "/"
+        expect_raises(ArgumentError, "Invalid HTTP resource") do
+          req.path = "foo\r"
+        end
+        expect_raises(ArgumentError, "Invalid HTTP resource") do
+          req.path = "\r"
+        end
       end
 
       it "accepts empty path" do
         req = Request.new "GET", "/foo"
         req.path = ""
         req.path.should eq "/"
+        req.resource.should eq "/"
       end
     end
 

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -352,6 +352,17 @@ module HTTP
           request.to_io(io)
         end
       end
+
+      it "validates resource after unobserved modification" do
+        request = Request.new "GET", "/"
+        request.uri.path = "foo bar"
+        io = IO::Memory.new
+        request.to_io(io)
+        io.to_s.should eq <<-HTTP
+          GET foo bar HTTP/1.1\r
+          \r\n
+          HTTP
+      end
     end
 
     describe ".from_io" do
@@ -691,6 +702,12 @@ module HTTP
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).as(Request)
         request.query.should eq("filter=hello&world=test")
       end
+
+      it "rejects invalid query" do
+        request = Request.new "GET", "/"
+        request.query = "foo bar"
+        request.resource.should eq("/?foo bar")
+      end
     end
 
     describe "#query=" do
@@ -903,6 +920,14 @@ module HTTP
 
         request.uri.path = "/some_other_route"
         request.resource.should eq("/some_other_route")
+      end
+    end
+
+    describe "#resource" do
+      it "validates after unobserved modification" do
+        request = Request.new "GET", "/"
+        request.uri.path = "foo bar"
+        request.resource.should eq "foo bar"
       end
     end
 

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -359,11 +359,9 @@ module HTTP
         request = Request.new "GET", "/"
         request.uri.path = "foo bar"
         io = IO::Memory.new
-        request.to_io(io)
-        io.to_s.should eq <<-HTTP
-          GET foo bar HTTP/1.1\r
-          \r\n
-          HTTP
+        expect_raises(ArgumentError, %(Invalid HTTP resource: "foo bar")) do
+          request.to_io(io)
+        end
       end
     end
 
@@ -930,7 +928,13 @@ module HTTP
       it "validates after unobserved modification" do
         request = Request.new "GET", "/"
         request.uri.path = "foo bar"
-        request.resource.should eq "foo bar"
+        expect_raises(ArgumentError, %(Invalid HTTP resource: "foo bar")) do
+          request.resource
+        end
+        request.uri.path = "\r"
+        expect_raises(ArgumentError, %(Invalid HTTP resource: "\\r")) do
+          request.resource
+        end
       end
     end
 

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -707,8 +707,9 @@ module HTTP
 
       it "rejects invalid query" do
         request = Request.new "GET", "/"
-        request.query = "foo bar"
-        request.resource.should eq("/?foo bar")
+        expect_raises(ArgumentError, "Invalid HTTP resource: \"/?foo bar\"") do
+          request.query = "foo bar"
+        end
       end
     end
 

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -936,6 +936,12 @@ module HTTP
           request.resource
         end
       end
+
+      it "always yields a valid resource for arbitrary query_params" do
+        request = Request.new "GET", "/"
+        request.query_params["x a"] = "foo\rbar"
+        request.resource.should eq "/?x+a=foo%0Dbar"
+      end
     end
 
     describe "#if_none_match" do

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -118,8 +118,13 @@ class HTTP::Request
   end
 
   def resource : String
+    uri = @uri
+    return @resource unless uri
+
     update_uri
-    @uri.try(&.request_target) || @resource
+    resource = uri.request_target
+    HTTP.validate_resource(resource)
+    resource
   end
 
   def keep_alive? : Bool

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -296,6 +296,7 @@ class HTTP::Request
 
   # Sets request's path component.
   def path=(path : String) : String
+    HTTP.validate_resource(path) unless path.empty?
     uri.path = path
   end
 

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -309,6 +309,7 @@ class HTTP::Request
   # Sets request's query component.
   def query=(value : String?) : String?
     uri.query = value
+    HTTP.validate_resource(uri.request_target)
     update_query_params
     value
   end


### PR DESCRIPTION
#17310 added validation for direct assignment to `HTTP::Request#resource` in the constructor.

But the resource can be modified by assigning `#path=` or `#query=` or mutating `#uri` or `#query_params`.

This patch ensures:
- The setters `#path=` and `#query=` directly validate parameter.
- `#resource` (and `#to_io`) validate the result in order to detect malformed values injected through mutating the `#uri` instance.
- Mutation through the `#query_params` instance should always be safe because the values are URL encoded.