### PR TITLE
Fix: enqueue thread once into thread pool

### DIFF
--- a/src/fiber/execution_context/thread_pool.cr
+++ b/src/fiber/execution_context/thread_pool.cr
@@ -128,7 +128,12 @@ class Fiber
             end
 
             @mutex.synchronize do
-              @pool.push pointerof(parked)
+              # pthread_cond_wait happens to return zero without being signaled
+              # (Darwin targets at least), so we make sure to only add the
+              # thread to the pool once:
+              unless parked.linked?
+                @pool.push pointerof(parked)
+              end
             end
 
             if thread == @main_thread || {% flag?(:win32) && Crystal::EventLoop.has_constant?(:IOCP) %}


### PR DESCRIPTION
I thought that the only possibility for a mutex deadlock was for the thread to dequeue itself, but that was impossible. Right?

On macOS `pthread_cond_wait` can return zero without the condition variable being signaled (or broadcasted).

The thread's loop was checking the predicate (is there a scheduler?) but wasn't checking whether the thread was already in the pool, which leads to add the same thread multiple times, messing up the linked list, leading to impossible situations.

Fixes #17165