### PR TITLE
Fix: correctly iterate ELF file sections

### DIFF
--- a/src/crystal/system/unix/elf.cr
+++ b/src/crystal/system/unix/elf.cr
@@ -16,6 +16,9 @@ class Crystal::System::ELF
     ENDIAN_LITTLE = 1
     ENDIAN_BIG    = 2
 
+    SHN_UNDEF  =      0
+    SHN_XINDEX = 0xffff
+
     struct Header
       ei_magic : UInt8[4]
       ei_class : UInt8
@@ -88,15 +91,32 @@ class Crystal::System::ELF
   end
 
   def section?(name : String, &)
-    sh = (@pointer + header.value.e_shoff).as(LibELF::SectionHeader*)
-    sh_name_offset = @pointer + (sh + header.value.e_shstrndx).value.sh_offset
+    sh_pointer = @pointer + header.value.e_shoff
 
-    header.value.e_shnum.times do |i|
-      if name_equal?(name, sh_name_offset + sh.value.sh_name)
+    e_shnum = header.value.e_shnum
+    e_shstrndx = header.value.e_shstrndx
+
+    if e_shnum == LibELF::SHN_UNDEF && e_shstrndx == LibELF::SHN_XINDEX
+      # extended sections: values don't fit in the ELF header, they're in
+      # section #0 (reserved)
+      sh_0 = sh_pointer.as(LibELF::SectionHeader*)
+      e_shnum = sh_0.value.sh_size
+      e_shstrndx = sh_0.value.sh_link
+    end
+
+    sh_str = (sh_pointer + e_shstrndx.to_u64 * header.value.e_shentsize).as(LibELF::SectionHeader*)
+    sh_names = @pointer + sh_str.value.sh_offset
+
+    e_shnum.times do |i|
+      sh = sh_pointer.as(LibELF::SectionHeader*)
+      sh_name = sh_names + sh.value.sh_name
+
+      if name_equal?(name, sh_name)
         bytes = Bytes.new(@pointer + sh.value.sh_offset, sh.value.sh_size)
         return yield bytes, sh.value.sh_offset.to_i64
       end
-      sh += 1
+
+      sh_pointer += header.value.e_shentsize
     end
   end
 


### PR DESCRIPTION
Use `e_shentsize` to iterate the section headers, not the `LibELF::SectionHeader` struct size. The ELF format allows section headers to have more data, for future versions for example.

The actual number of sections in an ELF file is limited. When `e_shnum=SHN_UNDEF` and `e_shstrndx=SHN_XINDEX` the actual number of sections and the index to the `.shstrtab` section header are in the reserved first section. See https://gabi.xinuos.com/elf/03-sheader.html#first-section-header-table-entry

With this patch we properly parse `many_sections.o.elf` from the pyelftools test suite, instead of segfaulting believing there are more sections (65535) than in reality (65287).