### PR TITLE
Fix `Float#modulo` and `Float#remainder` to use `fmod`

### DIFF
--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "spec/helpers/string"
+require "big"
 
 describe "Float" do
   describe "**" do
@@ -53,6 +54,13 @@ describe "Float" do
       (-1.0.modulo 5e-324).should eq(0.0)
     end
 
+    it "does not raise with a divisor too large for the dividend's type" do
+      (1.0_f32.modulo 1e300).should eq(1.0_f32)
+      (1.0_f32.modulo -1e300).should eq(-Float32::INFINITY)
+      (-1.0_f32.modulo 1e300).should eq(Float32::INFINITY)
+      (-1.0_f32.modulo -1e300).should eq(-1.0_f32)
+    end
+
     it "returns a result with the sign of the divisor" do
       (-3.7702231914821416e-103.modulo 1e300).should eq(1e300)
       (3.7702231914821416e-103.modulo -1e300).should eq(-1e300)
@@ -76,6 +84,39 @@ describe "Float" do
       (Float64::INFINITY.modulo 5.0).nan?.should be_true
       (5.0.modulo Float64::NAN).nan?.should be_true
       (Float64::NAN.modulo 5.0).nan?.should be_true
+    end
+
+    describe "with a non-primitive operand" do
+      it "keeps the divisor's type and precision" do
+        (1e17.modulo 3.to_big_f).should be_a(BigFloat)
+        (13.0.modulo 4.to_big_f).should eq(1.to_big_f)
+        (-13.0.modulo 4.to_big_f).should eq(3.to_big_f)
+        (13.0.modulo -4.to_big_f).should eq(-3.to_big_f)
+      end
+
+      it "does not round a BigFloat dividend to Float64" do
+        # 2 ** 60 + 1 needs 61 bits of significand, so `Float64` rounds it down
+        # to 2 ** 60 and every power-of-two divisor then divides it exactly
+        big = BigInt.new("1152921504606846977").to_big_f
+        (big.modulo 4.0).should eq(1.to_big_f)
+        (big.modulo 4.to_big_f).should eq(1.to_big_f)
+      end
+
+      it "supports an infinite divisor" do
+        big = 5.to_big_f
+        (big.modulo Float64::INFINITY).should eq(big)
+        (-big).modulo(-Float64::INFINITY).should eq(-big)
+      end
+
+      it "raises when an infinite or NaN result is not representable" do
+        expect_raises(ArgumentError) { -5.to_big_f.modulo Float64::INFINITY }
+        expect_raises(ArgumentError) { 5.to_big_f.modulo Float64::NAN }
+      end
+
+      it "raises when mods by zero" do
+        expect_raises(DivisionByZeroError) { 5.to_big_f.modulo 0.0 }
+        expect_raises(DivisionByZeroError) { 1.2.modulo 0.to_big_f }
+      end
     end
   end
 
@@ -125,6 +166,37 @@ describe "Float" do
     it "returns NaN for an infinite dividend or a NaN operand" do
       Float64::INFINITY.remainder(5.0).nan?.should be_true
       5.0.remainder(Float64::NAN).nan?.should be_true
+    end
+
+    describe "with a non-primitive operand" do
+      it "keeps the divisor's type and precision" do
+        1e17.remainder(3.to_big_f).should be_a(BigFloat)
+        13.0.remainder(4.to_big_f).should eq(1.to_big_f)
+        (-13.0).remainder(4.to_big_f).should eq(-1.to_big_f)
+        13.0.remainder(-4.to_big_f).should eq(1.to_big_f)
+      end
+
+      it "does not round a BigFloat dividend to Float64" do
+        big = BigInt.new("1152921504606846977").to_big_f
+        big.remainder(4.0).should eq(1.to_big_f)
+        big.remainder(4.to_big_f).should eq(1.to_big_f)
+      end
+
+      it "supports an infinite divisor" do
+        big = 5.to_big_f
+        big.remainder(Float64::INFINITY).should eq(big)
+        big.remainder(-Float64::INFINITY).should eq(big)
+        (-big).remainder(Float64::INFINITY).should eq(-big)
+      end
+
+      it "raises when a NaN result is not representable" do
+        expect_raises(ArgumentError) { 5.to_big_f.remainder Float64::NAN }
+      end
+
+      it "raises when mods by zero" do
+        expect_raises(DivisionByZeroError) { 5.to_big_f.remainder 0.0 }
+        expect_raises(DivisionByZeroError) { 1.2.remainder 0.to_big_f }
+      end
     end
   end
 

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -32,6 +32,51 @@ describe "Float" do
     it { (11.5.modulo -4.0).should eq(-0.5) }
     it { (-11.5.modulo 4.0).should eq(0.5) }
     it { (-11.5.modulo -4.0).should eq(-3.5) }
