### PR TITLE
Unify LLVM types used for `ReferenceStorage`

### DIFF
--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -280,6 +280,10 @@ module Crystal
       llvm_type(type, wants_size)
     end
 
+    private def create_llvm_struct_type(type : ReferenceStorageType, wants_size)
+      llvm_type(type, wants_size)
+    end
+
     private def create_llvm_struct_type(type : InstanceVarContainer, wants_size)
       if type.extern_union?
         return create_llvm_c_union_struct_type(type, wants_size)


### PR DESCRIPTION
The following snippet is causing CI failures for LLVM 13 and 14:

```crystal
@[Primitive(:ReferenceStorageType)]
struct MyReferenceStorage(T) < Value
  def to_reference : T
    pointerof(@type_id).as(T)
  end
end

class Foo
end

x = uninitialized MyReferenceStorage(Foo)
foo = x.to_reference
```

> error: Explicit gep type does not match pointee type of pointer operand (Producer: 'LLVM14.0.6' Reader: 'LLVM 14.0.6')

Normally, `Crystal::LLVMTyper#llvm_type` already maps `MyReferenceStorage(Foo)` to the LLVM type `%Foo = type { i32 }`. However, the `pointerof` here takes a pointer to an instance variable, requesting the implicit self's member layout via `#llvm_struct_type` here:

https://github.com/crystal-lang/crystal/blob/97225c4fb7fc8c4e1734f33cd089384ba8d52132/src/compiler/crystal/codegen/codegen.cr#L735
https://github.com/crystal-lang/crystal/blob/97225c4fb7fc8c4e1734f33cd089384ba8d52132/src/compiler/crystal/codegen/codegen.cr#L2548

That method maps `MyReferenceStorage(Foo)` to the duplicate `%"MyReferenceStorage(Foo)" = type { i32 }` instead. This discrepancy means that when LLVM pointers are non-opaque, `pointerof(@type_id)` becomes `%0 = getelementptr inbounds %"MyReferenceStorage(Foo)", %Foo* %self, i32 0, i32 0`, which is invalid IR since the two types must be exactly the same, not just equivalent.

This PR ensures that `#llvm_struct_type` also returns `%Foo` for `ReferenceStorage(Foo)`.