### PR TITLE
Serialize `IO::Memory` in HTTP body with `Content-Length` header

### DIFF
--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -262,7 +262,8 @@ class HTTP::Client::Response
     end
 
     it "serialize as chunked with body_io" do
-      response = Response.new(:ok, body_io: IO::Memory.new("hello"))
+      # IO::Sized wrapper simulates an arbitrary IO to ensure that `Response#to_io` does not apply the optimization for IO::Memory
+      response = Response.new(:ok, body_io: IO::Sized.new(IO::Memory.new("hello"), 100))
       io = IO::Memory.new
       response.to_io(io)
       io.to_s.should eq("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n")

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -317,10 +317,25 @@ module HTTP
       end
 
       it "serialize POST (with io body, without content-length header)" do
-        request = Request.new "POST", "/", body: IO::Memory.new("thisisthebody")
+        # IO::Sized wrapper simulates an arbitrary IO to ensure that `Request#to_io` does not apply the optimization for IO::Memory
+        request = Request.new "POST", "/", body: IO::Sized.new(IO::Memory.new("thisisthebody"), 100)
         io = IO::Memory.new
         request.to_io(io)
         io.to_s.should eq("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\nd\r\nthisisthebody\r\n0\r\n\r\n")
+      end
+
+      it "serializes POST (with io body)`" do
+        request = Request.new "POST", "/", body: IO::Memory.new("thisisthebody")
+        io = IO::Memory.new
+        request.to_io(io)
+        io.to_s.should eq("POST / HTTP/1.1\r\nContent-Length: 13\r\n\r\nthisisthebody")
+      end
+
+      it "serializes POST (with io body, starting at offset)" do
+        request = Request.new "POST", "/", body: IO::Memory.new("thisisthebody").tap { |io| io.pos = 4 }
+        io = IO::Memory.new
+        request.to_io(io)
+        io.to_s.should eq("POST / HTTP/1.1\r\nContent-Length: 9\r\n\r\nisthebody")
       end
 
       it "serialize POST (with io body, with content-length header)" do

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -317,7 +317,8 @@ module HTTP
       end
 
       it "serialize POST (with io body, without content-length header)" do
-        # IO::Sized wrapper simulates an arbitrary IO to ensure that `Request#to_io` does not apply the optimization for IO::Memory
+        # IO::Sized wrapper simulates an arbitrary IO to ensure that the body
+        # is chunked because `Request#to_io` optimizes for IO::Memory.
         request = Request.new "POST", "/", body: IO::Sized.new(IO::Memory.new("thisisthebody"), 100)
         io = IO::Memory.new
         request.to_io(io)

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -280,6 +280,11 @@ module HTTP
         if copied != content_length
           raise ArgumentError.new("Content-Length header is #{content_length} but body had #{copied} bytes")
         end
+      elsif body_io.is_a?(IO::Memory)
+        headers.serialize(io)
+        slice = body_io.to_slice + body_io.pos
+        io << "Content-Length: " << slice.bytesize << "\r\n\r\n"
+        io.write slice
       elsif Client::Response.supports_chunked?(version)
         headers["Transfer-Encoding"] = "chunked"
         headers.serialize(io)


### PR DESCRIPTION
This optimization allows us to send `IO::Memory` content with a known size directly, instead of chunked encoding.