+
+    # 1e17 is exactly the integer 100000000000000000, and
+    # 100000000000000000 = 3 * 33333333333333333 + 1 = 7 * 14285714285714285 + 5
+    it "is exact when the quotient is large" do
+      (1e17.modulo 3.0).should eq(1.0)
+      (1e17.modulo 7.0).should eq(5.0)
+      (-1e17.modulo 7.0).should eq(2.0)
+      (1e17.modulo 1024.0).should eq(0.0)
+    end
+
+    # 1e10_f32 is exactly the integer 10000000000, and 10000000000 = 7 * 1428571428 + 4
+    it "is exact when the quotient is large (Float32)" do
+      (1e10_f32.modulo 7.0_f32).should eq(4.0_f32)
+      (-1e10_f32.modulo 7.0_f32).should eq(3.0_f32)
+    end
+
+    it "does not overflow with a divisor much smaller than the dividend" do
+      (1.0.modulo 5e-324).should eq(0.0)
+      (-1.0.modulo 5e-324).should eq(0.0)
+    end
+
+    it "returns a result with the sign of the divisor" do
+      (-3.7702231914821416e-103.modulo 1e300).should eq(1e300)
+      (3.7702231914821416e-103.modulo -1e300).should eq(-1e300)
+    end
+
+    it "returns a zero with the sign of the divisor" do
+      (6.0.modulo 3.0).sign_bit.should eq(1)
+      (6.0.modulo -3.0).sign_bit.should eq(-1)
+      (-6.0.modulo 3.0).sign_bit.should eq(1)
+      (-6.0.modulo -3.0).sign_bit.should eq(-1)
+    end
+
+    it "supports an infinite divisor (#17222)" do
+      (5.0.modulo Float64::INFINITY).should eq(5.0)
+      (-5.0.modulo Float64::INFINITY).should eq(Float64::INFINITY)
+      (5.0.modulo -Float64::INFINITY).should eq(-Float64::INFINITY)
+      (-5.0.modulo -Float64::INFINITY).should eq(-5.0)
+    end
+
+    it "returns NaN for an infinite dividend or a NaN operand" do
+      (Float64::INFINITY.modulo 5.0).nan?.should be_true
+      (5.0.modulo Float64::NAN).nan?.should be_true
+      (Float64::NAN.modulo 5.0).nan?.should be_true
+    end
   end
 
   describe "remainder" do
@@ -51,6 +96,35 @@ describe "Float" do
     it "preserves type" do
       r = 1.5_f32.remainder(1)
       typeof(r).should eq(Float32)
+    end
+
+    it "is exact when the quotient is large" do
+      1e17.remainder(7.0).should eq(5.0)
+      (-1e17).remainder(7.0).should eq(-5.0)
+      1e10_f32.remainder(7.0_f32).should eq(4.0_f32)
+    end
+
+    it "returns a value with the same magnitude as the dividend when the divisor is larger" do
+      (-1.2348533312932808e+48).remainder(1e300).should eq(-1.2348533312932808e+48)
+      (-0.06607380836084875).remainder(1e17).should eq(-0.06607380836084875)
+    end
+
+    it "returns a zero with the sign of the dividend" do
+      6.0.remainder(3.0).sign_bit.should eq(1)
+      6.0.remainder(-3.0).sign_bit.should eq(1)
+      (-6.0).remainder(3.0).sign_bit.should eq(-1)
+      (-6.0).remainder(-3.0).sign_bit.should eq(-1)
+    end
+
+    it "supports an infinite divisor (#17222)" do
+      5.0.remainder(Float64::INFINITY).should eq(5.0)
+      (-5.0).remainder(Float64::INFINITY).should eq(-5.0)
+      5.0.remainder(-Float64::INFINITY).should eq(5.0)
+    end
+
+    it "returns NaN for an infinite dividend or a NaN operand" do
+      Float64::INFINITY.remainder(5.0).nan?.should be_true
+      5.0.remainder(Float64::NAN).nan?.should be_true
     end
   end
 

