### PR TITLE
Fix vswhere ignoring ARM64-only MSVC installations

### DIFF
--- a/src/crystal/system/win32/visual_studio.cr
+++ b/src/crystal/system/win32/visual_studio.cr
@@ -44,7 +44,9 @@ module Crystal::System::VisualStudio
 
   private def self.get_vs_installations : Array(Installation)?
     if vswhere_path = find_vswhere
-      vc_install_json = `#{::Process.quote(vswhere_path)} -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -products * -sort -format json`.chomp
+      # the workload ID for host build support depends on machine architecture
+      arch = {{ flag?(:aarch64) ? "ARM64" : "x86.x64" }}
+      vc_install_json = `#{::Process.quote(vswhere_path)} -requires Microsoft.VisualStudio.Component.VC.Tools.#{arch} -products * -sort -format json`.chomp
       return if !$?.success? || vc_install_json.empty?
 
       Array(Installation).from_json(vc_install_json)


### PR DESCRIPTION
Previously the compiler always required the x86/x64 build tools to be present even on an ARM64 machine, which is not always the case considering that the GUI installer will prompt to install the tools for the host machine only.