### PR TITLE
CI: Fix allow unsafe PR checkout in `backport` workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,6 +26,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.CRYSBOT_WRITE_PAT }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Create backport PR
         uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6


### PR DESCRIPTION
Ref https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target