### PR TITLE
Fix: rewrite thread pool logic to avoid race conditions

### DIFF
--- a/src/crystal/tracing.cr
+++ b/src/crystal/tracing.cr
@@ -6,6 +6,7 @@ module Crystal
     @[Flags]
     enum Section
       GC
+      Thread
       Sched
       Evloop
 

--- a/src/fiber/execution_context/thread_pool.cr
+++ b/src/fiber/execution_context/thread_pool.cr
@@ -13,54 +13,51 @@ class Fiber
         getter thread : Thread
 
         def initialize(@thread : Thread)
-          @mutex = Thread::Mutex.new
           @condition_variable = Thread::ConditionVariable.new
         end
 
-        def synchronize(&)
-          @mutex.synchronize { yield }
-        end
-
         def wake
+          Crystal.trace :thread, "wake", thread: @thread
           @condition_variable.signal
         end
 
-        def wait
-          @condition_variable.wait(@mutex)
+        def wait(mutex)
+          Crystal.trace :thread, "wait"
+          @condition_variable.wait(mutex)
         end
 
-        def wait(timeout, &)
-          @condition_variable.wait(@mutex, timeout) { yield }
-        end
-
-        def linked?
-          !@previous.null?
+        def wait(mutex, timeout, &)
+          Crystal.trace :thread, "wait", timeout: timeout.to_nanoseconds
+          @condition_variable.wait(mutex, timeout) { yield }
         end
       end
 
       def initialize
         @mutex = Thread::Mutex.new
-        @condition_variable = Thread::ConditionVariable.new
         @pool = Crystal::PointerLinkedList(Parked).new
         @main_thread = Thread.current
       end
 
       protected def checkout(scheduler)
-        thread =
-          if parked = @mutex.synchronize { @pool.shift? }
-            parked.value.synchronize do
-              attach(parked.value.thread, scheduler)
-              parked.value.wake
-            end
-            parked.value.thread
-          else
-            # OPTIMIZE: start thread with minimum stack size
-            Thread.new do |thread|
-              attach(thread, scheduler)
-              enter_thread_loop(thread)
-            end
+        thread = nil
+
+        @mutex.synchronize do
+          if parked = @pool.shift?
+            thread = parked.value.thread
+
+            attach(thread, scheduler)
+            parked.value.wake
           end
-        Crystal.trace :sched, "thread.checkout", thread: thread
+        end
+
+        thread ||= Thread.new do |thread|
+          Crystal.trace :thread, "start"
+
+          attach(thread, scheduler)
+          enter_thread_loop(thread)
+        end
+
+        Crystal.trace :thread, "checkout", thread: thread
         thread
       end
 
@@ -76,14 +73,17 @@ class Fiber
       end
 
       protected def checkin : Nil
-        Crystal.trace :sched, "thread.checkin"
+        Crystal.trace :thread, "checkin"
+
         thread = Thread.current
         detach(thread)
 
         if thread == @main_thread
+          thread.internal_name = "?"
           resume(main_thread_loop)
         else
           Thread.name = ""
+          thread.internal_name = "?"
           resume(thread.main_fiber)
         end
       end
@@ -108,84 +108,91 @@ class Fiber
       # isolated context).
       private def enter_thread_loop(thread)
         parked = Parked.new(thread)
-        parked.synchronize do
-          loop do
-            if scheduler = thread.scheduler?
-              unless thread == @main_thread
-                Thread.name = scheduler.name
-              end
 
-              resume(scheduler.main_fiber)
+        while true
+          scheduler = wait_for_scheduler?(thread, pointerof(parked))
 
