### PR TITLE
Drop `Process.fork`

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -1122,25 +1122,6 @@ describe Process do
     end
   {% end %}
 
-  {% if flag?(:without_mt) && !flag?(:win32) %}
-    describe ".fork" do
-      it "executes the new process with exec" do
-        with_tempfile("crystal-spec-exec") do |path|
-          File.exists?(path).should be_false
-
-          fork = Process.fork do
-            Process.exec("/usr/bin/env", {"touch", path})
-          end
-          fork.wait
-
-          File.exists?(path).should be_true
-        end
-      end
-
-      typeof(Process.fork)
-    end
-  {% end %}
-
   describe ".exec" do
     it "redirects STDIN and STDOUT to files", tags: %w[slow] do
       with_tempfile("crystal-exec-stdin", "crystal-exec-stdout") do |stdin_path, stdout_path|

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -376,7 +376,7 @@ module Crystal
 
       {% if LibLLVM::IS_LT_170 %}
         # initialize the legacy pass manager once in the main thread/process
-        # before we start codegen in threads (MT) or processes (fork)
+        # before we start codegen in threads (MT)
         init_llvm_legacy_pass_manager unless optimization_mode.o0?
       {% end %}
 

--- a/src/crystal/event_loop/epoll.cr
+++ b/src/crystal/event_loop/epoll.cr
@@ -19,31 +19,6 @@ class Crystal::EventLoop::Epoll < Crystal::EventLoop::Polling
     @epoll.add(@timerfd.fd, LibC::EPOLLIN, u64: @timerfd.fd.to_u64!)
   end
 
-  {% if flag?(:without_mt) %}
-    def after_fork : Nil
-      super
-
-      # close inherited fds
-      @epoll.close
-      @eventfd.close
-      @timerfd.close
-
-      # create new fds
-      @epoll = System::Epoll.new
-
-      @interrupted.set(false, :relaxed)
-      @eventfd = System::EventFD.new
-      @epoll.add(@eventfd.fd, LibC::EPOLLIN, u64: @eventfd.fd.to_u64!)
-
-      @timerfd = System::TimerFD.new
-      @epoll.add(@timerfd.fd, LibC::EPOLLIN, u64: @timerfd.fd.to_u64!)
-      system_set_timer(@timers.next_ready?)
-
-      # re-add all registered fds
-      Polling.arena.each_index { |fd, index| system_add(fd, index) }
-    end
-  {% end %}
-
   private def system_run(blocking : Bool, & : Fiber ->) : Nil
     Crystal.trace :evloop, "run", blocking: blocking
 

--- a/src/crystal/event_loop/io_uring.cr
+++ b/src/crystal/event_loop/io_uring.cr
@@ -214,11 +214,6 @@ class Crystal::EventLoop::IoUring < Crystal::EventLoop
     @mutex = Thread::Mutex.new
   end
 
-  {% if flag?(:without_mt) %}
-    def after_fork : Nil
-    end
-  {% end %}
-
   private def ring : Ring
     {% if !flag?(:without_mt) && !flag?(:preview_mt) || flag?(:execution_context) %}
       Fiber::ExecutionContext::Scheduler.current.__evloop_ring

--- a/src/crystal/event_loop/kqueue.cr
+++ b/src/crystal/event_loop/kqueue.cr
@@ -19,28 +19,6 @@ class Crystal::EventLoop::Kqueue < Crystal::EventLoop::Polling
       LibC::EV_ADD | LibC::EV_ENABLE | LibC::EV_CLEAR)
   end
 
-  {% if flag?(:without_mt) %}
-    def after_fork : Nil
-      super
-
-      # kqueue isn't inherited by fork on darwin/dragonfly, but we still close
-      @kqueue.close
-      @kqueue = System::Kqueue.new
-
-      @interrupted.set(false, :relaxed)
-
-      @kqueue.kevent(
-        INTERRUPT_IDENTIFIER,
-        LibC::EVFILT_USER,
-        LibC::EV_ADD | LibC::EV_ENABLE | LibC::EV_CLEAR)
-
-      system_set_timer(@timers.next_ready?)
-
-      # re-add all registered fds
-      Polling.arena.each_index { |fd, index| system_add(fd, index) }
-    end
-  {% end %}
-
   private def system_run(blocking : Bool, & : Fiber ->) : Nil
     buffer = uninitialized LibC::Kevent[128]
 

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -17,13 +17,6 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
   def initialize(parallelism : Int32)
   end
 
