### PR TITLE
Fix `HTTP::Request::Processor` resuming connection on unconsumed request body

### DIFF
--- a/spec/std/http/server/request_processor_spec.cr
+++ b/spec/std/http/server/request_processor_spec.cr
@@ -289,19 +289,14 @@ describe HTTP::Server::RequestProcessor do
       output = IO::Memory.new
       processor.process(input, output)
       output.rewind
-      output.gets_to_end.should eq(<<-HTTP
-        HTTP/1.1 200 OK\r
-        Connection: keep-alive\r
-        Content-Length: 0\r
-        \r
-        HTTP/1.1 414 URI Too Long\r
-        Content-Type: text/plain\r
-        Content-Length: 17\r
-        \r
-        414 URI Too Long
+      output.gets_to_end.should eq(requestize(<<-HTTP
+        HTTP/1.1 200 OK
+        Connection: keep-alive
+        Content-Length: 0
+
 
         HTTP
-      )
+      ))
     end
 
     it "continues when request has no body" do

--- a/spec/std/http/server/request_processor_spec.cr
+++ b/spec/std/http/server/request_processor_spec.cr
@@ -235,6 +235,131 @@ describe HTTP::Server::RequestProcessor do
         HTTP
       ))
     end
+
+    it "continues when `request.body` is replaced as long as original is consumed" do
+      processor = HTTP::Server::RequestProcessor.new do |context|
+        context.request.body.should_not(be_nil).gets_to_end
+        context.request.body = IO::Memory.new
+      end
+
+      input = IO::Memory.new(requestize(<<-HTTP
+        POST / HTTP/1.1
+        Content-Length: 16387
+
+        #{"0" * 16_384}1
+        POST / HTTP/1.1
+        Content-Length: 7
+
+        hello
+        HTTP
+      ))
+      output = IO::Memory.new
+      processor.process(input, output)
+      output.rewind
+      output.gets_to_end.should eq(requestize(<<-HTTP
+        HTTP/1.1 200 OK
+        Connection: keep-alive
+        Content-Length: 0
+
+        HTTP/1.1 200 OK
+        Connection: keep-alive
+        Content-Length: 0
+
+
+        HTTP
+      ))
+    end
+
+    it "closes connection when `request.body` is replaced" do
+      processor = HTTP::Server::RequestProcessor.new do |context|
+        context.request.body = IO::Memory.new
+      end
+
+      input = IO::Memory.new(requestize(<<-HTTP
+        POST / HTTP/1.1
+        Content-Length: 16387
+
+        #{"0" * 16_384}1
+        POST / HTTP/1.1
+        Content-Length: 7
+
+        hello
+        HTTP
+      ))
+      output = IO::Memory.new
+      processor.process(input, output)
+      output.rewind
+      output.gets_to_end.should eq(<<-HTTP
+        HTTP/1.1 200 OK\r
+        Connection: keep-alive\r
+        Content-Length: 0\r
+        \r
+        HTTP/1.1 414 URI Too Long\r
+        Content-Type: text/plain\r
+        Content-Length: 17\r
+        \r
+        414 URI Too Long
+
+        HTTP
+      )
+    end
+
+    it "continues when request has no body" do
+      processor = HTTP::Server::RequestProcessor.new do |context|
+      end
+
+      input = IO::Memory.new(<<-HTTP
+        POST / HTTP/1.1
+
+        POST / HTTP/1.1
+        Content-Length: 7
+
+        hello
+        HTTP
+      )
+      output = IO::Memory.new
+      processor.process(input, output)
+      output.rewind
+      output.gets_to_end.should eq(requestize(<<-HTTP
+        HTTP/1.1 200 OK
+        Connection: keep-alive
+        Content-Length: 0
+
+        HTTP/1.1 200 OK
+        Connection: keep-alive
+        Content-Length: 0
+
+
+        HTTP
+      ))
+    end
+
+    it "errors when request unexpectedly has a body" do
+      processor = HTTP::Server::RequestProcessor.new { }
+
+      input = IO::Memory.new(<<-HTTP
+        POST / HTTP/1.1
+
+        hello
+        HTTP
+      )
+      output = IO::Memory.new
+      processor.process(input, output)
+      output.rewind
+      output.gets_to_end.should eq(<<-HTTP
+        HTTP/1.1 200 OK\r
+        Connection: keep-alive\r
+        Content-Length: 0\r
+        \r
+        HTTP/1.1 400 Bad Request\r
+        Content-Type: text/plain\r
+        Content-Length: 16\r
+        \r
+        400 Bad Request
+
+        HTTP
+      )
+    end
   end
 
   it "handles IO::Error while reading" do

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -43,6 +43,8 @@ class HTTP::Server::RequestProcessor
           return
         end
 
+        original_body = request.body
+
         # RFC 9112, Section 6.1: reject & close on ambiguous body content to
         # prevent request smuggling
         if request.headers.has_key?("Content-Length") && request.headers.has_key?("Transfer-Encoding")
@@ -94,16 +96,16 @@ class HTTP::Server::RequestProcessor
 
         # The request body is either FixedLengthContent or ChunkedContent.
         # In case it has not entirely been consumed by the handler, the connection is
-        # closed the connection even if keep alive was requested.
-        case body = request.body
+        # closed even if keep alive was requested.
+        case original_body
         when FixedLengthContent
-          if body.read_remaining > 0
+          if original_body.read_remaining > 0
             # Close the connection if there are bytes remaining
             break
           end
         when ChunkedContent
           # Close the connection if the IO has still bytes to read.
-          break unless body.closed?
+          break unless original_body.closed?
         end
       end
     rescue IO::Error

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -106,6 +106,12 @@ class HTTP::Server::RequestProcessor
         when ChunkedContent
           # Close the connection if the IO has still bytes to read.
           break unless original_body.closed?
+        when Nil
+          # No request body
+          next
+        else
+          # Unexpected request body type
+          break
         end
       end
     rescue IO::Error


### PR DESCRIPTION
`HTTP::Request#body` is mutable, so the processor must store a reference to the original body to ensure it decides based on the actual stream status.