--- a/src/float.cr
+++ b/src/float.cr
@@ -78,6 +78,33 @@ struct Float
     !nan? && !infinite?
   end
 
+  # Returns `self` modulo *other*, using floored division.
+  #
+  # The result has the same sign as *other*.
+  #
+  # ```
+  # 13.0.modulo(4.0)   # => 1.0
+  # -13.0.modulo(4.0)  # => 3.0
+  # 13.0.modulo(-4.0)  # => -3.0
+  # -13.0.modulo(-4.0) # => -1.0
+  # ```
+  #
+  # Raises `DivisionByZeroError` if *other* is zero.
+  def modulo(other : Number::Primitive) : self
+    raise DivisionByZeroError.new if other == 0
+
+    mod = LibM.fmod_f64(to_f64, other.to_f64)
+    if mod == 0
+      # `fmod` returns a zero with the sign of `self`, but a floored modulo
+      # must carry the sign of *other*
+      mod = other < 0 ? -0.0 : 0.0
+    elsif (mod < 0) != (other < 0)
+      mod += other
+    end
+    self.class.new(mod)
+  end
+
+  # :ditto:
   def modulo(other)
     if other == 0.0
       raise DivisionByZeroError.new
@@ -86,6 +113,25 @@ struct Float
     end
   end
 
+  # Returns `self` remainder *other*, using truncated division.
+  #
+  # The result has the same sign as `self`.
+  #
+  # ```
+  # 13.0.remainder(4.0)   # => 1.0
+  # -13.0.remainder(4.0)  # => -1.0
+  # 13.0.remainder(-4.0)  # => 1.0
+  # -13.0.remainder(-4.0) # => -1.0
+  # ```
+  #
+  # Raises `DivisionByZeroError` if *other* is zero.
+  def remainder(other : Number::Primitive) : self
+    raise DivisionByZeroError.new if other == 0
+
+    self.class.new(LibM.fmod_f64(to_f64, other.to_f64))
+  end
+
+  # :ditto:
   def remainder(other)
     if other == 0.0
       raise DivisionByZeroError.new

--- a/src/float.cr
+++ b/src/float.cr
@@ -90,27 +90,33 @@ struct Float
   # ```
   #
   # Raises `DivisionByZeroError` if *other* is zero.
-  def modulo(other : Number::Primitive) : self
-    raise DivisionByZeroError.new if other == 0
-
-    mod = LibM.fmod_f64(to_f64, other.to_f64)
-    if mod == 0
-      # `fmod` returns a zero with the sign of `self`, but a floored modulo
-      # must carry the sign of *other*
-      mod = other < 0 ? -0.0 : 0.0
-    elsif (mod < 0) != (other < 0)
-      mod += other
-    end
-    self.class.new(mod)
-  end
-
-  # :ditto:
   def modulo(other)