-  {% if flag?(:without_mt) %}
-    # Reinitializes the event loop after a fork.
-    def after_fork : Nil
-      event_base.reinit
-    end
-  {% end %}
-
   def run(blocking : Bool) : Bool
     flags = LibEvent2::EventLoopFlags::Once
     flags |= blocking ? LibEvent2::EventLoopFlags::NoExitOnEmpty : LibEvent2::EventLoopFlags::NonBlock

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -108,13 +108,6 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
   @timers_lock = SpinLock.new
   @timers = Timers(Event).new
 
-  {% if flag?(:without_mt) %}
-    # no parallelism issues, but let's clean-up anyway
-    def after_fork : Nil
-      @timers_lock = SpinLock.new
-    end
-  {% end %}
-
   # thread unsafe
   def run(blocking : Bool) : Bool
     system_run(blocking, &.enqueue)

--- a/src/crystal/system/process.cr
+++ b/src/crystal/system/process.cr
@@ -69,10 +69,6 @@ struct Crystal::System::Process
   # Measures CPU times.
   # def self.times : ::Process::Tms
 
-  # Duplicates the current process.
-  # def self.fork : ProcessInformation
-  # def self.fork(&)
-
   # def prepare_args(command : String, args : Enumerable(String)?, shell : Bool) : Args
   # def prepare_args(args : Enumerable(String)) : Args
 

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -204,34 +204,6 @@ struct Crystal::System::Process
     {% end %}
   end
 
-  # Only used by deprecated `::Process.fork`
-  def self.fork
-    {% raise("Process fork is unsupported with multithreaded mode") unless flag?(:without_mt) %}
-
-    pid, errno = lock_write do
-      pthread_disable_cancelstate do
-        block_signals do
-          pid = LibC.fork
-          {pid, Errno.value}
-        end
-      end
-    end
-
-    case pid
-    when 0
-      # forked process
-      ::Process.after_fork_child_callbacks.each(&.call)
-
-      nil
-    when -1
-      # forking process: error
-      raise RuntimeError.from_os_error("fork", errno)
-    else
-      # forking process: success
-      pid
-    end
-  end
-
   private def self.block_signals(&)
     newmask = uninitialized LibC::SigsetT
     oldmask = uninitialized LibC::SigsetT
@@ -267,26 +239,6 @@ struct Crystal::System::Process
         LibC.pthread_setcancelstate(cancel_state, nil)
       end
     {% end %}
-  end
-
-  # Duplicates the current process.
-  # Returns a `Process` representing the new child process in the current process
-  # and `nil` inside the new child process.
-  # Only used by deprecated `::Process.fork(&)` and compiler `fork_codegen`
-  def self.fork(&)
-    pid = fork
-    return pid if pid
-
-    begin
-      yield
-      LibC._exit 0
-    rescue ex
-      ex.inspect_with_backtrace STDERR
-      STDERR.flush
-      LibC._exit 1
-    ensure
-      LibC._exit 254 # not reached
-    end
   end
 
   def self.prepare_args(command : String, args : Enumerable(String)?, shell : Bool) : {String, LibC::Char**}

--- a/src/crystal/system/unix/signal.cr
+++ b/src/crystal/system/unix/signal.cr
@@ -114,17 +114,6 @@ module Crystal::System::Signal
     end
   end
 
-  # Replaces the signal pipe so the child process won't share the file
-  # descriptors of the parent process and send it received signals.
-  def self.after_fork
-    @@pipe.each do |pipe_io|
-      Crystal::EventLoop.remove(pipe_io)
-      pipe_io.file_descriptor_close { }
-    end
-  ensure
-    @@pipe = IO.pipe(read_blocking: false, write_blocking: true)
-  end
-
   # Resets signal handlers to `SIG_DFL`. This avoids the child to receive
   # signals that would be sent to the parent process through the signal
   # pipe.
@@ -327,11 +316,5 @@ module Crystal::System::SignalChildHandler
         end
       end
     end
-  end
-
-  def self.after_fork
-    @@pending.clear
-    @@waiting.each_value(&.close)
-    @@waiting.clear
   end
 end

