### PR TITLE
Build stage-2 compiler on ARM64 MSVC CI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -8,198 +8,23 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
-env:
-  SPEC_SPLIT_DOTS: 160
-  CI_LLVM_VERSION: "20.1.7"
-  CI_LLVM_TARGETS: "X86,AArch64"
-  CI_LLVM_LDFLAGS: "psapi.lib shell32.lib ole32.lib uuid.lib advapi32.lib ws2_32.lib ntdll.lib"
-
 jobs:
-  x86_64-windows-deps:
-    name: Build dependencies
-    uses: ./.github/workflows/win_build_libs.yml
+  x86_64-msvc:
+    name: x64 MSVC
+    uses: ./.github/workflows/win_steps.yml
     with:
       arch: x86_64
       runs-on: windows-2025-vs2026
       llvm_version: "20.1.7"
       llvm_targets: "X86;AArch64"
-
-  x86_64-windows-release:
-    needs: [x86_64-windows-deps]
-    uses: ./.github/workflows/win_build_portable.yml
-    with:
-      release: true
-      llvm_version: "20.1.7"
-      llvm_targets: "X86;AArch64"
       llvm_ldflags: "psapi.lib shell32.lib ole32.lib uuid.lib advapi32.lib ws2_32.lib ntdll.lib"
 