+    # fallback implementation; `Float32` and `Float64` override this
     if other == 0.0
       raise DivisionByZeroError.new
     else
       self - other * (self // other)
     end
+  end
+
+  # :ditto:
+  #
+  # This overload only applies to a `Float` that does not implement `#modulo`
+  # itself, such as `BigFloat`. `self - other * (self // other)` cannot be used
+  # when *other* is not finite: `self // other` is then zero or a not-a-number,
+  # and *other* times either one is a not-a-number for every dividend.
+  def modulo(other : Float::Primitive)
+    raise DivisionByZeroError.new if other == 0
+    return self.class.new(other) if other.nan?
+
+    if infinity = other.infinite?
+      # a finite dividend already lies inside the interval spanned by an
+      # infinite divisor when the two share a sign, and is one whole *other*
+      # away from it when they do not
+      return self == 0 || (self > 0) == (infinity > 0) ? self : self.class.new(other)
+    end
+
+    self - other * (self // other)
   end
 
   # Returns `self` remainder *other*, using truncated division.
@@ -125,14 +131,8 @@ struct Float
   # ```
   #
   # Raises `DivisionByZeroError` if *other* is zero.
-  def remainder(other : Number::Primitive) : self
-    raise DivisionByZeroError.new if other == 0
-
-    self.class.new(LibM.fmod_f64(to_f64, other.to_f64))
-  end
-
-  # :ditto:
   def remainder(other)
+    # fallback implementation; `Float32` and `Float64` override this
     if other == 0.0
       raise DivisionByZeroError.new
     else
@@ -143,6 +143,26 @@ struct Float
 
       mod - other
     end
+  end
+
+  # :ditto:
+  #
+  # This overload only applies to a `Float` that does not implement
+  # `#remainder` itself, such as `BigFloat`. See `#modulo` for why a divisor
+  # that is not finite cannot go through the general formula.
+  def remainder(other : Float::Primitive)
+    raise DivisionByZeroError.new if other == 0
+    return self.class.new(other) if other.nan?
+    # a truncated remainder is the dividend whenever the divisor is larger in
+    # magnitude, and an infinity always is
+    return self if other.infinite?
+
+    mod = self % other
+    return self.class.zero if mod == 0.0
+    return mod if self > 0 && other > 0
+    return mod if self < 0 && other < 0
+
+    mod - other
   end
 
   # Writes this float to the given *io* in the given *format*.
@@ -321,6 +341,32 @@ struct Float32
   # Returns the greatest `Float32` that is less than `self`.
   def prev_float : Float32
     LibM.nextafter_f32(self, -INFINITY)
+  end
+
+  # :inherit:
+  def modulo(other : Number::Primitive) : Float32
+    raise DivisionByZeroError.new if other == 0
+
+    # `to_f32!` rather than `to_f32`, so that a divisor too large for `Float32`
+    # becomes an infinity instead of raising `OverflowError`
+    divisor = other.to_f32!
+    mod = LibM.fmod_f32(self, divisor)
+    if mod == 0
+      # `fmod` returns a zero with the sign of `self`, but a floored modulo
+      # must carry the sign of *other*
+      divisor < 0 ? -0.0_f32 : 0.0_f32
+    elsif (mod < 0) != (divisor < 0)
+      mod + divisor
+    else
+      mod
+    end
+  end
+
+  # :inherit:
+  def remainder(other : Number::Primitive) : Float32
+    raise DivisionByZeroError.new if other == 0
+
+    LibM.fmod_f32(self, other.to_f32!)
   end
 
   def **(other : Int32)
@@ -539,6 +585,30 @@ struct Float64
   # Returns the greatest `Float64` that is less than `self`.
   def prev_float : Float64
     LibM.nextafter_f64(self, -INFINITY)
+  end
+
+  # :inherit:
+  def modulo(other : Number::Primitive) : Float64
+    raise DivisionByZeroError.new if other == 0
+
+    divisor = other.to_f64
+    mod = LibM.fmod_f64(self, divisor)
+    if mod == 0
+      # `fmod` returns a zero with the sign of `self`, but a floored modulo
+      # must carry the sign of *other*
+      divisor < 0 ? -0.0 : 0.0
+    elsif (mod < 0) != (divisor < 0)
+      mod + divisor
+    else
+      mod
+    end
+  end
+
+  # :inherit:
+  def remainder(other : Number::Primitive) : Float64
+    raise DivisionByZeroError.new if other == 0
+
+    LibM.fmod_f64(self, other.to_f64)
   end
 
   def **(other : Int32)

--- a/src/math/libm.cr
+++ b/src/math/libm.cr
@@ -180,6 +180,7 @@ lib LibM
   fun erf_f64 = erf(value : Float64) : Float64
   fun expm1_f32 = expm1f(value : Float32) : Float32
   fun expm1_f64 = expm1(value : Float64) : Float64
+  fun fmod_f32 = fmodf(value1 : Float32, value2 : Float32) : Float32
   fun fmod_f64 = fmod(value1 : Float64, value2 : Float64) : Float64
   {% unless flag?(:win32) %}
     fun frexp_f32 = frexpf(value : Float32, exp : Int32*) : Float32

--- a/src/math/libm.cr
+++ b/src/math/libm.cr
@@ -180,6 +180,7 @@ lib LibM
   fun erf_f64 = erf(value : Float64) : Float64
   fun expm1_f32 = expm1f(value : Float32) : Float32
   fun expm1_f64 = expm1(value : Float64) : Float64
+  fun fmod_f64 = fmod(value1 : Float64, value2 : Float64) : Float64
   {% unless flag?(:win32) %}
     fun frexp_f32 = frexpf(value : Float32, exp : Int32*) : Float32
   {% end %}


### PR DESCRIPTION
Fixes #17222, but the infinite divisor is one corner of a wider problem: `self - other * (self // other)` is inexact whenever the quotient is large, and overflows when the divisor is tiny.

```crystal
1e17 % 3.0      # => 0.0   (1e17 is exactly 100000000000000000, so this is 1.0)
1e17 % 7.0      # => 0.0   (should be 5.0)
1.0 % 5e-324    # => -Infinity
-3.77e-103 % 1e300  # => -3.77e-103   (negative, for a positive divisor)
```

`fmod` computes the truncated remainder exactly, so the floored result is that value plus the divisor when the signs differ.

**Measured.** 13,500 operand pairs (special values, random exponents, random bit patterns) against a reference implementation of CPython's `float_rem`, which I first checked against CPython's own `%` — 0 mismatches over 12,600 rows. Same corpus, same binary, before and after:

| | `modulo` | `remainder` |
|---|---|---|
| before | 4645 / 13500 wrong | 7711 / 13500 wrong |
| after | 0 | 0 |

A separate Float32 corpus against C `fmodf` goes 1596/3988 → 0 and 2404/3988 → 0. Routing Float32 through `fmod_f64` and narrowing is exact, since the remainder of two Float32 values is representable in Float32.

The narrow fix — special-casing an infinite divisor only — still leaves 3755/13500 and 7266/13500 wrong, so I did not take it.

**Two behaviour changes worth flagging.** `6.0 % -3.0` now returns `-0.0` rather than `0.0` (a floored modulo carries the divisor's sign), and `(-6.0).remainder(3.0)` returns `-0.0` (`fmod` carries the dividend's sign). Both match C, CPython and the documented rule for `Int#//`.

**Cost.** Best of 5 runs, 204,800 ops each, macOS 26 / aarch64: `Float64#%` 0.97 → 9.5 ns/op. Isolating the call, `fmod` alone is 6.2 ns/op against 0.56 for the old expression, so the cost is libm's, not the wrapper's. CPython, Ruby and C all pay it. Happy to add a fast path if you want one.

**Not fixed here.** `Float#//` is still `fdiv(other).floor`, so it disagrees with the corrected `%` on the cases where the floored correction applies — 659/12600 of the corpus differ from CPython's `//`. `divmod` still improves from 62.7% to 94.8% agreement. I left it out to keep the diff to the two methods #17222 names; glad to do it as a follow-up.

The existing specs never exercised this: the `modulo`/`remainder` block came in with the implementation in f2776c39c (2015) and uses only 13.0, 11.5 and 4.0 — values where the subtraction happens to be exact.

Full `spec/std_spec.cr` on this branch and on master: 4 failures + 2 errors on both, identical names (iconv shift-state and `$PATH`). One `Fiber::ExecutionContext::GlobalQueue` error appeared once on this branch; it passes 3/3 in isolation on both trees.

---

*Written with the assistance of Claude Opus 5 (`claude-opus-5`); I reviewed and verified every claim above myself, and the measurements are mine.*
