### PR TITLE
Revert "Print compiler progress in TTY by default (plus `--no-progress` flag)"

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -576,10 +576,6 @@ class Crystal::Command
         @progress_tracker.progress = true
       end
 
-      opts.on("--no-progress", "Disable progress output") do
-        @progress_tracker.progress = false
-      end
-
       opts.on("-t", "--time", "Enable execution time output") do
         @time = true
       end

--- a/src/compiler/crystal/progress_tracker.cr
+++ b/src/compiler/crystal/progress_tracker.cr
@@ -5,7 +5,7 @@ module Crystal
     STAGE_PADDING = 34
 
     property? stats = false
-    property? progress : Bool = STDOUT.tty?
+    property? progress = false
 
     getter current_stage = 1
     getter current_stage_name : String?


### PR DESCRIPTION
Reverts crystal-lang/crystal#17315

This feature caused some regressions and seems like it needs a bit more polish before we can merge it.

Resolves #17368