-  x86_64-windows-test:
-    runs-on: windows-2025-vs2026
-    needs: [x86_64-windows-release]
-    steps:
-      - name: Disable CRLF line ending substitution
-        run: |
-          git config --global core.autocrlf false
-
-      - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-
-      - name: Download Crystal source
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Download Crystal executable
-        uses: actions/download-artifact@v8
-        with:
-          name: crystal
-          path: build
-
-      - name: Set up environment
-        run: |
-          Add-Content $env:GITHUB_PATH "$(pwd)\build"
-          Add-Content $env:GITHUB_ENV "CRYSTAL_SPEC_COMPILER_BIN=$(pwd)\build\crystal.exe"
-          Add-Content $env:GITHUB_ENV "LLVM_VERSION=${{ env.CI_LLVM_VERSION }}"
-          Add-Content $env:GITHUB_ENV "LLVM_TARGETS=${{ env.CI_LLVM_TARGETS }}"
-          Add-Content $env:GITHUB_ENV "LLVM_LDFLAGS=${{ env.CI_LLVM_LDFLAGS }}"
-
-      - name: Run stdlib specs
-        run: make -f Makefile.win std_spec
-
-      - name: Run compiler specs
-        run: make -f Makefile.win compiler_spec
-
-      - name: Run interpreter specs
-        run: make -f Makefile.win interpreter_spec
-
-      - name: Run primitives specs
-        run: make -f Makefile.win -o .build\crystal.exe primitives_spec # we know the compiler is fresh; do not rebuild it here
-
-      - name: Run CLI specs
-        run: make -f Makefile.win cli_spec
-
-      - name: Build samples
-        run: make -f Makefile.win samples
-
-  test-std:
-    runs-on: windows-2025-vs2026
-    needs: [x86_64-windows-release]
-    strategy:
-      fail-fast: false
-      matrix:
-        opts:
-          - flags: "-Dwithout_mt"
-          - workers: 4 # execution_context: parallel
-
-    steps:
-      - name: Disable CRLF line ending substitution
-        run: git config --global core.autocrlf false
-
-      - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-
-      - name: Download Crystal source
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Download Crystal executable
-        uses: actions/download-artifact@v8
-        with:
-          name: crystal
-          path: build
-
-      - name: Set up environment
-        run: |
-          Add-Content $env:GITHUB_PATH "$(pwd)\build"
-          Add-Content $env:GITHUB_ENV "CRYSTAL_SPEC_COMPILER_BIN=$(pwd)\build\crystal.exe"
-          Add-Content $env:GITHUB_ENV "LLVM_VERSION=${{ env.CI_LLVM_VERSION }}"
-          Add-Content $env:GITHUB_ENV "LLVM_TARGETS=${{ env.CI_LLVM_TARGETS }}"
-          Add-Content $env:GITHUB_ENV "LLVM_LDFLAGS=${{ env.CI_LLVM_LDFLAGS }}"
-
-      - name: Test
-        run: make -f Makefile.win std_spec FLAGS="${{ matrix.opts.flags || '' }}"
-        env:
-          CRYSTAL_WORKERS: ${{ matrix.opts.workers || 1 }}
-
-  x86_64-windows-test-interpreter:
-    runs-on: windows-2025-vs2026
-    needs: [x86_64-windows-release]
-    steps:
-      - name: Disable CRLF line ending substitution
-        run: |
-          git config --global core.autocrlf false
-
-      - name: Download Crystal source
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Download Crystal executable
-        uses: actions/download-artifact@v8
-        with:
-          name: crystal
-          path: build
-
-      - name: Set up environment
-        run: |
-          Add-Content $env:GITHUB_PATH "$(pwd)\build"
-          Add-Content $env:GITHUB_ENV "CRYSTAL_SPEC_COMPILER_BIN=$(pwd)\build\crystal.exe"
-          Add-Content $env:GITHUB_ENV "LLVM_VERSION=${{ env.CI_LLVM_VERSION }}"
-          Add-Content $env:GITHUB_ENV "LLVM_TARGETS=${{ env.CI_LLVM_TARGETS }}"
-          Add-Content $env:GITHUB_ENV "LLVM_LDFLAGS=${{ env.CI_LLVM_LDFLAGS }}"
-
-      - name: Build crystal-pu
-        run: make -f Makefile.win build\crystal-pu.exe O=build
-
-      - name: Run stdlib specs with interpreter
-        run: bin\crystal i spec\std_spec.cr
-
-      - name: Run primitives specs with interpreter
-        run: bin\crystal i spec\primitives_spec.cr
-
-  x86_64-windows-installer:
-    if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/ci/'))
-    runs-on: windows-2025-vs2026
-    needs: [x86_64-windows-release]
-    steps:
-      - name: Disable CRLF line ending substitution
-        run: |
-          git config --global core.autocrlf false
-
-      - name: Download Crystal source
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Download Crystal executable
-        uses: actions/download-artifact@v8
-        with:
-          name: crystal
-          path: etc/win-ci/portable
-
-      - name: Set up Inno Setup
-        run: |
-          Invoke-WebRequest -Uri https://github.com/jrsoftware/issrc/releases/download/is-7_0_2/innosetup-7.0.2-x64.exe -OutFile C:\is.exe
-          C:\is.exe /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
-
-      - name: Set up environment
-        run: |
-          Add-Content $env:GITHUB_PATH "$(pwd)\etc\win-ci\portable"
-          Add-Content $env:GITHUB_ENV "LLVM_VERSION=${{ env.CI_LLVM_VERSION }}"
-          Add-Content $env:GITHUB_ENV "LLVM_TARGETS=${{ env.CI_LLVM_TARGETS }}"
-          Add-Content $env:GITHUB_ENV "LLVM_LDFLAGS=${{ env.CI_LLVM_LDFLAGS }}"
-
-      - name: Build docs
-        run: make -f Makefile.win install_docs prefix=etc\win-ci\portable
-
-      - name: Build installer
-        working-directory: ./etc/win-ci
-        run: |
-          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" crystal.iss
-
-      - name: Upload Crystal installer
-        uses: actions/upload-artifact@v7
-        with:
-          name: crystal-installer
-          path: etc/win-ci/Output/crystal-setup.exe
+  aarch64-msvc:
+    name: ARM64 MSVC
+    uses: ./.github/workflows/win_steps.yml
+    with:
+      arch: aarch64
+      runs-on: windows-11-vs2026-arm
+      llvm_version: "22.1.8"
+      llvm_targets: "X86;AArch64"
+      llvm_ldflags: "psapi.lib shell32.lib ole32.lib uuid.lib advapi32.lib ws2_32.lib ntdll.lib"

