### PR TITLE
docs(stdlib): document primitive numeric aliases in Int, Float, and Number

### DIFF
--- a/src/float.cr
+++ b/src/float.cr
@@ -37,6 +37,19 @@ require "./float/printer"
 #
 # See [`Float` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/floats.html) in the language reference.
 struct Float
+  # Union of all built-in primitive floating-point types.
+  #
+  # Useful for method parameter restrictions that accept any standard IEEE 754 floating-point type
+  # while excluding arbitrary-precision types like `BigFloat`.
+  #
+  # ```
+  # def float_primitive?(x : Float::Primitive)
+  #   true
+  # end
+  #
+  # float_primitive?(1.0_f32) # => true
+  # float_primitive?(2.5_f64) # => true
+  # ```
   alias Primitive = Float32 | Float64
 
   # Negates this value's sign.

--- a/src/int.cr
+++ b/src/int.cr
@@ -65,8 +65,50 @@
 #
 # See [`Integer` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/integers.html) in the language reference.
 struct Int
+  # Union of all built-in signed integer types.
+  #
+  # Commonly used in method parameter restrictions when an algorithm is only valid
+  # for signed integer numbers.
+  #
+  # ```
+  # def check_negative(x : Int::Signed)
+  #   x < 0
+  # end
+  #
+  # check_negative(-5_i32) # => true
+  # check_negative(10_i64) # => false
+  # ```
   alias Signed = Int8 | Int16 | Int32 | Int64 | Int128
+
+  # Union of all built-in unsigned integer types.
+  #
+  # Commonly used in method parameter restrictions when an algorithm is only valid
+  # for unsigned integer numbers.
+  #
+  # ```
+  # def format_hex(x : Int::Unsigned)
+  #   "0x#{x.to_s(16)}"
+  # end
+  #
+  # format_hex(255_u8)   # => "0xff"
+  # format_hex(1024_u16) # => "0x400"
+  # ```
   alias Unsigned = UInt8 | UInt16 | UInt32 | UInt64 | UInt128
+
+  # Union of all built-in primitive integer types (`Int::Signed | Int::Unsigned`).
+  #
+  # Useful for type restrictions where any primitive integer is accepted, excluding
+  # arbitrary-precision integers such as `BigInt`.
+  #
+  # ```
+  # def primitive_byte_size(x : Int::Primitive)
+  #   sizeof(typeof(x))
+  # end
+  #
+  # primitive_byte_size(1_i8)   # => 1
+  # primitive_byte_size(1_i32)  # => 4
+  # primitive_byte_size(1_u128) # => 16
+  # ```
   alias Primitive = Signed | Unsigned
 
   # Returns a `Char` that has the unicode codepoint of `self`.

--- a/src/number.cr
+++ b/src/number.cr
@@ -3,6 +3,19 @@ struct Number
   include Comparable(Number)
   include Steppable
 
+  # Union of all built-in primitive integer and floating-point types (`Int::Primitive | Float::Primitive`).
+  #
+  # Useful for method parameter restrictions that accept any built-in primitive number
+  # while excluding custom or arbitrary-precision types like `BigInt` and `BigFloat`.
+  #
+  # ```
+  # def numeric_primitive?(x : Number::Primitive)
+  #   true
+  # end
+  #
+  # numeric_primitive?(42)   # => true
+  # numeric_primitive?(3.14) # => true
+  # ```
   alias Primitive = Int::Primitive | Float::Primitive
 
   # Returns the value zero in the respective type.


### PR DESCRIPTION
### Description

This PR adds API docstrings and usage examples for the standard primitive numeric type aliases:
- `Int::Signed`, `Int::Unsigned`, and `Int::Primitive` in `src/int.cr`
- `Float::Primitive` in `src/float.cr`
- `Number::Primitive` in `src/number.cr`

These aliases are widely used across the Crystal standard library and shards for method parameter type restrictions, but previously lacked documentation in generated API docs.

### Motivation & Verification

Fixes #11864

Verified locally with:
- `bin/crystal tool format --check src/int.cr src/float.cr src/number.cr`
- `bin/crystal docs src/number.cr src/int.cr src/float.cr`
- `bin/crystal spec spec/std/int_spec.cr spec/std/float_spec.cr spec/std/number_spec.cr` (1361 examples, 0 failures)

Co-authored-by: Gemini <gemini@google.com>