### PR TITLE
Add `IO::FileDescriptor#exit_on_broken_pipe`

### DIFF
--- a/.github/workflows/interpreter.yml
+++ b/.github/workflows/interpreter.yml
@@ -38,12 +38,16 @@ jobs:
       - name: Build compiler
         run: make interpreter=1 release=1
 
+      - name: Build process-utils
+        run: make .build/crystal-pu
+
       - name: Upload compiler artifact
         uses: actions/upload-artifact@v7
         with:
           name: crystal-interpreter
           path: |
             .build/crystal
+            .build/crystal-pu
 
   test-interpreter-std_spec:
     needs: build-interpreter
@@ -66,8 +70,8 @@ jobs:
           name: crystal-interpreter
           path: .build/
 
-      - name: Mark downloaded compiler as executable
-        run: chmod +x .build/crystal
+      - name: Mark downloaded files as executable
+        run: chmod +x .build/crystal .build/crystal-pu
 
       - name: Run std_spec with interpreter
         run: SPEC_SPLIT="${{ matrix.part }}%4" bin/crystal i spec/std_spec.cr -- --junit_output .junit/interpreter-std_spec.${{ matrix.part }}.xml

--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -318,3 +318,38 @@ end
     {% end %}
   end
 {% end %}
+
+require "../support/process-utils"
+
+describe "SIGPIPE emulation" do
+  it "exits cleanly when stdout is closed" do
+    IO.pipe do |reader, writer|
+      reader.close
+      result = Process.capture_result(ProcessUtils::EXE, "pu", "echo", "foobar", output: writer)
+      result.output.should eq ""
+      result.error.should contain "Unhandled exception: write"
+      result.error.should contain "Broken pipe (IO::Error)"
+      result.status.should eq Process::Status[1]
+    end
+  end
+
+  it "exits cleanly when stderr is closed" do
+    IO.pipe do |reader, writer|
+      reader.close
+      result = Process.capture_result(ProcessUtils::EXE, "pu", "echo", "--stderr", "foobar", error: writer)
+      result.output.should eq ""
+      result.error.should eq ""
+      result.status.should eq Process::Status[1]
+    end
+  end
+
+  it "exits cleanly when stdin is closed" do
+    IO.pipe do |reader, writer|
+      writer.close
+      result = Process.capture_result(ProcessUtils::EXE, "pu", "cat", input: reader)
+      result.output.should eq ""
+      result.error.should eq ""
+      result.status.success?.should be_true
+    end
+  end
+end

--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -54,12 +54,12 @@ describe "exit" do
     status.exit_code.should eq(42)
   end
 
-  it "exists with Process::Status", tags: %w[slow] do
+  it "exits with Process::Status", tags: %w[slow] do
     status, _, _ = compile_and_run_source "exit Process::Status.new(system_exit_status: 0)"
     status.success?.should be_true
   end
 
-  it "exists with abnormal status", tags: %w[slow] do
+  it "exits with abnormal status", tags: %w[slow] do
     status, _, _ = compile_and_run_source "exit Process::Status.new(system_exit_status: {% if flag?(:unix) %}Signal::INT.value{% else %}LibC::STATUS_CONTROL_C_EXIT{% end %})"
     status.exit_reason.should eq Process::ExitReason::Interrupted
   end

--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -352,4 +352,27 @@ describe "SIGPIPE emulation" do
       result.status.success?.should be_true
     end
   end
+
+  context "with exit_on_epipe: false" do
+    it "exits cleanly when stdout is closed" do
+      IO.pipe do |reader, writer|
+        reader.close
+        result = Process.capture_result(ProcessUtils::EXE, "pu", "echo", "--no-exit-on-epipe", "foobar", output: writer)
+        result.output.should eq ""
+        result.error.should contain "Unhandled exception: write"
+        result.error.should contain "Broken pipe (IO::Error)"
+        result.status.should eq Process::Status[1]
+      end
+    end
+
+    it "exits cleanly when stderr is closed" do
+      IO.pipe do |reader, writer|
+        reader.close
+        result = Process.capture_result(ProcessUtils::EXE, "pu", "echo", "--stderr", "--no-exit-on-epipe", "foobar", error: writer)
+        result.output.should eq ""
+        result.error.should eq ""
+        result.status.should eq Process::Status[1]
+      end
+    end
+  end
 end

--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -358,13 +358,8 @@ describe "SIGPIPE emulation" do
         reader.close
         result = Process.capture_result(ProcessUtils::EXE, "pu", "echo", "--no-exit-on-epipe", "foobar", output: writer)
         result.output.should eq ""
-        {% if flag?(:win32) %}
-          result.error.should contain "Unhandled exception: Error writing file"
-          result.error.should contain "The pipe is being closed. (IO::Error)"
-        {% else %}
-          result.error.should contain "Unhandled exception: write"
-          result.error.should contain "Broken pipe (IO::Error)"
-        {% end %}
+        result.error.should match /Unhandled exception: (write|Error writing file)/
+        result.error.should match /(The pipe is being closed.|Broken pipe)/
         result.status.should eq Process::Status[1]
       end
     end

--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -358,8 +358,13 @@ describe "SIGPIPE emulation" do
         reader.close
         result = Process.capture_result(ProcessUtils::EXE, "pu", "echo", "--no-exit-on-epipe", "foobar", output: writer)
         result.output.should eq ""
