### PR TITLE
Fix CSV error line numbers with CRLF input

### DIFF
--- a/spec/std/csv/csv_lex_spec.cr
+++ b/spec/std/csv/csv_lex_spec.cr
@@ -17,6 +17,17 @@ class CSV::Lexer
   end
 end
 
+private def expect_csv_error(source, message, line_number, column_number)
+  lexer = CSV::Lexer.new(source)
+  error = expect_raises CSV::MalformedCSVError, "#{message} at line #{line_number}, column #{column_number}" do
+    loop do
+      break if lexer.next_token.kind == CSV::Token::Kind::Eof
+    end
+  end
+  error.line_number.should eq(line_number)
+  error.column_number.should eq(column_number)
+end
+
 describe CSV do
   describe "lex" do
     it "lexes two columns" do
@@ -143,6 +154,20 @@ describe CSV do
         lexer = CSV::Lexer.new %("foo)
         lexer.next_token
       end
+    end
+
+    it "reports correct error locations after CRLF" do
+      input = "foo,bar\r\nhel\"lo,baz"
+
+      expect_csv_error input, "Unexpected quote", 2, 4
+      expect_csv_error IO::Memory.new(input), "Unexpected quote", 2, 4
+    end
+
+    it "reports correct error locations after CRLF in quoted cells" do
+      input = %("foo\r\nbar"x)
+
+      expect_csv_error input, "Expecting comma, newline or end, not 'x'", 2, 5
+      expect_csv_error IO::Memory.new(input), "Expecting comma, newline or end, not 'x'", 2, 5
     end
 
     it "doesn't consume char after \\n (#11172)" do

--- a/src/csv/lexer.cr
+++ b/src/csv/lexer.cr
@@ -137,10 +137,15 @@ abstract class CSV::Lexer
 
   private def next_char
     @column_number += 1
+    previous_char = current_char
     char = next_char_no_column_increment
-    if char.in?('\n', '\r')
+    case char
+    when '\r'
       @column_number = 0
       @line_number += 1
+    when '\n'
+      @column_number = 0
+      @line_number += 1 unless previous_char == '\r'
     end
     char
   end


### PR DESCRIPTION


`CSV::Lexer` currently increments the line number when advancing to both `\r` and `\n`. Since CRLF input is handled as two character advances, a `\r\n` sequence increments the line number twice.

This causes malformed CSV errors after a CRLF sequence to report the following physical line. The issue affects both string-based and IO-based lexers, as well as CRLF sequences inside quoted cells.

For example:

```crystal
require "csv"

input = "foo,bar\r\nhel\"lo,baz"

CSV.parse(input)
# Before this change:
# CSV::MalformedCSVError: Unexpected quote at line 3, column 5
#
# Expected:
# CSV::MalformedCSVError: Unexpected quote at line 2, column 4
```



Track whether the previously consumed character was `\r`. A following `\n` resets the column without incrementing the line number again.  And lone `\r` and lone `\n` continue to be counted as individual line breaks.

