### PR TITLE
Fix: save stdio closed state on program start

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -382,7 +382,7 @@ describe Process do
       closed_io.close
       Process.run(exe, ["pu", "cat"], input: closed_io)
       Process.run(exe, ["pu", "cat"], output: closed_io)
-      Process.run(exe, ["pu", "cat"], error: closed_io)
+      Process.run(exe, ["pu", "cat", "--stderr"], error: closed_io)
     end
 
     it "forwards non-blocking file" do

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -378,21 +378,21 @@ describe Process do
     end
 
     it "forwards closed io" do
-      opened = IO::Memory.new
+      open = IO::Memory.new
       closed = IO::Memory.new.tap(&.close)
       path = File.tempname("stdio")
 
-      status = Process.run(exe, ["pu", "stdio", path], input: closed, output: opened, error: opened)
+      status = Process.run(exe, ["pu", "stdio", path], input: closed, output: open, error: open)
       status.success?.should be_true
-      File.read(path).should eq "stdin=closed stdout=opened stderr=opened"
+      File.read(path).should eq "stdin=closed stdout=open stderr=open"
 
-      status = Process.run(exe, ["pu", "stdio", path], input: opened, output: closed, error: opened)
+      status = Process.run(exe, ["pu", "stdio", path], input: open, output: closed, error: open)
       status.success?.should be_true
-      File.read(path).should eq "stdin=opened stdout=closed stderr=opened"
+      File.read(path).should eq "stdin=open stdout=closed stderr=open"
 
-      status = Process.run(exe, ["pu", "stdio", path], input: opened, output: opened, error: closed)
+      status = Process.run(exe, ["pu", "stdio", path], input: open, output: open, error: closed)
       status.success?.should be_true
-      File.read(path).should eq "stdin=opened stdout=opened stderr=closed"
+      File.read(path).should eq "stdin=open stdout=open stderr=closed"
 
       status = Process.run(exe, ["pu", "stdio", path], input: closed, output: closed, error: closed)
       status.success?.should be_true

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -378,11 +378,27 @@ describe Process do
     end
 
     it "forwards closed io" do
-      closed_io = IO::Memory.new
-      closed_io.close
-      Process.run(exe, ["pu", "cat"], input: closed_io)
-      Process.run(exe, ["pu", "cat"], output: closed_io)
-      Process.run(exe, ["pu", "cat", "--stderr"], error: closed_io)
+      opened = IO::Memory.new
+      closed = IO::Memory.new.tap(&.close)
+      path = File.tempname("stdio")
+
+      status = Process.run(exe, ["pu", "stdio", path], input: closed, output: opened, error: opened)
+      status.success?.should be_true
+      File.read(path).should eq "stdin=closed stdout=opened stderr=opened"
+
+      status = Process.run(exe, ["pu", "stdio", path], input: opened, output: closed, error: opened)
+      status.success?.should be_true
+      File.read(path).should eq "stdin=opened stdout=closed stderr=opened"
+
+      status = Process.run(exe, ["pu", "stdio", path], input: opened, output: opened, error: closed)
+      status.success?.should be_true
+      File.read(path).should eq "stdin=opened stdout=opened stderr=closed"
+
+      status = Process.run(exe, ["pu", "stdio", path], input: closed, output: closed, error: closed)
+      status.success?.should be_true
+      File.read(path).should eq "stdin=closed stdout=closed stderr=closed"
+    ensure
+      File.delete?(path) if path
     end
 
     it "forwards non-blocking file" do

--- a/spec/support/process-utils-exe.cr
+++ b/spec/support/process-utils-exe.cr
@@ -59,6 +59,12 @@ module ProcessUtils
       output.puts Dir.current
     when "sleep"
       sleep
+    when "stdio"
+      File.open(args.shift, "w") do |file|
+        file << "stdin=" << (STDIN.closed? ? "closed" : "opened") << ' '
+        file << "stdout=" << (STDOUT.closed? ? "closed" : "opened") << ' '
+        file << "stderr=" << (STDERR.closed? ? "closed" : "opened")
+      end
     else
       ::abort "Unknown process util command: #{command}"
     end

--- a/spec/support/process-utils-exe.cr
+++ b/spec/support/process-utils-exe.cr
@@ -61,9 +61,9 @@ module ProcessUtils
       sleep
     when "stdio"
       File.open(args.shift, "w") do |file|
-        file << "stdin=" << (STDIN.closed? ? "closed" : "opened") << ' '
-        file << "stdout=" << (STDOUT.closed? ? "closed" : "opened") << ' '
-        file << "stderr=" << (STDERR.closed? ? "closed" : "opened")
+        file << "stdin=" << (STDIN.closed? ? "closed" : "open") << ' '
+        file << "stdout=" << (STDOUT.closed? ? "closed" : "open") << ' '
+        file << "stderr=" << (STDERR.closed? ? "closed" : "open")
       end
     else
       ::abort "Unknown process util command: #{command}"

