### PR TITLE
Fix ICE when module with ivar is included in a type that can't have them

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4344,6 +4344,18 @@ describe "Semantic: instance var" do
     end
   end
 
+  it "errors if including a module with a guessed instance var in a primitive type" do
+    assert_error <<-CRYSTAL, "can't declare instance variables in Int32"
+      module Foo
+        @x = 1
+      end
+
+      struct Int32
+        include Foo
+      end
+      CRYSTAL
+  end
+
   it "errors if declaring instance variable in module included in Object" do
     assert_error <<-CRYSTAL, "can't declare instance variables in Object"
       module Moo

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -264,7 +264,7 @@ struct Crystal::TypeDeclarationProcessor
       if extender = find_extending_type(owner)
         raise TypeException.new("can't declare instance variables in #{owner} because #{extender} extends it", type_decl.location)
       end
-    elsif owner.metaclass?
+    elsif owner.metaclass? || !owner.is_a?(InstanceVarContainer)
       raise TypeException.new("can't declare instance variables in #{owner}", type_decl.location)
     end
 
@@ -378,7 +378,7 @@ struct Crystal::TypeDeclarationProcessor
       if extender = find_extending_type(owner)
         raise TypeException.new("can't declare instance variables in #{owner} because #{extender} extends it", type_info.location)
       end
-    elsif owner.metaclass?
+    elsif owner.metaclass? || !owner.is_a?(InstanceVarContainer)
       raise TypeException.new("can't declare instance variables in #{owner}", type_info.location)
     end
 


### PR DESCRIPTION
The following code in Crystal 1.21.0 produces an ICE

```crystal
module M
  @x = 1
end

struct Int32
  include M
end
```

```
% crystal foo.cr 
BUG: Int32 doesn't implement instance_vars (Exception)
  from /opt/homebrew/Cellar/crystal/1.21.0_1/bin/crystal in 'raise<Exception>:NoReturn'
  from /opt/homebrew/Cellar/crystal/1.21.0_1/bin/crystal in 'raise<String>:NoReturn'
  from /opt/homebrew/Cellar/crystal/1.21.0_1/bin/crystal in 'Crystal::Type+@Crystal::Type#instance_vars:NoReturn'
```

After this PR

```
% ./bin/crystal foo.cr
Showing last frame. Use --error-trace for full trace.

In foo.cr:2:3

 2 | @x = 1
     ^
Error: can't declare instance variables in Int32
```