### PR TITLE
Add `File::Info#inspect`

### DIFF
--- a/src/file/info.cr
+++ b/src/file/info.cr
@@ -143,6 +143,18 @@ class File
       type.symlink?
     end
 
+    def inspect(io : IO) : Nil
+      io << "File::Info("
+      io << "type=" << type
+      io << ", size=" << size
+      io << ", permissions=" << permissions
+      io << ", flags=" << flags
+      io << ", modification_time=" << modification_time
+      io << ", owner_id=" << owner_id
+      io << ", group_id=" << group_id
+      io << ")"
+    end
+
     # Returns `true` if *path* is readable by the real user id of this process else returns `false`.
     #
     # ```


### PR DESCRIPTION
The string representation of `File::Info` currently consists of gibberish system data.
This patch adds a proper text format that includes all properties exposed in the public API.

```console
$ # before
$ crystal eval 'puts File.info?("bin/crystal")'
File::Info(@stat=LibC::Stat(@st_dev=2112, @st_ino=402448, @st_nlink=1, @st_mode=33261, @st_uid=1000, @st_gid=1000, @__pad0=0, @st_rdev=0, @st_size=6149, @st_blksize=4096, @st_blocks=16, @st_atim=LibC::Timespec(@tv_sec=1788685897, @tv_nsec=875524015), @st_mtim=LibC::Timespec(@tv_sec=1788559559, @tv_nsec=130112791), @st_ctim=LibC::Timespec(@tv_sec=1788559559, @tv_nsec=130112791), @__glibc_reserved=StaticArray[0, 0, 0]))
$ # after
$ bin/crystal eval 'puts File.info?("bin/crystal")'
File::Info(type=File, size=6149, permissions=rwxr-xr-x (0o755), flags=None, modification_time=2026-09-04 22:05:59 UTC, owner_id=1000, group_id=1000)
```