-        result.error.should contain "Unhandled exception: write"
-        result.error.should contain "Broken pipe (IO::Error)"
+        {% if flag?(:win32) %}
+          result.error.should contain "Unhandled exception: Error writing file"
+          result.error.should contain "The pipe is being closed. (IO::Error)"
+        {% else %}
+          result.error.should contain "Unhandled exception: write"
+          result.error.should contain "Broken pipe (IO::Error)"
+        {% end %}
         result.status.should eq Process::Status[1]
       end
     end

--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -327,9 +327,8 @@ describe "SIGPIPE emulation" do
       reader.close
       result = Process.capture_result(ProcessUtils::EXE, "pu", "echo", "foobar", output: writer)
       result.output.should eq ""
-      result.error.should contain "Unhandled exception: write"
-      result.error.should contain "Broken pipe (IO::Error)"
-      result.status.should eq Process::Status[1]
+      result.error.should eq ""
+      result.status.should eq Process::Status[141]
     end
   end
 
@@ -339,7 +338,7 @@ describe "SIGPIPE emulation" do
       result = Process.capture_result(ProcessUtils::EXE, "pu", "echo", "--stderr", "foobar", error: writer)
       result.output.should eq ""
       result.error.should eq ""
-      result.status.should eq Process::Status[1]
+      result.status.should eq Process::Status[141]
     end
   end
 

--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -353,7 +353,7 @@ describe "SIGPIPE emulation" do
   end
 
   context "with exit_on_epipe: false" do
-    it "exits cleanly when stdout is closed" do
+    it "raises IO::Error when stdout is closed" do
       IO.pipe do |reader, writer|
         reader.close
         result = Process.capture_result(ProcessUtils::EXE, "pu", "echo", "--no-exit-on-epipe", "foobar", output: writer)
@@ -364,7 +364,7 @@ describe "SIGPIPE emulation" do
       end
     end
 
-    it "exits cleanly when stderr is closed" do
+    it "raises IO::Error when stderr is closed" do
       IO.pipe do |reader, writer|
         reader.close
         result = Process.capture_result(ProcessUtils::EXE, "pu", "echo", "--stderr", "--no-exit-on-epipe", "foobar", error: writer)

--- a/spec/support/process-utils-exe.cr
+++ b/spec/support/process-utils-exe.cr
@@ -38,6 +38,10 @@ module ProcessUtils
       opts.on("", "--stderr", "Write to stderr instead of stdout") do
         output = STDERR
       end
+      opts.on("", "--no-exit-on-epipe", "Set exit_on_epipe = false on stdio") do
+        STDOUT.exit_on_epipe = false
+        STDERR.exit_on_epipe = false
+      end
     end
 
     case command = args.shift?

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -94,8 +94,6 @@ module Crystal::System::FileDescriptor
       case error = WinError.value
       when .error_access_denied?
         raise IO::Error.new "File not open for writing", target: self
-      when .error_broken_pipe?
-        return 0_u32
       else
         raise IO::Error.from_os_error("Error writing file", error, target: self)
       end

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -341,6 +341,12 @@ class IO::FileDescriptor < IO
     until slice.empty?
       slice += @fd_lock.write { system_write(slice) }
     end
+  rescue exc : IO::Error
+    if exc.os_error == Errno::EPIPE && exit_on_epipe?
+      LibC.exit 141
+    else
+      raise exc
+    end
   end
 
   private def unbuffered_rewind : Nil

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -30,6 +30,8 @@ class IO::FileDescriptor < IO
   # The time to wait when reading before raising an `IO::TimeoutError`.
   property read_timeout : Time::Span?
 
+  property? exit_on_epipe : Bool = false
+
   # Sets the number of seconds to wait when reading before raising an `IO::TimeoutError`.
   @[Deprecated("Use `#read_timeout=(Time::Span?)` instead.")]
   def read_timeout=(read_timeout : Number) : Number
@@ -78,7 +80,9 @@ class IO::FileDescriptor < IO
 
   # :nodoc:
   def self.from_stdio(fd : Handle) : self
-    Crystal::System::FileDescriptor.from_stdio(fd)
+    Crystal::System::FileDescriptor.from_stdio(fd).tap do |io|
+      io.exit_on_epipe = true
+    end
   end
 
   # Returns whether I/O operations on this file descriptor block the current

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -342,7 +342,7 @@ class IO::FileDescriptor < IO
       slice += @fd_lock.write { system_write(slice) }
     end
   rescue exc : IO::Error
-    if exc.os_error == Errno::EPIPE && exit_on_epipe?
+    if (exc.os_error == Errno::EPIPE || exc.os_error.in?(WinError::ERROR_BROKEN_PIPE, WinError::ERROR_NO_DATA)) && exit_on_epipe?
       LibC.exit 141
     else
       raise exc


### PR DESCRIPTION
When a file descriptor errors with `EPIPE` on a write, and `exit_on_broken_pipe` is `true`, it exits the process. This emulates the standard behaviour of Unix processes receiving the `SIGPIPE` signal.
It resolves a long-standing issue that Crystal processes would print error information about a closed pipe when the standard output is closed.

`exit_on_broken_pipe` is implicitly enabled on the standard streams.

This is a breaking change because previously an `EPIPE` error on stdout or stderr would raise an exception which could be rescued. Now, they directly exit the process without unwinding the stack.
This can be avoided by explicitly setting `exit_on_epipe` to false which results in an exception on `EPIPE` error.

Resolves #7810
Depends on #17047 