### PR TITLE
Fix deprecation warnings in samples

### DIFF
--- a/samples/red_black_tree.cr
+++ b/samples/red_black_tree.cr
@@ -383,24 +383,25 @@ class RedBlackTreeRunner
 end
 
 def bench(name, n = 1, &)
-  start = Time.instant
   print "#{name}: "
   res = nil
-  n.times do
-    res = yield
+  time = Time.measure do
+    n.times do
+      res = yield
+    end
   end
-
-  puts "#{Time.instant - start}, res: #{res}"
+  puts "#{time}, res: #{res}"
 end
 
-start = Time.instant
-b = RedBlackTreeRunner.new 100_000
-bench("delete", 10) { b.run_delete }
-bench("add", 10) { b.run_add }
-bench("search", 10) { b.run_search }
-bench("walk", 100) { b.run_inorder_walk }
-bench("reverse_walk", 100) { b.run_reverse_inorder_walk }
-bench("min", 100) { b.run_min }
-bench("max", 100) { b.run_max }
+time = Time.measure do
+  b = RedBlackTreeRunner.new 100_000
+  bench("delete", 10) { b.run_delete }
+  bench("add", 10) { b.run_add }
+  bench("search", 10) { b.run_search }
+  bench("walk", 100) { b.run_inorder_walk }
+  bench("reverse_walk", 100) { b.run_reverse_inorder_walk }
+  bench("min", 100) { b.run_min }
+  bench("max", 100) { b.run_max }
+end
 
-puts "summary time: #{Time.instant - start}"
+puts "summary time: #{time}"

--- a/samples/red_black_tree.cr
+++ b/samples/red_black_tree.cr
@@ -383,17 +383,17 @@ class RedBlackTreeRunner
 end
 
 def bench(name, n = 1, &)
-  start = Time.monotonic
+  start = Time.instant
   print "#{name}: "
   res = nil
   n.times do
     res = yield
   end
 
-  puts "#{Time.monotonic - start}, res: #{res}"
+  puts "#{Time.instant - start}, res: #{res}"
 end
 
-start = Time.monotonic
+start = Time.instant
 b = RedBlackTreeRunner.new 100_000
 bench("delete", 10) { b.run_delete }
 bench("add", 10) { b.run_add }
@@ -403,4 +403,4 @@ bench("reverse_walk", 100) { b.run_reverse_inorder_walk }
 bench("min", 100) { b.run_min }
 bench("max", 100) { b.run_max }
 
-puts "summary time: #{Time.monotonic - start}"
+puts "summary time: #{Time.instant - start}"

--- a/samples/sdl/raytracer.cr
+++ b/samples/sdl/raytracer.cr
@@ -202,7 +202,7 @@ def render(scene, surface)
   surface.update_rect 0, 0, 0, 0
 end
 
-Process.on_interrupt { exit }
+Process.on_terminate { exit }
 
 scene = Scene.new(
   [


### PR DESCRIPTION
Removes the remaining uses of `Process.on_interrupt` and `Time.monotonic`.