--- a/src/crystal/system/wasi/process.cr
+++ b/src/crystal/system/wasi/process.cr
@@ -80,14 +80,6 @@ struct Crystal::System::Process
     raise NotImplementedError.new("Process.times")
   end
 
-  def self.fork
-    raise NotImplementedError.new("Process.fork")
-  end
-
-  def self.fork(&)
-    raise NotImplementedError.new("Process.fork")
-  end
-
   def self.spawn(command, args, shell, env, clear_env, input, output, error, chdir)
     raise NotImplementedError.new("Process.spawn")
   end

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -231,14 +231,6 @@ struct Crystal::System::Process
       0)
   end
 
-  def self.fork
-    raise NotImplementedError.new("Process.fork")
-  end
-
-  def self.fork(&)
-    raise NotImplementedError.new("Process.fork")
-  end
-
   private def self.handle_from_io(io : IO::FileDescriptor, parent_io)
     source_handle =
       if io.is_a?(File) && !io.system_blocking? && !io.closed?

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -577,28 +577,6 @@ def abort(message = nil, status = 1) : NoReturn
   exit status
 end
 
-{% if flag?(:without_mt) && flag?(:unix) %}
-  class Process
-    # :nodoc:
-    #
-    # Hooks are defined here due to load order problems.
-    def self.after_fork_child_callbacks
-      @@after_fork_child_callbacks ||= [
-        # reinit event loop first:
-        -> { Crystal::EventLoop.current.after_fork },
-
-        # reinit signal handling:
-        ->Crystal::System::Signal.after_fork,
-        ->Crystal::System::SignalChildHandler.after_fork,
-
-        # additional reinitialization
-        ->Random::DEFAULT.new_seed,
-        -> { Random.thread_default.new_seed },
-      ] of -> Nil
-    end
-  end
-{% end %}
-
 {% if flag?(:win32) && (!flag?(:without_mt) && !flag?(:preview_mt) || flag?(:execution_context)) %}
   Crystal::EventLoop::IOCP.start_forwarder_thread
 {% end %}

--- a/src/process.cr
+++ b/src/process.cr
@@ -132,33 +132,6 @@ class Process
     Crystal::System::Process.times
   end
 
-  # :nodoc:
-  #
-  # Runs the given block inside a new process and
-  # returns a `Process` representing the new child process.
-  #
-  # Available only on Unix-like operating systems.
-  @[Deprecated("Fork is no longer supported.")]
-  def self.fork(&) : Process
-    new Crystal::System::Process.new(Crystal::System::Process.fork { yield })
-  end
-
-  # :nodoc:
-  #
-  # Duplicates the current process.
-  # Returns a `Process` representing the new child process in the current process
-  # and `nil` inside the new child process.
-  #
-  # Available only on Unix-like operating systems.
-  @[Deprecated("Fork is no longer supported.")]
-  def self.fork : Process?
-    {% raise("Process fork is unsupported with multithread mode") unless flag?(:without_mt) %}
-
-    if pid = Crystal::System::Process.fork
-      new Crystal::System::Process.new(pid)
-    end
-  end
-
   # How to redirect the standard input, output and error IO of a process.
   enum Redirect
     # Pipe the IO so the parent process can read (or write) to the process IO


### PR DESCRIPTION
After dropping fork behaviour from the compiler (#16417) we have no need to keep `Crystal::System::Process.fork` anymore. It used to power `Process.fork`. We've kept it around long after its deprecation in #9136 (released in 0.35.0) out of courtesy because the internal implementation was available anyway. Now we reached the end of that story.
As of Crystal 1.21, `Process.fork` is already unavailable in the now multi-threaded default configuration (only works with `-Dwithout_mt`).

Dropping `fork` entirely removes a lot of obsolete code.

For some system-specific use cases, a forking may still be required, for example to achieve privilege separation. That's out of scope for the standard library. But it can be implemented in user code. The only condition is that the fork happens before the execution context runtime initializes, so the process is guaranteed to be single threaded.
See https://forum.crystal-lang.org/t/why-process-fork-needs-a-good-alternative-in-crystal/8949/15 for a practical example that injects user code into `Crystal.main_user_code`.

Resolves #16371

