### PR TITLE
Fix `with ... yield` calls on a module-typed scope

### DIFF
--- a/spec/compiler/codegen/method_missing_spec.cr
+++ b/spec/compiler/codegen/method_missing_spec.cr
@@ -431,4 +431,36 @@ describe "Code gen: method_missing" do
       end
       CRYSTAL
   end
+
+  it "finds method_missing in a module with 'with ... yield' (#17393)" do
+    run(<<-CRYSTAL).to_i.should eq(10)
+      module Moo
+        macro method_missing(call)
+          @{{call.name.id}}
+        end
+      end
+
+      class Foo
+        include Moo
+
+        def initialize(@x : Int32)
+        end
+      end
+
+      class Bar
+        include Moo
+
+        def initialize(@x : Int32)
+        end
+      end
+
+      def bar(x : Moo, &)
+        with x yield
+      end
+
+      bar(Foo.new(10).as(Moo)) do
+        x
+      end
+      CRYSTAL
+  end
 end

--- a/spec/compiler/codegen/yield_with_scope_spec.cr
+++ b/spec/compiler/codegen/yield_with_scope_spec.cr
@@ -221,4 +221,60 @@ describe "Semantic: yield with scope" do
       foo { method }
       CRYSTAL
   end
+
+  it "yields module type dispatching to the including type's override (#17393)" do
+    run(<<-CRYSTAL).to_i.should eq(2)
+      module Moo
+        def method
+          1
+        end
+      end
+
+      class Foo
+        include Moo
+      end
+
+      class Bar
+        include Moo
+
+        def method
+          2
+        end
+      end
+
+      def foo(x : Moo, &)
+        with x yield
+      end
+
+      foo(Bar.new.as(Moo)) { method }
+      CRYSTAL
+  end
+
+  it "yields generic module type dispatching to the including type's override (#17393)" do
+    run(<<-CRYSTAL).to_i.should eq(2)
+      module Moo(T)
+        def method
+          1
+        end
+      end
+
+      class Foo
+        include Moo(Int32)
+      end
+
+      class Bar
+        include Moo(Int32)
+
+        def method
+          2
+        end
+      end
+
+      def foo(x : Moo(Int32), &)
+        with x yield
+      end
+
+      foo(Bar.new.as(Moo(Int32))) { method }
+      CRYSTAL
+  end
 end

--- a/spec/compiler/semantic/method_missing_spec.cr
+++ b/spec/compiler/semantic/method_missing_spec.cr
@@ -91,6 +91,32 @@ describe "Semantic: method_missing" do
       CRYSTAL
   end
 
+  it "finds method_missing in a module with 'with ... yield' (#17393)" do
+    assert_type(<<-CRYSTAL) { int32 }
+      module Moo
+        macro method_missing(call)
+          1
+        end
+      end
+
+      class Foo
+        include Moo
+      end
+
+      class Bar
+        include Moo
+      end
+
+      def bar(x : Moo, &)
+        with x yield
+      end
+
+      bar(Foo.new.as(Moo)) do
+        baz
+      end
+      CRYSTAL
+  end
+
   it "doesn't look up method_missing in with_yield_scope if call has a receiver (#12097)" do
     assert_error(<<-CRYSTAL, "undefined method 'bar' for Int32")
       class Foo

--- a/spec/compiler/semantic/yield_with_scope_spec.cr
+++ b/spec/compiler/semantic/yield_with_scope_spec.cr
@@ -186,6 +186,80 @@ describe "Semantic: yield with scope" do
       CRYSTAL
   end
 
+  it "yields module type (#17393)" do
+    assert_type(<<-CRYSTAL) { int32 }
+      module Moo
+        def moo
+          1
+        end
+      end
+
+      class Base
+      end
+
+      class Foo < Base
+        include Moo
+      end
+
+      class Bar < Base
+        include Moo
+      end
+
+      def foo(x : Base, &)
+        with x.as(Moo) yield
+      end
+
+      foo(Foo.new) { moo }
+      CRYSTAL
+  end
+
+  it "yields module type with a single including type (#17393)" do
+    assert_type(<<-CRYSTAL) { int32 }
+      module Moo
+        def moo
+          1
+        end
+      end
+
+      class Foo
+        include Moo
+      end
+
+      def foo(x : Moo, &)
+        with x yield
+      end
+
+      foo(Foo.new.as(Moo)) { moo }
+      CRYSTAL
+  end
+
+  it "uses method of enclosing scope if module yield scope has no match (#17393)" do
+    assert_type(<<-CRYSTAL) { int32 }
+      module Moo
+      end
+
+      class Foo
+        include Moo
+      end
+
+      def foo(x : Moo, &)
+        with x yield
+      end
+
+      class Bar
+        def bar
+          foo(Foo.new.as(Moo)) { baz }
+        end
+
+        def baz
+          1
+        end
+      end
+
+      Bar.new.bar
+      CRYSTAL
+  end
+
   it "mentions with yield scope and current scope in error" do
     assert_error <<-CRYSTAL, "undefined local variable or method 'baz' for Int32 (with ... yield) and Foo (current scope)"
       def foo

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -251,6 +251,15 @@ class Crystal::Call
     end
 
     @uses_with_scope = true
+
+    # A module can't hold def instances, and can't be a receiver at runtime, so
+    # the matches found above only establish that the scope responds to this
+    # call. Resolve it against the types including the module, which is also
+    # what a call with an explicit receiver of a module type does.
+    if owner.module?
+      return lookup_matches_in owner, arg_types, named_args_types, with_autocast: with_autocast
+    end
+
     instantiate signature, matches, owner, self_type: nil, with_autocast: with_autocast
   end
 
@@ -278,8 +287,18 @@ class Crystal::Call
       elsif with_scope = @with_scope
         defined_method_missing = with_scope.check_method_missing(signature, self)
         if defined_method_missing
-          matches = with_scope.lookup_matches(signature, analyze_all: with_autocast)
           @uses_with_scope = true
+
+          # `check_method_missing` defined the method on the module, which can't
+          # hold its def instances, so resolve the call against the types
+          # including it, as `#lookup_matches_with_scope_in` does. When
+          # `self_type` is given it is the def instance owner, and then there's
+          # nothing to expand.
+          if with_scope.module? && !self_type
+            return lookup_matches_in with_scope, arg_types, named_args_types, with_autocast: with_autocast
+          end
+
+          matches = with_scope.lookup_matches(signature, analyze_all: with_autocast)
         end
       end
     end


### PR DESCRIPTION
Fixes #17393.

## Summary

The compiler aborts with an error when a block passed to `with ... yield` calls a method through a scope whose static type is a module. When compiling the following code, the compiler tells me that I've "found a bug in the Crystal compiler":

```crystal
module Moo
  def moo
  end
end

class Foo
  include Moo
end

def apply(x : Moo, &)
  with x yield
end

apply(Foo.new.as(Moo)) { moo }
```

The error:

```
Cast from Crystal::NonGenericModuleType to Crystal::DefInstanceContainer failed, at /private/tmp/crystal-20260818-5197-j32i1o/crystal-1.21.0/src/compiler/crystal/semantic/call.cr:394:28 (TypeCastError)
```

This PR fixes the compiler by handling the case that the owner is a module, not a class, in `Crystal::Call#lookup_matches_with_scope_in` and `Crystal::Call#lookup_matches_in`