### PR TITLE
Use epoll event loop on Solaris targets

### DIFF
--- a/src/crystal/event_loop.cr
+++ b/src/crystal/event_loop.cr
@@ -12,7 +12,7 @@ abstract class Crystal::EventLoop
         end
       {% elsif flag?("evloop=libevent") %}
         Crystal::EventLoop::LibEvent
-      {% elsif flag?("evloop=epoll") || flag?(:android) || flag?(:linux) %}
+      {% elsif flag?("evloop=epoll") || flag?(:android) || flag?(:linux) || flag?(:solaris) %}
         Crystal::EventLoop::Epoll
       {% elsif flag?("evloop=kqueue") || flag?(:darwin) || flag?(:freebsd) || flag?(:openbsd) %}
         Crystal::EventLoop::Kqueue
@@ -164,7 +164,7 @@ end
     require "./event_loop/io_uring"
   {% elsif flag?("evloop=libevent") %}
     require "./event_loop/libevent"
-  {% elsif flag?("evloop=epoll") || flag?(:android) || flag?(:linux) %}
+  {% elsif flag?("evloop=epoll") || flag?(:android) || flag?(:linux) || flag?(:solaris) %}
     require "./event_loop/epoll"
   {% elsif flag?("evloop=kqueue") || flag?(:darwin) || flag?(:freebsd) || flag?(:openbsd) %}
     require "./event_loop/kqueue"

--- a/src/crystal/event_loop.cr
+++ b/src/crystal/event_loop.cr
@@ -12,6 +12,8 @@ abstract class Crystal::EventLoop
         end
       {% elsif flag?("evloop=libevent") %}
         Crystal::EventLoop::LibEvent
+      # The native async solution on Solaris (Illumos) are Event Ports, but both
+      # `epoll` and `timerfd` are supported, and the epoll event loop works.
       {% elsif flag?("evloop=epoll") || flag?(:android) || flag?(:linux) || flag?(:solaris) %}
         Crystal::EventLoop::Epoll
       {% elsif flag?("evloop=kqueue") || flag?(:darwin) || flag?(:freebsd) || flag?(:openbsd) %}

--- a/src/crystal/system/unix/timerfd.cr
+++ b/src/crystal/system/unix/timerfd.cr
@@ -1,4 +1,4 @@
-{% skip_file unless flag?(:linux) %}
+{% skip_file unless flag?(:linux) || flag?(:solaris) %}
 require "c/sys/timerfd"
 
 struct Crystal::System::TimerFD
@@ -10,7 +10,12 @@ struct Crystal::System::TimerFD
     # order to accept absolute timers with `Time::Instant` values.
     # Since `TimerFD` is only used on Linux, we do not have to differentiate
     # between different targets.
-    @fd = LibC.timerfd_create(LibC::CLOCK_BOOTTIME, LibC::TFD_CLOEXEC)
+    clock = {% if flag?(:linux) %}
+              LibC::CLOCK_BOOTTIME
+            {% else %}
+              LibC::CLOCK_MONOTONIC
+            {% end %}
+    @fd = LibC.timerfd_create(clock, LibC::TFD_CLOEXEC)
     raise RuntimeError.from_errno("timerfd_settime") if @fd == -1
   end
 


### PR DESCRIPTION
The native async solution on Solaris (Illumos) are Event Ports, but both `epoll` and `timerfd` are supported, and the Epoll event loop just works. No need to fallback to libevent.

Verified on [OmniOS](https://omnios.org/) r151058.