### PR TITLE
DEBUG: thread pool issues on macos (WIP)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,6 +11,9 @@ concurrency:
 env:
   SPEC_SPLIT_DOTS: 160
   CI_NIX_SHELL: true
+  CRYSTAL_OPTS: -Dtracing
+  CRYSTAL_TRACE: sched
+  CRYSTAL_TRACE_FILE: trace.log
 
 jobs:
   darwin-test:
@@ -54,6 +57,13 @@ jobs:
       - name: Test interpreter
         run: bin/ci with_build_env 'make interpreter_spec'
 
+      - name: Upload trace
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tracing
+          path: trace.log
+
   test-std:
     runs-on: macos-26
     strategy:
@@ -86,3 +96,10 @@ jobs:
 
       - name: Test
         run: bin/ci with_build_env 'CRYSTAL_WORKERS=${{ matrix.opts.workers || 1 }} make std_spec threads=1 FLAGS="${{ matrix.opts.flags || '' }}"'
+
+      - name: Upload trace
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: tracing
+          path: trace.log

--- a/src/crystal/system/thread_linked_list.cr
+++ b/src/crystal/system/thread_linked_list.cr
@@ -48,29 +48,63 @@ class Thread
       end
     end
 
+    # Removes a node from the tail of the list. The operation is thread-safe.
+    def pop? : T | Nil
+      @mutex.synchronize do
+        if node = @tail
+          unsafe_delete(node)
+          node
+        end
+      end
+    end
+
+    # Removes a node from the head of the list. The operation is thread-safe.
+    def shift? : T | Nil
+      @mutex.synchronize do
+        if node = @head
+          unsafe_delete(node)
+          node
+        end
+      end
+    end
+
     # Removes a node from the list. The operation is thread-safe.
     #
     # There are no guarantees that a node being deleted won't be iterated by
     # `#unsafe_each` until the method has returned.
     def delete(node : T) : Nil
       @mutex.synchronize do
-        previous = node.previous
-        _next = node.next
-
-        if previous
-          node.previous = nil
-          previous.next = _next
-        else
-          @head = _next
-        end
-
-        if _next
-          node.next = nil
-          _next.previous = previous
-        else
-          @tail = previous
-        end
+        unsafe_delete(node)
       end
+    end
+
+    # Identical to `#delete` but returns true if the node was unlinked from the
+    # list, and false otherwise.
+    def delete?(node : T) : Bool
+      @mutex.synchronize do
+        unsafe_delete(node)
+      end
+    end
+
+    private def unsafe_delete(node)
+      previous = node.previous
+      _next = node.next
+
+      if previous
+        node.previous = nil
+        previous.next = _next
+      else
+        @head = _next
+      end
+
+      if _next
+        node.next = nil
+        _next.previous = previous
+      else
+        @tail = previous
+      end
+
+      !previous.nil? || !_next.nil?
     end
   end
 end

--- a/src/fiber/execution_context/thread_pool.cr
+++ b/src/fiber/execution_context/thread_pool.cr
@@ -7,10 +7,10 @@ class Fiber
     # :nodoc:
     class ThreadPool
       # :nodoc:
-      struct Parked
-        include Crystal::PointerLinkedList::Node
-
+      class Parked
         getter thread : Thread
+        property next : Parked?
+        property previous : Parked?
 
         def initialize(@thread : Thread)
           @mutex = Thread::Mutex.new
@@ -32,27 +32,21 @@ class Fiber
         def wait(timeout, &)
           @condition_variable.wait(@mutex, timeout) { yield }
         end
-
-        def linked?
-          !@previous.null?
-        end
       end
 
       def initialize
-        @mutex = Thread::Mutex.new
-        @condition_variable = Thread::ConditionVariable.new
-        @pool = Crystal::PointerLinkedList(Parked).new
+        @pool = Thread::LinkedList(Parked).new
         @main_thread = Thread.current
       end
 
       protected def checkout(scheduler)
         thread =
-          if parked = @mutex.synchronize { @pool.shift? }
-            parked.value.synchronize do
-              attach(parked.value.thread, scheduler)
-              parked.value.wake
+          if parked = @pool.shift?
+            parked.synchronize do
+              attach(parked.thread, scheduler)
+              parked.wake
             end
-            parked.value.thread
+            parked.thread
           else
             # OPTIMIZE: start thread with minimum stack size
             Thread.new do |thread|
@@ -108,6 +102,7 @@ class Fiber
       # isolated context).
       private def enter_thread_loop(thread)
         parked = Parked.new(thread)
+
         parked.synchronize do
           loop do
             if scheduler = thread.scheduler?
@@ -127,9 +122,7 @@ class Fiber
               {% end %}
             end
 
-            @mutex.synchronize do
-              @pool.push pointerof(parked)
-            end
+            @pool.push(parked)
 
             if thread == @main_thread || {% flag?(:win32) && Crystal::EventLoop.has_constant?(:IOCP) %}
               # never shutdown the main thread: the main fiber is running on its
@@ -144,17 +137,8 @@ class Fiber
                 # reached timeout: try to shutdown thread, but another thread
                 # might dequeue from @pool in parallel: run checks to avoid any
                 # race condition:
-                if !thread.scheduler? && parked.linked?
-                  deleted = false
-
-                  @mutex.synchronize do
-                    if parked.linked?
-                      @pool.delete pointerof(parked)
-                      deleted = true
-                    end
-                  end
-
-                  if deleted
+                unless thread.scheduler?
+                  if @pool.delete?(parked)
                     # no attached scheduler and we removed ourselves from the
                     # pool: we can safely shutdown (no races)
                     Crystal.trace :sched, "thread.shutdown"
@@ -173,8 +157,19 @@ class Fiber
               class: exception.class.name,
               message: exception.message
 
-            Crystal.print_error_buffered("BUG: %s#enter_thread_loop crashed",
-              self.class.name, exception: exception)
+            Crystal.print_error_buffered("BUG: %s#enter_thread_loop crashed (main_thread=%d)",
+              self.class.name, thread == @main_thread ? 1 : 0, exception: exception)
+
+            # The crash should never happen and is complex to recover.
+            #
+            # The main thread can't terminate before its main fiber (it could be
+            # put to sleep, however), and another might be associating it to a
+            # scheduler, and we lack the means to reassociate the scheduler to
+            # another thread.
+            #
+            # For the time being, we panic.
+            Crystal::System.print_error "Fatal: can't recover from crashing thread loop (yet)."
+            LibC.exit(1)
           end
         end
       end


### PR DESCRIPTION
Changed `struct Parked` into a class so it's allocated in the GC HEAP. Now uses `Thread::LinkedList` instead of `Crystal::PointerLinkedList` that only works with pointers. I doubt that will fix the problem, but :shrug:

Immediately panics when an exception is raised instead of looping forever.

Enables sched tracing on macOS so we can download the history and maybe understand what the heck is happening.

See #17165.