--- a/src/crystal/main.cr
+++ b/src/crystal/main.cr
@@ -18,16 +18,24 @@ module Crystal
     # stream is closed. The same can happen for crystal/tracing with
     # CRYSTAL_TRACE_FILE.
     #
-    # We thus store the state ASAP when the program starts, then go on to
+    # We thus store the state ASAP when the program starts, then use it to
+    # create the STDIN, ORIGINAL_STDIN, and others, as closed IO objects.
     @@stdio_closed = uninitialized {Bool, Bool, Bool}
 
     # :nodoc:
     private def self.init_stdio_closed : Nil
-      @@stdio_closed = {
-        LibC.fcntl(0, LibC::F_GETFL) == -1,
-        LibC.fcntl(1, LibC::F_GETFL) == -1,
-        LibC.fcntl(2, LibC::F_GETFL) == -1,
-      }
+      # check for closed stdio fds
+      closed_stdin = LibC.fcntl(0, LibC::F_GETFL) == -1
+      closed_stdout = LibC.fcntl(1, LibC::F_GETFL) == -1
+      closed_stderr = LibC.fcntl(2, LibC::F_GETFL) == -1
+
+      # reopen closed fds (guaranteed to be the smallest number)
+      LibC.open("/dev/null", LibC::O_RDONLY | LibC::O_CLOEXEC, 0) if closed_stdin
+      LibC.open("/dev/null", LibC::O_WRONLY | LibC::O_CLOEXEC, 0) if closed_stdout
+      LibC.open("/dev/null", LibC::O_WRONLY | LibC::O_CLOEXEC, 0) if closed_stderr
+
+      # save the closed state for when we create the IO objects
+      @@stdio_closed = {closed_stdin, closed_stdout, closed_stderr}
     end
 
     # :nodoc:

--- a/src/crystal/main.cr
+++ b/src/crystal/main.cr
@@ -4,6 +4,43 @@ lib LibCrystalMain
 end
 
 module Crystal
+  {% if !flag?(:win32) %}
+    # On POSIX targets, any closed fd can be recycled, and that includes fd 0, 1
+    # and 2 that only have special meaning, not special treatment. If stdout is
+    # closed, then the next call to open or socket will recycle fd 1.
+    #
+    # If such a case happens before we define STDIN, STDOUT and STDERR, then we
+    # can miss that the standard stream is actually closed, and mistake the newly
+    # opened fd to be the standard stream.
+    #
+    # For example, under some configuration (e.g. USE_MMAP=1 + USE_MMAP_ANON=0)
+    # the BDW GC will open /dev/zero and reuse any of 0, 1 or 2 for it if any
+    # stream is closed. The same can happen for crystal/tracing with
+    # CRYSTAL_TRACE_FILE.
+    #
+    # We thus store the state ASAP when the program starts, then go on to
+    @@stdio_closed = uninitialized {Bool, Bool, Bool}
+
+    # :nodoc:
+    private def self.init_stdio_closed : Nil
+      @@stdio_closed = {
+        LibC.fcntl(0, LibC::F_GETFL) == -1,
+        LibC.fcntl(1, LibC::F_GETFL) == -1,
+        LibC.fcntl(2, LibC::F_GETFL) == -1,
+      }
+    end
+
+    # :nodoc:
+    def self.stdio_closed?(fd)
+      @@stdio_closed[fd]
+    end
+  {% else %}
+    # :nodoc:
+    def self.stdio_closed?(fd)
+      false
+    end
+  {% end %}
+
   # Defines the main routine run by normal Crystal programs:
   #
   # - Initializes runtime requirements (GC, ...)
@@ -32,6 +69,7 @@ module Crystal
   # same can be accomplished with `at_exit`. But in some cases
   # redefinition of C's main is needed.
   def self.main(&block)
+    {% unless flag?(:win32) %} init_stdio_closed {% end %}
     {% if flag?(:tracing) %} Crystal::Tracing.init {% end %}
     GC.init
 

--- a/src/crystal/system/process.cr
+++ b/src/crystal/system/process.cr
@@ -87,9 +87,26 @@ struct Crystal::System::Process
 end
 
 module Crystal::System
