### PR TITLE
Fix: loopback interface may not be the first interface

### DIFF
--- a/spec/std/socket/address_spec.cr
+++ b/spec/std/socket/address_spec.cr
@@ -145,15 +145,19 @@ describe Socket::IPAddress do
     end
 
     it "looks up loopback interface index by name" do
+      # loopback interface is usually the first interface, but sometimes it's not
+      zone_id = Crystal::System::Socket.network_interface_to_index(loopback_iface) { pending! }
+
       address = Socket::IPAddress.new("fe80::1111%#{loopback_iface}", 0)
       address.address.should eq "fe80::1111"
-      address.zone_id.should eq 1
+      address.zone_id.should eq zone_id
     end
 
     it "looks up loopback interface name by index" do
-      # loopback interface "lo" is supposed to *always* be the first interface and
-      # enumerated with index 1
-      address = Socket::IPAddress.new("fe80::1111%#{loopback_iface}", 0)
+      # loopback interface is usually the first interface, but sometimes it's not
+      zone_id = Crystal::System::Socket.network_interface_to_index(loopback_iface) { pending! }
+
+      address = Socket::IPAddress.new("fe80::1111%#{zone_id}", 0)
       address.link_local_interface.should eq loopback_iface
     end
 

--- a/spec/std/socket/address_spec.cr
+++ b/spec/std/socket/address_spec.cr
@@ -146,7 +146,9 @@ describe Socket::IPAddress do
 
     it "looks up loopback interface index by name" do
       # loopback interface is usually the first interface, but sometimes it's not
-      zone_id = Crystal::System::Socket.network_interface_to_index(loopback_iface) { pending! }
+      zone_id = Crystal::System::Socket.network_interface_to_index(loopback_iface) do |error|
+        raise RuntimeError.from_os_error("Failed to lookup #{loopback_iface} network interface", error)
+      end
 
       address = Socket::IPAddress.new("fe80::1111%#{loopback_iface}", 0)
       address.address.should eq "fe80::1111"
@@ -155,7 +157,9 @@ describe Socket::IPAddress do
 
     it "looks up loopback interface name by index" do
       # loopback interface is usually the first interface, but sometimes it's not
-      zone_id = Crystal::System::Socket.network_interface_to_index(loopback_iface) { pending! }
+      zone_id = Crystal::System::Socket.network_interface_to_index(loopback_iface) do |error|
+        raise RuntimeError.from_os_error("Failed to lookup #{loopback_iface} network interface", error)
+      end
 
       address = Socket::IPAddress.new("fe80::1111%#{zone_id}", 0)
       address.link_local_interface.should eq loopback_iface


### PR DESCRIPTION
Fixes spec failures in my FreeBSD VM where the lo0 interface is defined _after_ the vtnet0 interface.