### PR TITLE
Codegen: use sret and memcpy for large aggregates

### DIFF
--- a/spec/compiler/codegen/return_spec.cr
+++ b/spec/compiler/codegen/return_spec.cr
@@ -123,9 +123,15 @@ describe "Code gen: return" do
       CRYSTAL
   end
 
-  it "returns large StaticArray through an sret pointer" do
+  it "returns large aggregates through an sret pointer" do
     mod = codegen(<<-CRYSTAL)
       struct StaticArray(T, N)
+      end
+
+      struct Big
+        def initialize
+          @x = uninitialized StaticArray(Int32, 20)
+        end
       end
 
       def make_arr
@@ -133,17 +139,50 @@ describe "Code gen: return" do
         arr
       end
 
-      def make_small
-        arr = uninitialized StaticArray(Int32, 16)
+      def make_big
+        Big.new
+      end
+
+      def make_nilable(x)
+        x ? make_arr : nil
+      end
+
+      def make_tuple
+        {make_arr, 1_i64}
+      end
+
+      def make_nine
+        arr = uninitialized StaticArray(Int64, 9)
         arr
       end
 
+      def make_small_arr
+        arr = uninitialized StaticArray(Int64, 8)
+        arr
+      end
+
+      def make_small_tuple
+        {1_i64, 2_i64, 3_i64}
+      end
+
       make_arr
-      make_small
+      make_big
+      make_nilable(true)
+      make_tuple
+      make_nine
+      make_small_arr
+      make_small_tuple
       CRYSTAL
     str = mod.to_s