--- a/.github/workflows/win_arm64.yml
+++ b/.github/workflows/win_arm64.yml
@@ -3,13 +3,17 @@
 
 name: Windows ARM64 CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+    outputs:
+      artifact-id:
+        value: ${{ jobs.build-stage1.outputs.artifact-id }}
 
 permissions: {}
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
   SPEC_SPLIT_DOTS: 160
@@ -19,18 +23,10 @@ env:
   CI_LLVM_LDFLAGS: "psapi.lib shell32.lib ole32.lib uuid.lib advapi32.lib ws2_32.lib ntdll.lib"
 
 jobs:
-  aarch64-windows-deps:
-    name: Build dependencies
-    uses: ./.github/workflows/win_build_libs.yml
-    with:
-      arch: aarch64
-      runs-on: windows-11-vs2026-arm
-      llvm_version: "22.1.8"
-      llvm_targets: "X86;AArch64"
-
-  aarch64-windows-release:
-    needs: [aarch64-windows-deps]
+  build-stage1:
     runs-on: windows-11-vs2026-arm
+    outputs:
+      artifact-id: ${{ steps.upload-stage1-compiler.outputs.artifact-id }}
     steps:
       - name: Disable CRLF line ending substitution
         run: |
@@ -124,10 +120,12 @@ jobs:
           Add-Content $env:GITHUB_ENV "CRYSTAL_PATH=lib;$(pwd)\src"
           Add-Content $env:GITHUB_ENV 'CRYSTAL_CONFIG_PATH=lib;$ORIGIN\src'
           Add-Content $env:GITHUB_ENV 'CRYSTAL_CONFIG_LIBRARY_PATH=$ORIGIN\lib'
+          Add-Content $env:GITHUB_ENV "LLVM_HOST_TARGET=$env:INPUTS_LLVM_HOST_TARGET"
           Add-Content $env:GITHUB_ENV "LLVM_VERSION=$env:INPUTS_LLVM_VERSION"
           Add-Content $env:GITHUB_ENV "LLVM_TARGETS=$env:INPUTS_LLVM_TARGETS"
           Add-Content $env:GITHUB_ENV "LLVM_LDFLAGS=$env:INPUTS_LLVM_LDFLAGS"
         env:
+          INPUTS_LLVM_HOST_TARGET: aarch64-windows-msvc
           INPUTS_LLVM_VERSION: ${{ env.CI_LLVM_VERSION }}
           INPUTS_LLVM_TARGETS: ${{ env.CI_LLVM_TARGETS }}
           INPUTS_LLVM_LDFLAGS: ${{ env.CI_LLVM_LDFLAGS }}
@@ -155,6 +153,7 @@ jobs:
 
       - name: Upload Crystal binaries
         uses: actions/upload-artifact@v7
+        id: upload-stage1-compiler
         with:
-          name: crystal
+          name: crystal-aarch64-stage1
           path: crystal

--- a/.github/workflows/win_build_portable.yml
+++ b/.github/workflows/win_build_portable.yml
@@ -3,6 +3,12 @@ name: Windows CI / Build Portable Package
 on:
   workflow_call:
     inputs:
+      arch:
+        required: true
+        type: string
+      runs-on:
+        required: true
+        type: string
       release:
         required: true
         type: boolean
@@ -15,15 +21,19 @@ on:
       llvm_ldflags:
         required: true
         type: string
+      compiler_artifact_id:
+        required: false
+        type: string
 
 permissions: {}
 
 env:
   CI_SSL_VERSION: "3.5.0"
+  WIN_ARCH: ${{ inputs.arch == 'aarch64' && 'arm64' || 'x64' }}
 
 jobs:
   build:
-    runs-on: windows-2025-vs2026
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Disable CRLF line ending substitution
         run: |
@@ -31,17 +41,34 @@ jobs:
 
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-
-      - name: Install Crystal
-        uses: crystal-lang/install-crystal@v1
-        id: install-crystal
         with:
