### PR TITLE
CI: Limit `forward-compatibility` to last 8 releases

### DIFF
--- a/.github/workflows/forward-compatibility.yml
+++ b/.github/workflows/forward-compatibility.yml
@@ -34,7 +34,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crystal_bootstrap_version: [1.14.1, 1.15.1, 1.16.3, 1.17.1, 1.18.2, 1.19.2, 1.20.3]
+        # We ensure forward compatibility with the previous 8 releases.
+        # Releases n-1 and n-8 are already covered in`linux.yml#x86_64-gnu-test`,
+        # so we only need to test releases n-2 through n-7 here.
+        crystal_bootstrap_version: [1.15.1, 1.16.3, 1.17.1, 1.18.2, 1.19.2, 1.20.3]
         env: [{}]
     steps:
       - name: Download Crystal source

--- a/.github/workflows/forward-compatibility.yml
+++ b/.github/workflows/forward-compatibility.yml
@@ -34,30 +34,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crystal_bootstrap_version: [1.7.3, 1.8.2, 1.9.2, 1.10.1, 1.11.2, 1.12.2, 1.13.3, 1.14.1, 1.15.1, 1.16.3, 1.17.1, 1.18.2, 1.19.2, 1.20.3]
+        crystal_bootstrap_version: [1.13.3, 1.14.1, 1.15.1, 1.16.3, 1.17.1, 1.18.2, 1.19.2, 1.20.3]
         env: [{}]
-        include:
-          # libffi is only available starting from the 1.2.2 build images
-          # pcre2 is only available starting from the 1.7.0 build images
-          - crystal_bootstrap_version: 1.1.1
-            env:
-              FLAGS: -Dwithout_ffi
-              USE_PCRE1: true
-          - crystal_bootstrap_version: 1.2.2
-            env:
-              USE_PCRE1: true
-          - crystal_bootstrap_version: 1.3.2
-            env:
-              USE_PCRE1: true
-          - crystal_bootstrap_version: 1.4.1
-            env:
-              USE_PCRE1: true
-          - crystal_bootstrap_version: 1.5.1
-            env:
-              USE_PCRE1: true
-          - crystal_bootstrap_version: 1.6.2
-            env:
-              USE_PCRE1: true
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v7

--- a/.github/workflows/forward-compatibility.yml
+++ b/.github/workflows/forward-compatibility.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crystal_bootstrap_version: [1.13.3, 1.14.1, 1.15.1, 1.16.3, 1.17.1, 1.18.2, 1.19.2, 1.20.3]
+        crystal_bootstrap_version: [1.14.1, 1.15.1, 1.16.3, 1.17.1, 1.18.2, 1.19.2, 1.20.3]
         env: [{}]
     steps:
       - name: Download Crystal source

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
         include:
           - arch: x86_64
             env:
-              CRYSTAL_BOOTSTRAP_VERSION: 1.13.3
+              CRYSTAL_BOOTSTRAP_VERSION: 1.14.1
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v7

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,11 +34,7 @@ jobs:
         include:
           - arch: x86_64
             env:
-              CRYSTAL_BOOTSTRAP_VERSION: 1.0.0
-              # libffi is only available starting from the 1.2.2 build images
-              FLAGS: "-Dwithout_ffi"
-              # pcre2 is only available starting from the 1.7.0 build images
-              USE_PCRE1: true
+              CRYSTAL_BOOTSTRAP_VERSION: 1.13.3
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v7

--- a/scripts/release-update.sh
+++ b/scripts/release-update.sh
@@ -31,12 +31,19 @@ sed -i -E "s/version: .*/version: $(cat src/VERSION)/" shard.yml
 rm -f src/SOURCE_DATE_EPOCH
 
 ##
-## 2. Add previous release to forward compatibility tests (if new minor branch)
+## 2. Add previous release to forward compatibility tests and drop oldest
+##    release to keep restricted compatibility window (if new minor branch)
 ##
 
 previous_release=$(grep -o -P '(?<=\$\{CRYSTAL_BOOTSTRAP_VERSION:=).*(?=\})' bin/ci)
 if [ "${minor_branch}" != "${previous_release%.*}" ]; then
-  sed -i -E "/crystal_bootstrap_version:/ s/(, ${previous_release%.*}\.[0-9]*)?\]\$/, $previous_release]/" .github/workflows/forward-compatibility.yml
+  sed -i -E "/crystal_bootstrap_version:/ {
+      s/\[[0-9.]+, /[/
+      s/(, ${previous_release%.*}\.[0-9]*)?\]\$/, $previous_release]/
+    }" .github/workflows/forward-compatibility.yml
+
+  min_forward_compat_version=$(grep -o -P '(?<=crystal_bootstrap_version: \[)[0-9.]+(?=,)' .github/workflows/forward-compatibility.yml)
+  sed -i -E "s/CRYSTAL_BOOTSTRAP_VERSION: [0-9.]+/CRYSTAL_BOOTSTRAP_VERSION: ${min_forward_compat_version}/" .github/workflows/linux.yml
 fi
 
 ##

--- a/scripts/release-update.sh
+++ b/scripts/release-update.sh
@@ -37,13 +37,13 @@ rm -f src/SOURCE_DATE_EPOCH
 
 previous_release=$(grep -o -P '(?<=\$\{CRYSTAL_BOOTSTRAP_VERSION:=).*(?=\})' bin/ci)
 if [ "${minor_branch}" != "${previous_release%.*}" ]; then
+  min_forward_compat_version=$(grep -o -P '(?<=crystal_bootstrap_version: \[)[0-9.]+(?=,)' .github/workflows/forward-compatibility.yml)
+  sed -i -E "s/CRYSTAL_BOOTSTRAP_VERSION: [0-9.]+/CRYSTAL_BOOTSTRAP_VERSION: ${min_forward_compat_version}/" .github/workflows/linux.yml
+
   sed -i -E "/crystal_bootstrap_version:/ {
       s/\[[0-9.]+, /[/
       s/(, ${previous_release%.*}\.[0-9]*)?\]\$/, $previous_release]/
     }" .github/workflows/forward-compatibility.yml
-
-  min_forward_compat_version=$(grep -o -P '(?<=crystal_bootstrap_version: \[)[0-9.]+(?=,)' .github/workflows/forward-compatibility.yml)
-  sed -i -E "s/CRYSTAL_BOOTSTRAP_VERSION: [0-9.]+/CRYSTAL_BOOTSTRAP_VERSION: ${min_forward_compat_version}/" .github/workflows/linux.yml
 fi
 
 ##


### PR DESCRIPTION
Restrict forward compatibility CI to cover only the eight most recent releases.

Implements https://github.com/crystal-lang/rfcs/pull/30

Closes #12937