+    nilable = %q(%"(StaticArray(Int32, 20) | Nil)")
+    tuple = %q(%"Tuple(StaticArray(Int32, 20), Int64)")
     str.should contain(%(#{fun_name "*make_arr:StaticArray(Int32, 20)"}(#{sret_param "[20 x i32]"} %0)))
-    str.should contain(%([16 x i32] #{fun_name "*make_small:StaticArray(Int32, 16)"}()))
+    str.should contain(%(#{fun_name "*make_big:Big"}(#{sret_param "%Big"} %0)))
+    str.should contain(%(#{fun_name "*make_nilable<Bool>:(StaticArray(Int32, 20) | Nil)"}(#{sret_param nilable} %0, i1 %x)))
+    str.should contain(%(#{fun_name "*make_tuple:Tuple(StaticArray(Int32, 20), Int64)"}(#{sret_param tuple} %0)))
+    str.should contain(%(#{fun_name "*make_nine:StaticArray(Int64, 9)"}(#{sret_param "[9 x i64]"} %0)))
+    str.should contain(%([8 x i64] #{fun_name "*make_small_arr:StaticArray(Int64, 8)"}()))
+    str.should contain(%(%"Tuple(Int64, Int64, Int64)" #{fun_name "*make_small_tuple:Tuple(Int64, Int64, Int64)"}()))
   end
 
   it "executes method returning large StaticArray" do

--- a/spec/compiler/codegen/return_spec.cr
+++ b/spec/compiler/codegen/return_spec.cr
@@ -1,5 +1,24 @@
 require "../../spec_helper"
 
+private def sret_param(type)
+  {% if LibLLVM::IS_LT_120 %}
+    "#{type}* sret"
+  {% elsif LibLLVM::IS_LT_150 %}
+    "#{type}* sret(#{type})"
+  {% else %}
+    "ptr sret(#{type})"
+  {% end %}
+end
+
+# Function names are mangled on MSVC (`CodeGenVisitor.safe_mangling`)
+private def fun_name(name)
+  {% if flag?(:msvc) %}
+    "@" + name.gsub(/[^A-Za-z0-9_]/) { |c| ".#{c[0].ord.to_s(16, upcase: true)}." }
+  {% else %}
+    %(@"#{name}")
+  {% end %}
+end
+
 describe "Code gen: return" do
   it "codegens return" do
     run("def foo; return 1; end; foo").to_i.should eq(1)
@@ -101,6 +120,338 @@ describe "Code gen: return" do
 
       v = foo
       v[3] &- v[2]
+      CRYSTAL
+  end
+
+  it "returns large StaticArray through an sret pointer" do
+    mod = codegen(<<-CRYSTAL)
+      struct StaticArray(T, N)
+      end
+
+      def make_arr
+        arr = uninitialized StaticArray(Int32, 20)
+        arr
+      end
+
+      def make_small
+        arr = uninitialized StaticArray(Int32, 16)
+        arr
+      end
+
+      make_arr
+      make_small
+      CRYSTAL
+    str = mod.to_s
+    str.should contain(%(#{fun_name "*make_arr:StaticArray(Int32, 20)"}(#{sret_param "[20 x i32]"} %0)))
+    str.should contain(%([16 x i32] #{fun_name "*make_small:StaticArray(Int32, 16)"}()))
+  end
+
+  it "executes method returning large StaticArray" do
+    run(<<-CRYSTAL).to_i.should eq(142)
+      struct StaticArray(T, N)
+        def to_unsafe
+          pointerof(@buffer)
+        end
+
+        def []=(i, v)
+          (to_unsafe + i).value = v
+        end
+
+        def [](i)
+          (to_unsafe + i).value
+        end
+      end
+
+      def make_arr(x)
+        arr = uninitialized StaticArray(Int32, 32)
+        arr[0] = x
+        arr[31] = 100
+        arr
+      end
+
+      a = make_arr(42)
+      a[0] &+ a[31]
+      CRYSTAL
+  end
+
+  it "executes struct method returning large StaticArray using self" do
+    run(<<-CRYSTAL).to_i.should eq(99)
+      struct StaticArray(T, N)
+        def to_unsafe
+          pointerof(@buffer)
+        end
+
+        def []=(i, v)
+          (to_unsafe + i).value = v
+        end
+
+        def [](i)
+          (to_unsafe + i).value
+        end
+      end
+
+      struct MyStruct
+        def initialize(@base : Int32)
+        end
+
+        def generate_array(offset)
+          arr = uninitialized StaticArray(Int32, 20)
+          arr[0] = @base &+ offset
+          arr
+        end
+      end
+
+      s = MyStruct.new(50)
+      arr = s.generate_array(49)
+      arr[0]
+      CRYSTAL
+  end
+
+  it "executes explicit return in method returning large StaticArray" do
+    run(<<-CRYSTAL).to_i.should eq(77)
+      struct StaticArray(T, N)
+        def to_unsafe
+          pointerof(@buffer)
+        end
+
+        def []=(i, v)
+          (to_unsafe + i).value = v
+        end
+
+        def [](i)
+          (to_unsafe + i).value
+        end
+      end
+
+      def make_arr(early : Bool)
+        arr = uninitialized StaticArray(Int32, 24)
+        if early
+          arr[0] = 77
+          return arr
+        end
+        arr[0] = 11
+        arr
+      end
+
+      make_arr(true)[0]
+      CRYSTAL
+  end
+
+  it "executes return from block in method returning large StaticArray" do
+    run(<<-CRYSTAL).to_i.should eq(42)
+      struct StaticArray(T, N)
+        def to_unsafe
+          pointerof(@buffer)
+        end
+
+        def []=(i, v)
+          (to_unsafe + i).value = v
+        end
+
+        def [](i)
+          (to_unsafe + i).value
+        end
+      end
+
+      def twice
+        yield 1
+        yield 2
+      end
+
+      def make_arr
+        arr = uninitialized StaticArray(Int32, 20)
+        twice do |i|
+          if i == 2
+            arr[0] = 42
+            return arr
+          end
+        end
+        arr[0] = 0
+        arr
+      end
+
+      make_arr[0]
+      CRYSTAL
+  end
+
+  it "executes method with captured block returning large StaticArray" do
+    run(<<-CRYSTAL).to_i.should eq(42)
+      struct StaticArray(T, N)
+        def to_unsafe
+          pointerof(@buffer)
+        end
+
+        def []=(i, v)
+          (to_unsafe + i).value = v
+        end
+
+        def [](i)
+          (to_unsafe + i).value
+        end
+      end
+
+      def make_arr(&block : Int32 -> Int32)
+        arr = uninitialized StaticArray(Int32, 20)
+        arr[0] = block.call(41)
+        arr
+      end
+
+      make_arr { |x| x &+ 1 }[0]
+      CRYSTAL
+  end
+
+  it "executes proc returning large StaticArray" do
+    run(<<-CRYSTAL).to_i.should eq(42)
+      struct StaticArray(T, N)
+        def to_unsafe
+          pointerof(@buffer)
+        end
+
+        def []=(i, v)
+          (to_unsafe + i).value = v
+        end
+
+        def [](i)
+          (to_unsafe + i).value
+        end
+      end
+
+      f = -> {
+        arr = uninitialized StaticArray(Int32, 20)
+        arr[0] = 42
+        arr
+      }
+      f.call[0]
+      CRYSTAL
+  end
+
+  it "executes method returning struct containing large StaticArray" do
+    run(<<-CRYSTAL).to_i.should eq(142)
+      struct StaticArray(T, N)
+        def to_unsafe
+          pointerof(@buffer)
+        end
+
+        def []=(i, v)
+          (to_unsafe + i).value = v
+        end
+
+        def [](i)
+          (to_unsafe + i).value
+        end
+      end
+
+      struct Big
+        def initialize(x : Int32)
+          @arr = uninitialized StaticArray(Int32, 32)
+          @arr[0] = x
+          @arr[31] = 100
+        end
+
+        def arr
+          @arr
+        end
+      end
+
+      def make_big(x)
+        Big.new(x)
+      end
+
+      b = make_big(42)
+      b.arr[0] &+ b.arr[31]
+      CRYSTAL
+  end
+
+  it "executes method returning nilable large StaticArray" do
+    run(<<-CRYSTAL).to_i.should eq(142)
+      struct StaticArray(T, N)
+        def to_unsafe
+          pointerof(@buffer)
+        end
+
+        def []=(i, v)
+          (to_unsafe + i).value = v
+        end
+
+        def [](i)
+          (to_unsafe + i).value
+        end
+      end
+
+      def find_arr(x)
+        if x
+          arr = uninitialized StaticArray(Int32, 32)
+          arr[0] = 42
+          arr[31] = 100
+          arr
+        end
+      end
+
+      sum = 0
+      if a = find_arr(true)
+        sum &+= a[0] &+ a[31]
+      end
+      if b = find_arr(false)
+        sum &+= b[0]
+      end
+      sum
+      CRYSTAL
+  end
+
+  it "executes multidispatch returning large StaticArray" do
+    run(<<-CRYSTAL).to_i.should eq(3)
+      struct StaticArray(T, N)
+        def to_unsafe
+          pointerof(@buffer)
+        end
+
+        def []=(i, v)
+          (to_unsafe + i).value = v
+        end
+
+        def [](i)
+          (to_unsafe + i).value
+        end
+      end
+
+      class Foo
+        def make
+          arr = uninitialized StaticArray(Int32, 20)
+          arr[0] = 1
+          arr
+        end
+      end
+
+      class Bar < Foo
+        def make
+          arr = uninitialized StaticArray(Int32, 20)
+          arr[0] = 2
+          arr
+        end
+      end
+
+      foo = 1 == 1 ? Foo.new : Bar.new
+      bar = 1 == 1 ? Bar.new : Foo.new
+      foo.make[0] &+ bar.make[0]
+      CRYSTAL
+  end
+
+  it "codegens method returning large StaticArray with debug info" do
+    codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
+      struct StaticArray(T, N)
+      end
+
+      struct MyStruct
+        def initialize(@x : Int32)
+        end
+
+        def make(y)
+          arr = uninitialized StaticArray(Int32, 20)
+          arr
+        end
+      end
+
+      MyStruct.new(1).make(2)
       CRYSTAL
   end
 end

--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -13,6 +13,42 @@ describe "StaticArray" do
     a[0].should eq(1)
     a[1].should eq(1)
     a[2].should eq(1)
+
+    zeros = StaticArray(Int32, 64).new 0
+    zeros.each { |x| x.should eq(0) }
+
+    nils = StaticArray(Nil, 32).new nil
+    nils.each { |x| x.should be_nil }
+
+    falses = StaticArray(Bool, 32).new false
+    falses.each { |x| x.should be_false }
+
+    trues = StaticArray(Bool, 32).new true
+    trues.each { |x| x.should be_true }
+
+    bytes = StaticArray(UInt8, 128).new 42_u8
+    bytes.each { |x| x.should eq(42_u8) }
+
+    i8s = StaticArray(Int8, 128).new -5_i8
+    i8s.each { |x| x.should eq(-5_i8) }
+
+    single_zero = StaticArray(Int32, 1).new 0
+    single_zero[0].should eq(0)
+
+    single_byte = StaticArray(UInt8, 1).new 99_u8
+    single_byte[0].should eq(99_u8)
+
+    large_zero = StaticArray(Int64, 1024).new 0_i64
+    large_zero.all?(&.zero?).should be_true
+
+    floats = StaticArray(Float64, 32).new 0.0_f64
+    floats.each { |x| x.should eq(0.0_f64) }
+
+    chars = StaticArray(Char, 16).new 'x'
+    chars.each { |c| c.should eq('x') }
+
+    tuples = StaticArray(NamedTuple(x: Int32, y: Int32), 10).new({x: 1, y: 2})
+    tuples.each { |p| p.should eq({x: 1, y: 2}) }
   end
 
   it "creates with new and block" do

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -508,6 +508,12 @@ class Crystal::CodeGenVisitor
     # using the original invocation
     set_current_debug_location node if @debug.line_numbers? && fun_type.nil?
 
+    # The `sret` slot goes before all other arguments, `self` included
+    if target_def && internal_sret?(target_def)
+      sret_pointer = alloca llvm_type(target_def.type)
+      call_args = [sret_pointer] + call_args
+    end
+
     if raises && (rescue_block = @rescue_block)
       invoke_out_block = new_block "invoke_out"
       @last = invoke func, call_args, invoke_out_block, rescue_block
@@ -563,7 +569,9 @@ class Crystal::CodeGenVisitor
       when .no_return?
         unreachable
       when .passed_by_value?
-        if @needs_value
+        if sret_pointer
+          @last = sret_pointer
+        elsif @needs_value
           union = alloca llvm_type(type)
           store @last, union
           @last = union
@@ -579,6 +587,8 @@ class Crystal::CodeGenVisitor
   def set_call_attributes(node : Call, target_def, self_type, is_closure, fun_type)
     if external = target_def.c_calling_convention?
       set_call_attributes_external(node, external)
+    elsif internal_sret?(target_def)
+      @last.add_instruction_attribute(1, LLVM::Attribute::StructRet, llvm_context, llvm_type(target_def.type))
     else
       # Non-external methods/functions have no arguments attributes
     end
@@ -630,5 +640,11 @@ class Crystal::CodeGenVisitor
 
   def sret?(abi_info)
     abi_info.return_type.attr == LLVM::Attribute::StructRet
+  end
+
+  # Externals follow the C ABI (`abi_info`) and primitives are inlined at
+  # their call sites, so neither uses `sret`
+  def internal_sret?(target_def : Def) : Bool
+    !target_def.c_calling_convention? && !target_def.body.is_a?(Primitive) && large_aggregate?(target_def.type?)
   end
 end

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -79,7 +79,7 @@ class Crystal::CodeGenVisitor
       if target_type.nil_type?
         value
       else
-        store to_rhs(value, target_type), target_pointer
+        store_lhs value, target_type, target_pointer
       end
     else
       assign_distinct target_pointer, target_type, value_type, value
@@ -138,7 +138,7 @@ class Crystal::CodeGenVisitor
         casted_value = cast_to_pointer(union_value_ptr, type_needing_cast)
         compatible_ptr = alloca llvm_compatible_type
         assign(compatible_ptr, compatible_type, type_needing_cast, casted_value)
-        store_in_union target_type, target_pointer, compatible_type, load(llvm_compatible_type, compatible_ptr)
+        store_in_union target_type, target_pointer, compatible_type, compatible_ptr
         br exit_label
 
         position_at_end doesnt_match_label
@@ -191,7 +191,6 @@ class Crystal::CodeGenVisitor
       end
     end
 
-    value = to_rhs(value, value_type)
     store_in_union target_type, target_pointer, value_type, value
   end
 
@@ -460,8 +459,7 @@ class Crystal::CodeGenVisitor
       value_ptr = aggregate_index(value_struct_type, value, index)
       loaded_value = to_lhs(value_ptr, value_tuple_type)
       downcasted_value = downcast(loaded_value, target_tuple_type, value_tuple_type, true)
-      downcasted_value = to_rhs(downcasted_value, target_tuple_type)
-      store downcasted_value, target_ptr
+      store_lhs downcasted_value, target_tuple_type, target_ptr
       index += 1
     end
     target_pointer
@@ -478,8 +476,7 @@ class Crystal::CodeGenVisitor
       target_index = to_type.name_index(entry.name).not_nil!
       target_index_type = to_type.name_type(entry.name)
       downcasted_value = downcast(value_at_index, target_index_type, entry.type, true)
-      downcasted_value = to_rhs(downcasted_value, target_index_type)
-      store downcasted_value, aggregate_index(target_struct_type, target_pointer, target_index)
+      store_lhs downcasted_value, target_index_type, aggregate_index(target_struct_type, target_pointer, target_index)
     end
     target_pointer
   end
@@ -648,7 +645,7 @@ class Crystal::CodeGenVisitor
     end
 
     union_ptr = alloca(llvm_type(to_type))
-    store_in_union(to_type, union_ptr, from_type, to_rhs(value, from_type))
+    store_in_union(to_type, union_ptr, from_type, value)
     union_ptr
   end
 

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2516,12 +2516,25 @@ module Crystal
     end
 
     # LLVM handles aggregate values one scalar at a time, so compile time grows
-    # with the element count (#2485). Such values are copied with `memcpy` and
-    # returned through an `sret` pointer instead.
+    # with the element count (#2485), and AArch64 and x86-64 return at most 8
+    # scalars in registers anyway. Bigger aggregates are copied with `memcpy`
+    # and returned through an `sret` pointer instead.
+    MAX_AGGREGATE_SCALARS = 8
+
     def large_aggregate?(type : Type?) : Bool
-      return false unless type
-      type = type.remove_typedef
-      type.is_a?(StaticArrayInstanceType) && type.size.as(NumberLiteral).value.to_i > 16
+      return false unless type && type.passed_by_value?
+      scalar_count(llvm_type(type)) > MAX_AGGREGATE_SCALARS
+    end
+
+    private def scalar_count(llvm_type : LLVM::Type) : Int64
+      case llvm_type.kind
+      when LLVM::Type::Kind::Struct
+        llvm_type.struct_element_types.sum(0_i64) { |element_type| scalar_count(element_type) }
+      when LLVM::Type::Kind::Array
+        llvm_type.array_size.to_i64 * scalar_count(llvm_type.element_type)
+      else
+        1_i64
+      end
     end
 
     def extern_to_lhs(value, type)

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -888,6 +888,9 @@ module Crystal
         ret
       elsif method_type.no_return?
         unreachable
+      elsif sret_pointer = context.sret_pointer
+        store_lhs upcast(@last, method_type, type), method_type, sret_pointer
+        ret
       else
         value = upcast(@last, method_type, type)
         ret to_rhs(value, method_type)
@@ -2147,9 +2150,7 @@ module Crystal
 
         if self_closured
           offset = parent_closure_type ? 1 : 0
-          self_value = to_rhs(llvm_self, current_context.type)
-
-          store self_value, gep(closure_type, closure_ptr, 0, closure_vars.size + offset, "self")
+          store_lhs llvm_self, current_context.type, gep(closure_type, closure_ptr, 0, closure_vars.size + offset, "self")
 
           current_context.closure_self = current_context.type
         end
@@ -2501,6 +2502,26 @@ module Crystal
 
     def to_rhs(value, type)
       type.passed_by_value? ? load(llvm_embedded_type(type), value) : value
+    end
+
+    # Stores the value of *type* held by *value* (a pointer if *type* is
+    # passed by value, see `to_lhs`) into *pointer*
+    def store_lhs(value, type, pointer)
+      if large_aggregate?(type)
+        llvm_type = llvm_type(type)
+        memcpy cast_to_void_pointer(pointer), cast_to_void_pointer(value), size_t(@llvm_typer.size_of(llvm_type)), @llvm_typer.align_of(llvm_type), int1(0)
+      else
+        store to_rhs(value, type), pointer
+      end
+    end
+
+    # LLVM handles aggregate values one scalar at a time, so compile time grows
+    # with the element count (#2485). Such values are copied with `memcpy` and
+    # returned through an `sret` pointer instead.
+    def large_aggregate?(type : Type?) : Bool
+      return false unless type
+      type = type.remove_typedef
+      type.is_a?(StaticArrayInstanceType) && type.size.as(NumberLiteral).value.to_i > 16
     end
 
     def extern_to_lhs(value, type)

--- a/src/compiler/crystal/codegen/context.cr
+++ b/src/compiler/crystal/codegen/context.cr
@@ -9,6 +9,7 @@ class Crystal::CodeGenVisitor
     property vars : Hash(String, LLVMVar)
     property return_type : Type?
     property return_phi : Phi?
+    property sret_pointer : LLVM::Value?
     property break_phi : Phi?
     property next_phi : Phi?
     property while_block : LLVM::BasicBlock?
@@ -41,6 +42,7 @@ class Crystal::CodeGenVisitor
       context = Context.new @fun, @fun_type, @type, @vars
       context.return_type = @return_type
       context.return_phi = @return_phi
+      context.sret_pointer = @sret_pointer
       context.break_phi = @break_phi
       context.next_phi = @next_phi
       context.while_block = @while_block

--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -81,6 +81,7 @@ class Crystal::CodeGenVisitor
       context.type = self_type
       context.vars = LLVMVars.new
       context.block_context = nil
+      context.sret_pointer = nil
 
       @llvm_mod = fun_module_info.mod
       @llvm_context = @llvm_mod.context
@@ -127,7 +128,9 @@ class Crystal::CodeGenVisitor
         end
 
         if !is_fun_literal && self_type.passed_as_self?
-          context.vars["self"] = LLVMVar.new(context.fun.params.first, self_type, true)
+          # `self` comes right after the `sret` pointer, if there is one
+          self_index = context.sret_pointer ? 1 : 0
+          context.vars["self"] = LLVMVar.new(context.fun.params[self_index], self_type, true)
         end
 
         if is_closure
@@ -149,10 +152,10 @@ class Crystal::CodeGenVisitor
             context.vars.each do |name, var|
               next if var.debug_variable_created
 
-              # Self always comes as the first parameter, unless it's a closure:
-              # then it will be fetched from the closure data.
+              # Self always comes first (after the `sret` pointer, if any), unless
+              # it's a closure: then it will be fetched from the closure data.
               if name == "self" && !is_closure
-                declare_debug_for_function_argument(name, var.type, 1, var.pointer, location)
+                declare_debug_for_function_argument(name, var.type, context.sret_pointer ? 2 : 1, var.pointer, location)
                 # Method debug parameters are skipped as they were defined in create_local_copy_of_fun_args()
                 # due to LLVM variable dominance issue in some closure cases
               elsif args.none? { |arg| arg.name == name }
@@ -316,12 +319,6 @@ class Crystal::CodeGenVisitor
       llvm_arg_type
     end
 
-    llvm_return_type = {% if LibLLVM::IS_LT_150 %}
-                         llvm_return_type(target_def.type)
-                       {% else %}
-                         target_def.llvm_intrinsic? ? llvm_intrinsic_return_type(target_def.type) : llvm_return_type(target_def.type)
-                       {% end %}
-
     if is_closure
       llvm_args_types.insert(0, llvm_context.void_pointer)
       offset = 1
@@ -329,7 +326,26 @@ class Crystal::CodeGenVisitor
       offset = 0
     end
 
+    # Fun literals must match `llvm_proc_type`, so they never use `sret`
+    if !is_fun_literal && internal_sret?(target_def)
+      sret_type = llvm_type(target_def.type)
+      llvm_args_types.insert(0, sret_type.pointer)
+      offset += 1
+      llvm_return_type = llvm_context.void
+    else
+      llvm_return_type = {% if LibLLVM::IS_LT_150 %}
+                           llvm_return_type(target_def.type)
+                         {% else %}
+                           target_def.llvm_intrinsic? ? llvm_intrinsic_return_type(target_def.type) : llvm_return_type(target_def.type)
+                         {% end %}
+    end
+
     setup_context_fun(mangled_name, target_def, llvm_args_types, llvm_return_type)
+
+    if sret_type
+      context.fun.add_attribute(LLVM::Attribute::StructRet, 1, sret_type)
+      context.sret_pointer = context.fun.params.first
+    end
 
     if @debug.variables?
       context.fun_debug_params.clear
@@ -528,7 +544,7 @@ class Crystal::CodeGenVisitor
     offset = is_closure ? 1 : 0
 
     abi_info = target_def.abi_info? ? abi_info(target_def) : nil
-    sret = abi_info && sret?(abi_info)
+    sret = (abi_info && sret?(abi_info)) || context.sret_pointer
     offset += 1 if sret
 
     target_def_vars = target_def.vars

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -76,7 +76,7 @@ module Crystal
       struct_type = llvm_type(union_type)
       store type_id(value, value_type), union_type_id(struct_type, union_pointer)
       casted_value_ptr = cast_to_pointer(union_value(struct_type, union_pointer), value_type)
-      store value, casted_value_ptr
+      store_lhs value, value_type, casted_value_ptr
     end
 
     def store_bool_in_union(target_type, union_pointer, value)
@@ -149,7 +149,7 @@ module Crystal
         # - cast the target pointer to Pointer(A | B)
         # - store the A | B from the value pointer into the casted target pointer
         casted_target_pointer = cast_to_pointer to_pointer, from_type
-        store load(llvm_type(from_type), from_pointer), casted_target_pointer
+        store_lhs from_pointer, from_type, casted_target_pointer
       else
         # Otherwise, the type ID and the value must be stored separately
         store_union_in_union to_type, to_pointer, from_type, from_pointer

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -78,7 +78,9 @@ struct StaticArray(T, N)
   # StaticArray(Int32, 3).new(42) # => StaticArray[42, 42, 42]
   # ```
   def self.new(value : T)
-    new { value }
+    array = uninitialized self
+    array.to_unsafe.fill(N, value)
+    array
   end
 
   # Disallow creating an uninitialized StaticArray with new.


### PR DESCRIPTION
Fixes #2485

Disclosure: generated and reviewed with Gemini 3.8 Flash and Claude Fable 5.1.

Methods returning an aggregate with more than 8 scalar elements (structs, tuples, named tuples, unions, `StaticArray`) now use the `sret` calling convention, and every copy of such a value is an `llvm.memcpy` instead of an aggregate `load`/`store`. LLVM processes aggregate values one scalar at a time, so compile time grew far faster than the size in `--release`. Values with 8 scalars or fewer (`Int32?`, `Time`, `{Int64, Int64, Int64}`, ...) keep the existing codegen: the backends Crystal targets return at most 8 scalars in registers (AArch64 8, x86-64 3), so past that a by-value return already goes through memory. External funs (C ABI via `#abi_info`) and procs (`llvm_proc_type`) are unchanged.

`StaticArray.new(value)` additionally fills through `Pointer#fill`, which already uses `memset` for `UInt8` and `clear` for zero numbers. It calls `Pointer#fill` directly rather than `StaticArray#fill`, because the latter reaches `Slice#check_writable` from inside the `raise` machinery on Windows (`Path#to_windows` → `String#tr`), which trips a latent cleanup-pass bug: a method typed while `raise` is still being typed loses its `raises?` flag, and `rescue` around it stops catching. That compiler bug is reported separately.

Commits: (1) `sret` for `StaticArray` over 16 elements, (2) `StaticArray.new(value)` via `Pointer#fill`, (3) generalize to all aggregates over 8 scalars, a two-file change on top of (1).

## Codegen

- `CodeGenVisitor#large_aggregate?` is the single predicate and `#store_lhs` the single copy helper (`memcpy` or `store to_rhs`), used by `assign`, `store_in_union`, union assignment, tuple casts, closure `self` capture and `codegen_return`.
- `#internal_sret?` decides a def's calling convention; `codegen_fun_signature_non_external` adds the hidden parameter and records it as `Context#sret_pointer`; `codegen_call_or_invoke` allocates and passes the result slot, so inlined calls, blocks and multidispatch need nothing special.
- Debug info keeps the logical return type; `self` becomes parameter 2.

```llvm
; before
define internal [16384 x i32] @"*make_arr:StaticArray(Int32, 16384)"()
  %1 = call [16384 x i32] @"*make_arr:StaticArray(Int32, 16384)"()
  store [16384 x i32] %1, ptr %a, align 4

; after
define internal void @"*make_arr:StaticArray(Int32, 16384)"(ptr sret([16384 x i32]) %0)
  call void @"*make_arr:StaticArray(Int32, 16384)"(ptr sret([16384 x i32]) %1)
  call void @llvm.memcpy.p0.p0.i64(ptr %a, ptr %1, i64 65536, i1 false)
```

## Benchmarks

Apple M2 (performance cores, verified against the efficiency-core clamp), LLVM 22.1.6, release-built compiler per commit, clean cache per run, best of 2. Every program printed the same result under every compiler.

### Compile time

`Codegen (bc+obj)` in `--release` for one method returning the type; the rest of `crystal build` adds a constant 0.5s.

| Return type | N = 4,096 | N = 8,192 | N = 16,384 | this PR, every N |
|---|---|---|---|---|
| `StaticArray(Int32, N)` | 3.7s | 7.4s | 20.1s | 2.6–2.7s |
| struct with a `StaticArray(Int32, N)` field | 37.8s | 258s | >200s | 2.6–2.7s |
| `StaticArray(Int32, N) \| Nil` | 3.5s | 39.9s | >200s | 2.6–2.7s |
| `{StaticArray(Int32, N/2), StaticArray(Int32, N/2)}` | 9.2s | 43.7s | >200s | 2.6–2.7s |

Commit 1 alone fixes only the first row; commit 2 does not touch the compiler and measured identically to commit 1. Debug builds show the same shape at a smaller scale (1.2s to 2.9s → 0.3s at N = 16,384). Building the compiler itself is unchanged: 165s → 158s in release, 16s in debug.

### Runtime

`@[NoInline]` methods, `--release`, N = 4,096:

| Return type | master | this PR |
|---|---|---|
| `StaticArray(Int32, N)` | 554ns | 2.4ns |
| struct with a `StaticArray(Int32, N)` field | 1.38µs | 162ns |
| `StaticArray(Int32, N) \| Nil` | 742ns | 214ns |
| `{StaticArray(Int32, N/2), StaticArray(Int32, N/2)}` | 1.79µs | 7.1ns |

The cutoff counts scalars, not bytes. A two-word byte cutoff was tried first and made small values that used to return in registers slower when not inlined:

| Return type | master | 2-word bytes (rejected) | >8 scalars |
|---|---|---|---|
| `{Int64, Int64, Int64}` | 2.56ns | 7.84ns | 2.55ns |
| `Range(Int64, Int64)` | 2.60ns | 4.14ns | 2.54ns |
| `Time` | 10.9ns | 11.3ns | 10.4ns |

Stdlib code with medium-sized values (`Time`, `Time?`, `JSON::Any`, `Char::Reader`, `Hash(String, Time)`, `Array(Time)#sort`) is unchanged within noise in both modes.

`StaticArray(Int32, 1024).new(0)` goes from 393ns to 40ns in `--release`; that comes from `sret` (commit 1), and `new(7)` gains the same. Filling through `Pointer#fill` (commit 2) matters in non-release builds only: 2.45µs → 153ns for that case, 8.8µs → 148ns for `StaticArray(UInt8, 4096).new(42_u8)`.

## Tests

Codegen specs (1807), primitives specs (716) and std specs (18148, minus 6 macOS iconv/`$PATH` failures also on master) pass with a compiler built from the branch (on the current master), and that compiler bootstraps. The codegen specs also pass with LLVM 14, the typed-pointer path CI covers. The Windows `slice_spec` and `static_array_spec`, cross-compiled for `x86_64-windows-gnu` and run under Wine, pass. New specs in `spec/compiler/codegen/return_spec.cr` cover the IR for each shape and the 8-scalar boundary, and execute returns through `self`, explicit `return`, `return` from blocks, captured blocks, procs, multidispatch and nilable results.