-          crystal: "1.21.0"
+          arch: ${{ env.WIN_ARCH }}
 
       - name: Download Crystal source
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        if: ${{ inputs.arch == 'x86_64' }}
+        id: install-crystal
+        with:
+          crystal: "1.21.0"
+
+      - name: Install Crystal (ARM64 stage-1 compiler)
+        uses: actions/download-artifact@v8
+        if: ${{ inputs.arch == 'aarch64' }}
+        id: install-aarch64-stage1-compiler
+        with:
+          name: crystal-aarch64-stage1
+          path: crystal-aarch64-stage1
+
+      - name: Add Crystal to PATH
+        if: ${{ inputs.arch == 'aarch64' }}
+        run: Add-Content $env:GITHUB_PATH "$env:INPUTS_CRYSTAL"
+        env:
+          INPUTS_CRYSTAL: ${{ steps.install-aarch64-stage1-compiler.outputs.download-path }}
 
       - name: Restore libraries
         uses: actions/cache/restore@v6
@@ -56,7 +83,7 @@ jobs:
             libs/yaml.lib
             libs/xml2.lib
             libs/libxml_VERSION
-          key: libs-x86_64-windows-msvc-${{ hashFiles('.github/workflows/win_build_libs.yml', 'etc/win-ci/*.ps1') }}
+          key: libs-${{ inputs.arch }}-windows-msvc-${{ hashFiles('.github/workflows/win_build_libs.yml', 'etc/win-ci/*.ps1') }}
           fail-on-cache-miss: true
       - name: Restore OpenSSL
         uses: actions/cache/restore@v6
@@ -65,7 +92,7 @@ jobs:
             libs/crypto.lib
             libs/ssl.lib
             libs/openssl_VERSION
-          key: libs-openssl-${{ env.CI_SSL_VERSION }}-x86_64-windows-msvc-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
+          key: libs-openssl-${{ env.CI_SSL_VERSION }}-${{ inputs.arch }}-windows-msvc-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
           fail-on-cache-miss: true
       - name: Restore DLLs
         uses: actions/cache/restore@v6
@@ -87,7 +114,7 @@ jobs:
             dlls/mpir.dll
             dlls/yaml.dll
             dlls/libxml2.dll
-          key: dlls-x86_64-windows-msvc-${{ hashFiles('.github/workflows/win_build_libs.yml', 'etc/win-ci/*.ps1') }}
+          key: dlls-${{ inputs.arch }}-windows-msvc-${{ hashFiles('.github/workflows/win_build_libs.yml', 'etc/win-ci/*.ps1') }}
           fail-on-cache-miss: true
       - name: Restore OpenSSL DLLs
         uses: actions/cache/restore@v6
@@ -95,9 +122,9 @@ jobs:
           path: |
             libs/crypto-dynamic.lib
             libs/ssl-dynamic.lib
-            dlls/libcrypto-3-x64.dll
-            dlls/libssl-3-x64.dll
-          key: dlls-openssl-${{ env.CI_SSL_VERSION }}-x86_64-windows-msvc-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
+            dlls/libcrypto-3-${{ env.WIN_ARCH }}.dll
+            dlls/libssl-3-${{ env.WIN_ARCH }}.dll
+          key: dlls-openssl-${{ env.CI_SSL_VERSION }}-${{ inputs.arch }}-windows-msvc-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}
           fail-on-cache-miss: true
       - name: Restore LLVM DLLs
         uses: actions/cache/restore@v6
@@ -106,16 +133,18 @@ jobs:
             libs/llvm_VERSION
             libs/llvm-dynamic.lib
             dlls/LLVM-C.dll
-          key: dlls-llvm-${{ inputs.llvm_version }}-x86_64-windows-msvc-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}
+          key: dlls-llvm-${{ inputs.llvm_version }}-${{ inputs.arch }}-windows-msvc-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}
           fail-on-cache-miss: true
 
       - name: Set up environment
         run: |
           Add-Content $env:GITHUB_ENV "CRYSTAL_LIBRARY_PATH=$(pwd)\libs"
