### PR TITLE
Fix: `sem_wait` may be interrupted by a signal [fixup #17226]

### DIFF
--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -303,8 +303,12 @@ module Crystal::System::Thread
   end
 
   def wait : Nil
-    if LibC.sem_wait(semaphore) == -1
-      raise RuntimeError.from_errno("sem_wait")
+    while true
+      if LibC.sem_wait(semaphore) == -1
+        raise RuntimeError.from_errno("sem_wait") unless Errno.value == Errno::EINTR
+      else
+        break
+      end
     end
   end
 

--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -303,12 +303,8 @@ module Crystal::System::Thread
   end
 
   def wait : Nil
-    while true
-      if LibC.sem_wait(semaphore) == -1
-        raise RuntimeError.from_errno("sem_wait") unless Errno.value == Errno::EINTR
-      else
-        break
-      end
+    while LibC.sem_wait(semaphore) == -1
+      raise RuntimeError.from_errno("sem_wait") unless Errno.value == Errno::EINTR
     end
   end
 


### PR DESCRIPTION
When interrupted the semaphore is left untouched. We just retry the wait.

Noticed on Darwin targets while trying to replace a pthread condition variable with the semaphore from `Thread#wait` and `Thread#wake`.