-              {% unless flag?(:interpreted) %}
-                if (stack = Thread.current.dead_fiber_stack?) && stack.reusable?
-                  # release pending fiber stack left after swapcontext; we don't
-                  # know which stack pool to return it to, and it may not even
-                  # have one (e.g. isolated fiber stack)
-                  Crystal::System::Fiber.free_stack(stack.pointer, stack.size)
+          unless scheduler
+            Crystal.trace :thread, "shutdown"
+            return
+          end
+
+          Thread.name = scheduler.name unless thread == @main_thread
+          thread.internal_name = scheduler.name
+
+          resume(scheduler.main_fiber)
+
+          {% unless flag?(:interpreted) %}
+            if (stack = Thread.current.dead_fiber_stack?) && stack.reusable?
+              # release pending fiber stack left after swapcontext; we don't
+              # know which stack pool to return it to, and it may not even
+              # have one (e.g. isolated fiber stack)
+              Crystal::System::Fiber.free_stack(stack.pointer, stack.size)
+            end
+          {% end %}
+        end
+      rescue exception
+        Crystal.trace :thread, "exception", class: exception.class.name, message: exception.message
+
+        # panic: the thread loop crashing is an unexpected runtime error
+        Crystal.print_error_buffered("BUG: %s#enter_thread_loop crashed", self.class.name, exception: exception)
+        LibC.exit(1)
+      end
+
+      private def wait_for_scheduler?(thread, parked)
+        # usually empty, save for the first iteration of a new thread
+        if scheduler = thread.scheduler?
+          return scheduler
+        end
+
+        @mutex.synchronize do
+          # always empty, but quick check just in case
+          if scheduler = thread.scheduler?
+            return scheduler
+          end
+
+          @pool.push(parked)
+
+          while true
+            if can_terminate?(thread)
+              parked.value.wait(@mutex, ExecutionContext.thread_keepalive) do
+                # reached timeout: synchronize with #checkout
+                if scheduler = thread.scheduler?
+                  return scheduler
                 end
-              {% end %}
-            end
 
-            @mutex.synchronize do
-              # pthread_cond_wait happens to return zero without being signaled
-              # (Darwin targets at least), so we make sure to only add the
-              # thread to the pool once:
-              unless parked.linked?
-                @pool.push pointerof(parked)
+                # no race: cleanup and terminate
+                @pool.delete(parked)
+                return
               end
-            end
-
-            if thread == @main_thread || {% flag?(:win32) && Crystal::EventLoop.has_constant?(:IOCP) %}
-              # never shutdown the main thread: the main fiber is running on its
-              # original stack, terminating the main thread would invalidate the
-              # main fiber stack (oops)
-              #
-              # FIXME: never shutdown a thread on windows: it would abort pending I/O
-              # operations (for example `Socket#accept`) that the thread started
-              parked.wait
             else
-              parked.wait(ExecutionContext.thread_keepalive) do
-                # reached timeout: try to shutdown thread, but another thread
-                # might dequeue from @pool in parallel: run checks to avoid any
-                # race condition:
-                if !thread.scheduler? && parked.linked?
-                  deleted = false
-
-                  @mutex.synchronize do
-                    if parked.linked?
-                      @pool.delete pointerof(parked)
-                      deleted = true
-                    end
-                  end
-
-                  if deleted
-                    # no attached scheduler and we removed ourselves from the
-                    # pool: we can safely shutdown (no races)
-                    Crystal.trace :sched, "thread.shutdown"
-                    return
-                  end
-
-                  # no attached scheduler but another thread removed ourselves
-                  # from the pool and is waiting to acquire parked.mutex to
-                  # handoff a scheduler: unsync so it can progress
-                  parked.wait
-                end
-              end
+              parked.value.wait(@mutex)
             end
-          rescue exception
-            Crystal.trace :sched, "thread.exception",
-              class: exception.class.name,
-              message: exception.message
 
-            Crystal.print_error_buffered("BUG: %s#enter_thread_loop crashed",
-              self.class.name, exception: exception)
+            if scheduler = thread.scheduler?
+              return scheduler
+            end
           end
         end
       end
 
+      private def can_terminate?(thread)
+        {% if flag?(:win32) || Crystal::EventLoop.has_constant?(:IOCP) %}
+          # never shutdown a thread on windows: it would abort pending I/O
+          # operations (for example `Socket#accept`) that the thread has started
+          #
+          # TODO: keep an async operation counter on the thread, so we may
+          # eventually terminate the thread (check on every keepalive timeout)
+          false
+        {% else %}
+          # never shutdown the main thread: the process would exit immediately
+          # while the main user code fiber is still running
+          thread != @main_thread
+        {% end %}
+      end
+
       private def resume(fiber) : Nil
-        Crystal.trace :sched, "thread.resume", fiber: fiber
+        Crystal.trace :thread, "resume", fiber: fiber
 
         # FIXME: duplicates Fiber::ExecutionContext::MultiThreaded::Scheduler#resume:
         attempts = 0


### PR DESCRIPTION
Fixes #17165

The thread pool now uses a single `Thread::Mutex` to protect the `@pool` object and attaching a scheduler, which simplifies the overall logic, especially termination after a timeout, and avoids any possibility of a race.

The downside is that it creates a potential contention point between threads that must now lock the single mutex after being awoken.

See https://github.com/ysbaddaden/crystal/actions/runs/34578027785/job/103194888864 where 3 × 20 std spec runs didn't lead to a single crash.