+          Add-Content $env:GITHUB_ENV "LLVM_HOST_TARGET=$env:INPUTS_LLVM_HOST_TARGET"
           Add-Content $env:GITHUB_ENV "LLVM_VERSION=$env:INPUTS_LLVM_VERSION"
           Add-Content $env:GITHUB_ENV "LLVM_TARGETS=$env:INPUTS_LLVM_TARGETS"
           Add-Content $env:GITHUB_ENV "LLVM_LDFLAGS=$env:INPUTS_LLVM_LDFLAGS"
         env:
+          INPUTS_LLVM_HOST_TARGET: ${{ inputs.arch }}-windows-msvc
           INPUTS_LLVM_VERSION: ${{ inputs.llvm_version }}
           INPUTS_LLVM_TARGETS: ${{ inputs.llvm_targets }}
           INPUTS_LLVM_LDFLAGS: ${{ inputs.llvm_ldflags }}
@@ -129,7 +158,7 @@ jobs:
           bin/crystal.bat env
           make -f Makefile.win -B ${{ inputs.release && 'release=1' || '' }} interpreter=1
         env:
-          CRYSTAL_DIR: ${{ steps.install-crystal.outputs.path }}
+          CRYSTAL_DIR: ${{ inputs.arch == 'aarch64' && steps.install-aarch64-stage1-compiler.outputs.download-path || steps.install-crystal.outputs.path }}
 
       - name: Download shards release
         uses: actions/checkout@v7
@@ -155,6 +184,13 @@ jobs:
 
       - name: Upload Crystal binaries
         uses: actions/upload-artifact@v7
+        with:
+          name: crystal-${{ inputs.arch }}-windows-msvc
+          path: crystal
+
+      - name: Upload Crystal binaries (compatibility)
+        uses: actions/upload-artifact@v7
+        if: ${{ inputs.arch == 'x86_64' }}
         with:
           name: crystal
           path: crystal

--- a/.github/workflows/win_build_portable.yml
+++ b/.github/workflows/win_build_portable.yml
@@ -31,6 +31,10 @@ env:
   CI_SSL_VERSION: "3.5.0"
   WIN_ARCH: ${{ inputs.arch == 'aarch64' && 'arm64' || 'x64' }}
 
+defaults:
+  run:
+    shell: pwsh
+
 jobs:
   build:
     runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/win_steps.yml
+++ b/.github/workflows/win_steps.yml
@@ -25,6 +25,10 @@ env:
   SPEC_SPLIT_DOTS: 160
   WIN_ARCH: ${{ inputs.arch == 'aarch64' && 'arm64' || 'x64' }}
 
+defaults:
+  run:
+    shell: pwsh
+
 jobs:
   build-deps:
     name: Build dependencies

