### PR TITLE
Allows modules to be included or extended in enum

### DIFF
--- a/spec/compiler/codegen/enum_spec.cr
+++ b/spec/compiler/codegen/enum_spec.cr
@@ -371,4 +371,30 @@ describe "Code gen: enum" do
       Foo::A.value.to_u64!
       CRYSTAL
   end
+
+  it "codegens enum with included module and virtual dispatch" do
+    run(<<-CRYSTAL).to_i.should eq(3)
+      module Moo
+        def moo
+          value &+ 1
+        end
+      end
+
+      enum Foo
+        A = 1
+
+        include Moo
+      end
+
+      enum Bar
+        B = 2
+
+        include Moo
+      end
+
+      x = 1 == 1 ? Foo::A.as(Moo) : Bar::B.as(Moo)
+      y = 1 == 2 ? Foo::A.as(Moo) : Bar::B.as(Moo)
+      x.moo &+ y.moo &- 2
+      CRYSTAL
+  end
 end

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1585,6 +1585,8 @@ describe Crystal::Formatter do
   assert_format "enum Foo\nA = 1\nend", "enum Foo\n  A = 1\nend"
   assert_format "enum Foo : Int32\nA = 1\nend", "enum Foo : Int32\n  A = 1\nend"
   assert_format "enum Foo : Int32\nA = 1\ndef foo\n1\nend\nend", "enum Foo : Int32\n  A = 1\n\n  def foo\n    1\n  end\nend"
+  assert_format "enum Foo\nA = 1\ninclude Bar\nend", "enum Foo\n  A = 1\n  include Bar\nend"
+  assert_format "enum Foo\nA = 1\n\ninclude Bar\nextend Baz\nend", "enum Foo\n  A = 1\n\n  include Bar\n  extend Baz\nend"
   assert_format "lib Bar\n  enum Foo\n  end\nend"
   assert_format "lib Bar\n  enum Foo\n    A\n  end\nend"
   assert_format "lib Bar\n  enum Foo\n    A = 1\n  end\nend"

--- a/spec/compiler/interpreter/enum_spec.cr
+++ b/spec/compiler/interpreter/enum_spec.cr
@@ -27,5 +27,25 @@ describe Crystal::Repl::Interpreter do
         blue.value
       CRYSTAL
     end
+
+    it "does enum with included module" do
+      interpret(<<-CRYSTAL).should eq(3)
+        module Moo
+          def moo
+            value &+ 1
+          end
+        end
+
+        enum Color
+          Red
+          Green
+          Blue
+
+          include Moo
+        end
+
+        Color::Blue.moo
+      CRYSTAL
+    end
   end
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2173,6 +2173,14 @@ module Crystal
 
     it_parses "enum Foo; @[Bar]; end", EnumDef.new("Foo".path, [Annotation.new("Bar".path)] of ASTNode)
 
+    it_parses "enum Foo; include Bar; end", EnumDef.new("Foo".path, [Include.new("Bar".path)] of ASTNode)
+    it_parses "enum Foo; A = 1\ninclude Bar\nend", EnumDef.new("Foo".path, [Arg.new("A", 1.int32), Include.new("Bar".path)] of ASTNode)
+    it_parses "enum Foo; extend Bar; end", EnumDef.new("Foo".path, [Extend.new("Bar".path)] of ASTNode)
+    it_parses "enum Foo; A = 1\nextend Bar\nend", EnumDef.new("Foo".path, [Arg.new("A", 1.int32), Extend.new("Bar".path)] of ASTNode)
+
+    it_parses "enum Foo; private include Bar; end", EnumDef.new("Foo".path, [VisibilityModifier.new(Visibility::Private, Include.new("Bar".path))] of ASTNode)
+    it_parses "enum Foo; protected extend Bar; end", EnumDef.new("Foo".path, [VisibilityModifier.new(Visibility::Protected, Extend.new("Bar".path))] of ASTNode)
+
     assert_syntax_error "enum Foo; A B; end", "expecting ';', 'end' or newline after enum member"
     assert_syntax_error "enum Foo\n  A,   B,   C\nend\n", "expecting ';', 'end' or newline after enum member"
 

--- a/spec/compiler/semantic/enum_spec.cr
+++ b/spec/compiler/semantic/enum_spec.cr
@@ -627,4 +627,105 @@ describe "Semantic: enum" do
     a_defs = result.program.types["Foo"].lookup_defs("bar?")
     a_defs.first.doc.should eq(":nodoc:")
   end