-  ORIGINAL_STDIN  = IO::FileDescriptor.new(handle: Crystal::System::FileDescriptor::STDIN_HANDLE, blocking: true)
-  ORIGINAL_STDOUT = IO::FileDescriptor.new(handle: Crystal::System::FileDescriptor::STDOUT_HANDLE, blocking: true)
-  ORIGINAL_STDERR = IO::FileDescriptor.new(handle: Crystal::System::FileDescriptor::STDERR_HANDLE, blocking: true)
+  ORIGINAL_STDIN =
+    if Crystal.stdio_closed?(Crystal::System::FileDescriptor::STDIN_HANDLE)
+      IO::FileDescriptor.new(closed: true)
+    else
+      IO::FileDescriptor.new(handle: Crystal::System::FileDescriptor::STDIN_HANDLE, blocking: true)
+    end
+
+  ORIGINAL_STDOUT =
+    if Crystal.stdio_closed?(Crystal::System::FileDescriptor::STDOUT_HANDLE)
+      IO::FileDescriptor.new(closed: true)
+    else
+      IO::FileDescriptor.new(handle: Crystal::System::FileDescriptor::STDOUT_HANDLE, blocking: true)
+    end
+
+  ORIGINAL_STDERR =
+    if Crystal.stdio_closed?(Crystal::System::FileDescriptor::STDERR_HANDLE)
+      IO::FileDescriptor.new(closed: true)
+    else
+      IO::FileDescriptor.new(handle: Crystal::System::FileDescriptor::STDERR_HANDLE, blocking: true)
+    end
 end
 
 {% if flag?(:wasi) %}

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -235,6 +235,10 @@ module Crystal::System::FileDescriptor
   end
 
   def self.from_stdio(fd)
+    if Crystal.stdio_closed?(fd)
+      return IO::FileDescriptor.new(closed: true)
+    end
+
     # If we have a TTY for stdin/out/err, it is possibly a shared terminal.
     # We need to reopen it to use O_NONBLOCK without causing other programs to break
 

--- a/src/crystal/system/wasi/file_descriptor.cr
+++ b/src/crystal/system/wasi/file_descriptor.cr
@@ -3,8 +3,12 @@ require "../unix/file_descriptor"
 # :nodoc:
 module Crystal::System::FileDescriptor
   def self.from_stdio(fd)
-    # TODO: WASI doesn't offer a way to detect if a 'fd' is a TTY.
-    IO::FileDescriptor.new(fd).tap(&.flush_on_newline=(true))
+    if Crystal.std_closed?(fd)
+      IO::FileDescriptor.new(closed: true)
+    else
+      # TODO: WASI doesn't offer a way to detect if a 'fd' is a TTY.
+      IO::FileDescriptor.new(fd).tap(&.flush_on_newline=(true))
+    end
   end
 
   def self.fcntl(fd, cmd, arg = 0)

--- a/src/crystal/system/wasi/file_descriptor.cr
+++ b/src/crystal/system/wasi/file_descriptor.cr
@@ -3,7 +3,7 @@ require "../unix/file_descriptor"
 # :nodoc:
 module Crystal::System::FileDescriptor
   def self.from_stdio(fd)
-    if Crystal.std_closed?(fd)
+    if Crystal.stdio_closed?(fd)
       IO::FileDescriptor.new(closed: true)
     else
       # TODO: WASI doesn't offer a way to detect if a 'fd' is a TTY.

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -65,6 +65,15 @@ class IO::FileDescriptor < IO
 
   # :nodoc:
   #
+  # Internal constructor to create a closed stdio object.
+  def initialize(*, @closed : Bool)
+    @volatile_fd = Atomic.new(-1)
+    @close_on_finalize = false
+    {% if flag?(:win32) %} @system_blocking = false {% end %}
+  end
+
+  # :nodoc:
+  #
   # Internal constructor to wrap a system *handle*. The *blocking* arg is purely
   # informational.
   def initialize(*, handle : Handle, @close_on_finalize = true, blocking = nil)

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -67,7 +67,7 @@ class IO::FileDescriptor < IO
   #
   # Internal constructor to create a closed stdio object.
   def initialize(*, @closed : Bool)
-    @volatile_fd = Atomic.new(-1)
+    @volatile_fd = Atomic.new(Handle.new(-1))
     @close_on_finalize = false
     {% if flag?(:win32) %} @system_blocking = false {% end %}
   end


### PR DESCRIPTION
0, 1 and 2 aren't reserved file descriptors, despite being expected to be stdin, stdout and stderr streams. They can be closed and reopened as sockets for example.

When a crystal program starts with one or many closed stdio, that stdio may be recycled then mistaken for the actual one when we initialize STDIN, STDOUT or STDERR. This can happen under some configuration of the GC for example, that may open `/dev/zero` as fd=1 to allocate memory. See comments under #17271.

This patch saves the closed state as the first thing in `Crystal.main` then relies on this initial information to create closed `IO::FileDescriptor` objects. The patch only applies on UNIX. I'm not sure if Windows is affected.