--- a/.github/workflows/win_steps.yml
+++ b/.github/workflows/win_steps.yml
@@ -1,0 +1,255 @@
+name: Windows CI / Build
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      runs-on:
+        required: true
+        type: string
+      llvm_version:
+        required: true
+        type: string
+      llvm_targets:
+        required: true
+        type: string
+      llvm_ldflags:
+        required: true
+        type: string
+
+permissions: {}
+
+env:
+  SPEC_SPLIT_DOTS: 160
+  WIN_ARCH: ${{ inputs.arch == 'aarch64' && 'arm64' || 'x64' }}
+
+jobs:
+  build-deps:
+    name: Build dependencies
+    uses: ./.github/workflows/win_build_libs.yml
+    with:
+      arch: ${{ inputs.arch }}
+      runs-on: ${{ inputs.runs-on }}
+      llvm_version: ${{ inputs.llvm_version }}
+      llvm_targets: ${{ inputs.llvm_targets }}
+
+  build-stage1:
+    name: Build stage-1 compiler
+    needs: [build-deps]
+    uses: ./.github/workflows/win_arm64.yml
+    if: ${{ inputs.arch == 'aarch64' }}
+    with:
+      arch: ${{ inputs.arch }}
+
+  build-release:
+    name: Build compiler
+    needs: [build-stage1]
+    uses: ./.github/workflows/win_build_portable.yml
+    if: ${{ !cancelled() }}
+    with:
+      release: true
+      arch: ${{ inputs.arch }}
+      runs-on: ${{ inputs.runs-on }}
+      llvm_version: ${{ inputs.llvm_version }}
+      llvm_targets: ${{ inputs.llvm_targets }}
+      llvm_ldflags: ${{ inputs.llvm_ldflags }}
+
+  run-tests:
+    name: Run tests
+    runs-on: ${{ inputs.runs-on }}
+    needs: [build-release]
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Disable CRLF line ending substitution
+        run: |
+          git config --global core.autocrlf false
+
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          arch: ${{ env.WIN_ARCH }}
+
+      - name: Download Crystal source
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Download Crystal executable
+        uses: actions/download-artifact@v8
+        with:
+          name: crystal-${{ inputs.arch }}-windows-msvc
+          path: build
+
+      - name: Set up environment
+        run: |
+          Add-Content $env:GITHUB_PATH "$(pwd)\build"
+          Add-Content $env:GITHUB_ENV "CRYSTAL_SPEC_COMPILER_BIN=$(pwd)\build\crystal.exe"
+          Add-Content $env:GITHUB_ENV "LLVM_VERSION=$env:INPUTS_LLVM_VERSION"
+          Add-Content $env:GITHUB_ENV "LLVM_TARGETS=$env:INPUTS_LLVM_TARGETS"
+          Add-Content $env:GITHUB_ENV "LLVM_LDFLAGS=$env:INPUTS_LLVM_LDFLAGS"
+        env:
+          INPUTS_LLVM_VERSION: ${{ inputs.llvm_version }}
+          INPUTS_LLVM_TARGETS: ${{ inputs.llvm_targets }}
+          INPUTS_LLVM_LDFLAGS: ${{ inputs.llvm_ldflags }}
+
+      - name: Run stdlib specs
+        run: make -f Makefile.win std_spec
+
+      - name: Run compiler specs
+        run: make -f Makefile.win compiler_spec
+
+      - name: Run interpreter specs
+        run: make -f Makefile.win interpreter_spec
+
+      - name: Run primitives specs
+        run: make -f Makefile.win -o .build\crystal.exe primitives_spec # we know the compiler is fresh; do not rebuild it here
+
+      - name: Run CLI specs
+        run: make -f Makefile.win cli_spec
+
+      - name: Build samples
+        run: make -f Makefile.win samples
+
+  run-tests-mt:
+    name: Run tests (MT)
+    runs-on: ${{ inputs.runs-on }}
+    needs: [build-release]
+    if: ${{ !cancelled() }}
+    strategy:
+      fail-fast: false
+      matrix:
+        opts:
+          - flags: "-Dwithout_mt"
+          - workers: 4 # execution_context: parallel
+
+    steps:
+      - name: Disable CRLF line ending substitution
+        run: git config --global core.autocrlf false
+
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        with:
+          arch: ${{ env.WIN_ARCH }}
+
+      - name: Download Crystal source
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Download Crystal executable
+        uses: actions/download-artifact@v8
+        with:
+          name: crystal-${{ inputs.arch }}-windows-msvc
+          path: build
+
+      - name: Set up environment
+        run: |
+          Add-Content $env:GITHUB_PATH "$(pwd)\build"
+          Add-Content $env:GITHUB_ENV "CRYSTAL_SPEC_COMPILER_BIN=$(pwd)\build\crystal.exe"
+          Add-Content $env:GITHUB_ENV "LLVM_VERSION=$env:INPUTS_LLVM_VERSION"
+          Add-Content $env:GITHUB_ENV "LLVM_TARGETS=$env:INPUTS_LLVM_TARGETS"
+          Add-Content $env:GITHUB_ENV "LLVM_LDFLAGS=$env:INPUTS_LLVM_LDFLAGS"
+        env:
+          INPUTS_LLVM_VERSION: ${{ inputs.llvm_version }}
+          INPUTS_LLVM_TARGETS: ${{ inputs.llvm_targets }}
+          INPUTS_LLVM_LDFLAGS: ${{ inputs.llvm_ldflags }}
+
+      - name: Test
+        run: make -f Makefile.win std_spec FLAGS="${{ matrix.opts.flags || '' }}"
+        env:
+          CRYSTAL_WORKERS: ${{ matrix.opts.workers || 1 }}
+
+  run-tests-with-interpreter:
+    name: Run tests with interpreter
+    runs-on: ${{ inputs.runs-on }}
+    needs: [build-release]
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Disable CRLF line ending substitution
+        run: |
+          git config --global core.autocrlf false
+
+      - name: Download Crystal source
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Download Crystal executable
+        uses: actions/download-artifact@v8
+        with:
+          name: crystal-${{ inputs.arch }}-windows-msvc
+          path: build
+
+      - name: Set up environment
+        run: |
+          Add-Content $env:GITHUB_PATH "$(pwd)\build"
+          Add-Content $env:GITHUB_ENV "CRYSTAL_SPEC_COMPILER_BIN=$(pwd)\build\crystal.exe"
+          Add-Content $env:GITHUB_ENV "LLVM_VERSION=$env:INPUTS_LLVM_VERSION"
+          Add-Content $env:GITHUB_ENV "LLVM_TARGETS=$env:INPUTS_LLVM_TARGETS"
+          Add-Content $env:GITHUB_ENV "LLVM_LDFLAGS=$env:INPUTS_LLVM_LDFLAGS"
+        env:
+          INPUTS_LLVM_VERSION: ${{ inputs.llvm_version }}
+          INPUTS_LLVM_TARGETS: ${{ inputs.llvm_targets }}
+          INPUTS_LLVM_LDFLAGS: ${{ inputs.llvm_ldflags }}
+
+      - name: Build crystal-pu
+        run: make -f Makefile.win build\crystal-pu.exe O=build
+
+      - name: Run stdlib specs with interpreter
+        run: bin\crystal i spec\std_spec.cr
+
+      - name: Run primitives specs with interpreter
+        run: bin\crystal i spec\primitives_spec.cr
+
+  build-installer:
+    name: Build installer
+    if: ${{ !cancelled() && inputs.arch == 'x86_64' && github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/ci/')) }}
+    runs-on: ${{ inputs.runs-on }}
+    needs: [build-release]
+    steps:
+      - name: Disable CRLF line ending substitution
+        run: |
+          git config --global core.autocrlf false
+
+      - name: Download Crystal source
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Download Crystal executable
+        uses: actions/download-artifact@v8
+        with:
+          name: crystal-${{ inputs.arch }}-windows-msvc
+          path: etc/win-ci/portable
+
+      - name: Set up Inno Setup
+        run: |
+          Invoke-WebRequest -Uri https://github.com/jrsoftware/issrc/releases/download/is-7_0_2/innosetup-7.0.2-x64.exe -OutFile C:\is.exe
+          C:\is.exe /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+
+      - name: Set up environment
+        run: |
+          Add-Content $env:GITHUB_PATH "$(pwd)\etc\win-ci\portable"
+          Add-Content $env:GITHUB_ENV "LLVM_VERSION=$env:INPUTS_LLVM_VERSION"
+          Add-Content $env:GITHUB_ENV "LLVM_TARGETS=$env:INPUTS_LLVM_TARGETS"
+          Add-Content $env:GITHUB_ENV "LLVM_LDFLAGS=$env:INPUTS_LLVM_LDFLAGS"
+        env:
+          INPUTS_LLVM_VERSION: ${{ inputs.llvm_version }}
+          INPUTS_LLVM_TARGETS: ${{ inputs.llvm_targets }}
+          INPUTS_LLVM_LDFLAGS: ${{ inputs.llvm_ldflags }}
+
+      - name: Build docs
+        run: make -f Makefile.win install_docs prefix=etc\win-ci\portable
+
+      - name: Build installer
+        working-directory: ./etc/win-ci
+        run: |
+          & "C:\Program Files\Inno Setup 7\ISCC.exe" crystal.iss
+
+      - name: Upload Crystal installer
+        uses: actions/upload-artifact@v7
+        with:
+          name: crystal-installer
+          path: etc/win-ci/Output/crystal-setup.exe

--- a/Makefile.win
+++ b/Makefile.win
@@ -82,6 +82,7 @@ ifeq ($(LLVM_VERSION),)
 LLVM_CONFIG  ?=
 LLVM_VERSION := $(if $(LLVM_CONFIG),$(shell "$(LLVM_CONFIG)" --version))
 endif
+LLVM_HOST_TARGET ?= $(if $(LLVM_CONFIG),$(shell $(LLVM_CONFIG) --host-target))
 
 LLVM_EXT_DIR = src\llvm\ext
 LLVM_EXT_OBJ = $(LLVM_EXT_DIR)\llvm_ext.obj
@@ -318,7 +319,7 @@ rc: ## Write compiler resource script to standard output
 	echo             VALUE "ProductName",      "Crystal"& \
 	echo             VALUE "ProductVersion",   "$(ver_full)"& \
 	echo             VALUE "FileVersion",      "$(ver_full)"& \
-	echo             VALUE "FileDescription",  "Crystal$(if $(LLVM_CONFIG), $(shell $(LLVM_CONFIG) --host-target))"& \
+	echo             VALUE "FileDescription",  "Crystal$(if $(LLVM_HOST_TARGET), $(LLVM_HOST_TARGET))"& \
 	echo             VALUE "Comments",         "$(if $(LLVM_VERSION),LLVM $(LLVM_VERSION))"& \
 	echo             VALUE "InternalName",     "crystal.exe"& \
 	echo             VALUE "OriginalFilename", "crystal.exe"& \

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -452,12 +452,17 @@ describe Process do
         value = Process.run(exe, ["pu", "env"], clear_env: true) do |proc|
           proc.output.gets_to_end
         end
+
+        {% if flag?(:win32) %}
+          # Ignore `PROCESSOR_ARCHITECTURE` which ucrt might inject.
+          value = value.gsub(/^(PATH|PROCESSOR_ARCHITECTURE)=.*\n/m, "")
+        {% end %}
         value.should eq("")
       end
 
       it "clears and sets an environment variable" do
         env = {"FOO" => "bar"}
-        {% if flag?(:win32) && flag?(:gnu) %}
+        {% if flag?(:win32) %}
           # We must pass PATH because otherwise dynamic libraries might not be found.
           env["PATH"] = ENV["PATH"]
         {% end %}
@@ -466,7 +471,7 @@ describe Process do
           proc.output.gets_to_end
         end
 
-        {% if flag?(:win32) && flag?(:gnu) %}
+        {% if flag?(:win32) %}
           # Ignore `PATH` (added above) and `PROCESSOR_ARCHITECTURE` which ucrt
           # might inject.
           value = value.gsub(/^(PATH|PROCESSOR_ARCHITECTURE)=.*\n/m, "")


### PR DESCRIPTION
Part of #17118.

Turns the existing MSVC workflow into a reusable one that can handle both x64 and ARM64. The existing stage-1 compiler is now used to immediately build a stage-2 compiler natively; it could be removed once 1.22.0 is out and `install-crystal` supports ARM64 MSVC. The full test suite now passes with `aarch64-windows-msvc`.

This PR also introduces the following new artifact names: (see #14248)

* `crystal-x86_64-windows-msvc`: x64 portable build
* `crystal-aarch64-windows-msvc`: ARM64 portable build

`crystal` remains available as an alias of `crystal-x86_64-windows-msvc`. The GUI installer will be patched in a subsequent PR; the new artifact names are expected to be `crystal-installer-*-windows-msvc`.

Some other minor fixes:

* Inno Setup's path is now correct (it was broken when we upgraded to 7.0.2).
* `%PROCESSOR_ARCHITECTURE%` needs to be ignored on `aarch64-windows-msvc` as well, not just `aarch64-windows-gnu`.
* The `LLVM_HOST_TARGET` variable can now be used to override the host's LLVM target triple when building the compiler with `Makefile.win`. This is needed when generating the `.build\crystal.res` resource file without `llvm-config.exe`. (This was previously missing for x64 builds too)