### PR TITLE
Always ignore `%PROCESSOR_ARCHITECTURE%` when running `Process` specs on MSVC

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -452,6 +452,11 @@ describe Process do
         value = Process.run(exe, ["pu", "env"], clear_env: true) do |proc|
           proc.output.gets_to_end
         end
+
+        {% if flag?(:win32) %}
+          # Ignore `PROCESSOR_ARCHITECTURE` which WOW64 might inject.
+          value = value.gsub(/^(PATH|PROCESSOR_ARCHITECTURE)=.*\n/m, "")
+        {% end %}
         value.should eq("")
       end
 
@@ -466,8 +471,8 @@ describe Process do
           proc.output.gets_to_end
         end
 
-        {% if flag?(:win32) && flag?(:gnu) %}
-          # Ignore `PATH` (added above) and `PROCESSOR_ARCHITECTURE` which ucrt
+        {% if flag?(:win32) %}
+          # Ignore `PATH` (added above) and `PROCESSOR_ARCHITECTURE` which WOW64
           # might inject.
           value = value.gsub(/^(PATH|PROCESSOR_ARCHITECTURE)=.*\n/m, "")
         {% end %}


### PR DESCRIPTION
This environment variable is injected by the [WOW64 emulator](https://learn.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details#environment-variables), and it appears that ARM64 subprocesses created by ARM64 parent processes always have this variable injected.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>