+
+  it "includes a module in an enum" do
+    assert_type(<<-CRYSTAL) { types["Foo"] }
+      module Moo
+        def foo
+          self
+        end
+      end
+
+      enum Foo
+        A = 1
+
+        include Moo
+      end
+
+      Foo::A.foo
+      CRYSTAL
+  end
+
+  it "matches an enum against an included module" do
+    assert_type(<<-CRYSTAL) { types["Foo"] }
+      module Moo
+      end
+
+      enum Foo
+        A = 1
+
+        include Moo
+      end
+
+      def foo(x : Moo)
+        x
+      end
+
+      foo(Foo::A)
+      CRYSTAL
+  end
+
+  it "extends a module in an enum" do
+    assert_type(<<-CRYSTAL) { types["Foo"].metaclass }
+      module Moo
+        def foo
+          self
+        end
+      end
+
+      enum Foo
+        A = 1
+
+        extend Moo
+      end
+
+      Foo.foo
+      CRYSTAL
+  end
+
+  it "runs included hook when including a module in an enum" do
+    assert_type(<<-CRYSTAL) { int32 }
+      module Moo
+        macro included
+          def self.moo
+            1
+          end
+        end
+      end
+
+      enum Foo
+        A = 1
+
+        include Moo
+      end
+
+      Foo.moo
+      CRYSTAL
+  end
+
+  it "errors if including a non-module in an enum" do
+    assert_error <<-CRYSTAL, "Moo is not a module, it's a class"
+      class Moo
+      end
+
+      enum Foo
+        A = 1
+
+        include Moo
+      end
+      CRYSTAL
+  end
+
+  it "errors if applying a visibility modifier to an include in an enum" do
+    assert_error <<-CRYSTAL, "can't apply visibility modifier"
+      module Moo
+      end
+
+      enum Foo
+        A = 1
+
+        private include Moo
+      end
+      CRYSTAL
+  end
 end

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4344,6 +4344,18 @@ describe "Semantic: instance var" do
     end
   end
 
+  it "errors if including a module with a guessed instance var in a primitive type" do
+    assert_error <<-CRYSTAL, "can't declare instance variables in Int32"
+      module Foo
+        @x = 1
+      end
+
+      struct Int32
+        include Foo
+      end
+      CRYSTAL
+  end
+
   it "errors if declaring instance variable in module included in Object" do
     assert_error <<-CRYSTAL, "can't declare instance variables in Object"
       module Moo

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4344,6 +4344,34 @@ describe "Semantic: instance var" do
     end
   end
 
+  it "errors if including a module with a declared instance var in an enum" do
+    assert_error <<-CRYSTAL, "can't declare instance variables in Bar"
+      module Foo
+        @x : Int32 = 1
+      end
+
+      enum Bar
+        A = 1
+
+        include Foo
+      end
+      CRYSTAL
+  end
+
+  it "errors if including a module with a guessed instance var in an enum" do
+    assert_error <<-CRYSTAL, "can't declare instance variables in Bar"
+      module Foo
+        @x = 1
+      end
+
+      enum Bar
+        A = 1
+
+        include Foo
+      end
+      CRYSTAL
+  end
+
   it "errors if including a module with a guessed instance var in a primitive type" do
     assert_error <<-CRYSTAL, "can't declare instance variables in Int32"
       module Foo

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -264,7 +264,7 @@ struct Crystal::TypeDeclarationProcessor
       if extender = find_extending_type(owner)
         raise TypeException.new("can't declare instance variables in #{owner} because #{extender} extends it", type_decl.location)
       end
-    elsif owner.metaclass?
+    elsif owner.metaclass? || !owner.is_a?(InstanceVarContainer)
       raise TypeException.new("can't declare instance variables in #{owner}", type_decl.location)
     end
 
@@ -378,7 +378,7 @@ struct Crystal::TypeDeclarationProcessor
       if extender = find_extending_type(owner)
         raise TypeException.new("can't declare instance variables in #{owner} because #{extender} extends it", type_info.location)
       end
-    elsif owner.metaclass?
+    elsif owner.metaclass? || !owner.is_a?(InstanceVarContainer)
       raise TypeException.new("can't declare instance variables in #{owner}", type_info.location)
     end
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -6345,6 +6345,14 @@ module Crystal
             member = parse_macro.at(def_location)
             member = VisibilityModifier.new(visibility, member).at(location) if visibility
             members << member
+          when Keyword::INCLUDE
+            member = parse_include.at(def_location)
+            member = VisibilityModifier.new(visibility, member).at(location) if visibility
+            members << member
+          when Keyword::EXTEND
+            member = parse_extend.at(def_location)
+            member = VisibilityModifier.new(visibility, member).at(location) if visibility
+            members << member
           else
             unexpected_token
           end


### PR DESCRIPTION
On top of #17386

Motivated by https://forum.crystal-lang.org/t/different-flavours-of-enum/9131/13?u=bcardiff

Allows modules to be included or extended in enum. 

The following compiles with this PR

```crystal
module AModule
end

enum AEnum
  A1
  A2

  include AModule
end

enum BEnum
  B1
  B2

  include AModule
end

def f(x : AModule)
  x
end

f(AEnum::A1)
f(BEnum::B2)
```
