### PR TITLE
Remove obsolete `FIXME`s for array literal parsing

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -3184,9 +3184,9 @@ module Crystal
         "/"   => "Unterminated regular expression",
         "%x[" => "Unterminated command literal",
         "`"   => "Unterminated command literal",
-        "%w[" => "Unterminated string array literal", # FIXME: #12277
-        "%W[" => "Unterminated string array literal", # FIXME: #12277
-        "%i[" => "Unterminated symbol array literal", # FIXME: #12277
+        "%w[" => "Unterminated string array literal",
+        "%W[" => "Unterminated string array literal",
+        "%i[" => "Unterminated symbol array literal",
         ":\"" => "unterminated quoted symbol",
       }
     end


### PR DESCRIPTION
#12277 has already been merged and the parsing behaviour is correct.
I believe the FIXMEs were incorrect from the beginning.