### PR TITLE
Run main user code in Fiber

### DIFF
--- a/src/compiler/crystal.cr
+++ b/src/compiler/crystal.cr
@@ -8,8 +8,4 @@ require "./requires"
 
 Log.setup_from_env(default_level: :warn, default_sources: "crystal.*")
 
-{% if Fiber.has_constant?(:ExecutionContext) %}
-  Fiber::ExecutionContext.default.resize(Fiber::ExecutionContext.default_workers_count)
-{% end %}
-
 Crystal::Command.run

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -649,6 +649,11 @@ module Crystal
       wg = WaitGroup.new
       mutex = Sync::Mutex.new
 
+      {% if Fiber.has_constant?(:ExecutionContext) %}
+        cpu_count = Fiber::ExecutionContext.default_workers_count.clamp(1..n_threads)
+        Fiber::ExecutionContext.default.resize(cpu_count)
+      {% end %}
+
       n_threads.times do
         wg.spawn do
           while unit = channel.receive?

--- a/src/crystal/main.cr
+++ b/src/crystal/main.cr
@@ -4,6 +4,7 @@ lib LibCrystalMain
 end
 
 module Crystal
+  {% begin %}
   # Defines the main routine run by normal Crystal programs:
   #
   # - Initializes runtime requirements (GC, ...)
@@ -31,30 +32,59 @@ module Crystal
   # Note that the above is really just an example, almost the
   # same can be accomplished with `at_exit`. But in some cases
   # redefinition of C's main is needed.
-  def self.main(&block)
+  def self.main(&block : ->)
     {% if flag?(:tracing) %} Crystal::Tracing.init {% end %}
-    GC.init
 
+    GC.init
     init_runtime
 
-    status =
-      begin
-        yield
-        0
-      rescue ex
-        1
-      end
+    {% if !flag?(:without_mt) && (!flag?(:preview_mt) || flag?(:execution_context)) %}
+      # Run main user code in a fiber so the main program doesn't run on a
+      # thread's stack. This avoids situations where thread B would pick and
+      # resume the main fiber of thread A (crashes on aarch64-darwin), and
+      # allows every fiber to run on the same stack size.
+      main_user_code_fiber = Fiber.new(-> {
+        status =
+          begin
+            block.call
+            0
+          rescue ex
+            1
+          end
+        LibC.exit(exit(status , ex))
+      })
+      Fiber::ExecutionContext.thread_pool.enter_main_thread_loop(main_user_code_fiber)
 
-    exit(status, ex)
+      # unreachable (the above never returns)
+      1
+    {% else %}
+      status =
+        begin
+          yield
+          0
+        rescue ex
+          1
+        end
+      exit(status, ex)
+    {% end %}
   end
+  {% end %}
 
   # :nodoc:
+  #
+  # Manually initializes parts of the stdlib that must be setup before we can
+  # execute main user code, that will initialize globals, runtime (kernel) then
+  # run the actual program.
   def self.init_runtime : Nil
-    # `__crystal_once` directly or indirectly depends on `Fiber` and `Thread`
-    # so we explicitly initialize their class vars, then init crystal/once
     Thread.init
     Fiber.init
+    Thread.current # define main thread & main fiber
+
     Crystal::Once.init
+
+    {% if !flag?(:without_mt) && (!flag?(:preview_mt) || flag?(:execution_context)) %}
+      Fiber::ExecutionContext.init
+    {% end %}
   end
 
   # :nodoc:

--- a/src/crystal/tracing.cr
+++ b/src/crystal/tracing.cr
@@ -167,10 +167,13 @@ module Crystal
           else
             @@handle = LibC.GetStdHandle(LibC::STD_ERROR_HANDLE).address
           end
+
+          # don't propagate to sub-processes
+          LibC.SetEnvironmentVariableW(System.wstr_literal "CRYSTAL_TRACE", nil)
+          LibC.SetEnvironmentVariableW(System.wstr_literal "CRYSTAL_TRACE_FILE", nil)
         {% else %}
-          if ptr = LibC.getenv("CRYSTAL_TRACE")
-            len = LibC.strlen(ptr)
-            parse_sections(Slice.new(ptr, len)) if len > 0
+          if (ptr = LibC.getenv("CRYSTAL_TRACE")) && (len = LibC.strlen(ptr)) > 0
+            parse_sections(Slice.new(ptr, len))
           end
 
           if (ptr = LibC.getenv("CRYSTAL_TRACE_FILE")) && (LibC.strlen(ptr) > 0)
@@ -178,6 +181,10 @@ module Crystal
           else
             @@handle = 2
           end
+
+          # don't propagate to sub-processes
+          LibC.unsetenv("CRYSTAL_TRACE")
+          LibC.unsetenv("CRYSTAL_TRACE_FILE")
         {% end %}
       end
 

--- a/src/crystal/tracing.cr
+++ b/src/crystal/tracing.cr
@@ -6,6 +6,7 @@ module Crystal
     @[Flags]
     enum Section
       GC
+      Thread
       Sched
       Evloop
 

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -131,6 +131,27 @@ class Fiber
   end
   {% end %}
 
+  {% if !flag?(:without_mt) && (!flag?(:preview_mt) || flag?(:execution_context)) %}
+    # :nodoc:
+    #
+    # Internal constructor for running the main user code in a new fiber. No
+    # execution context (yet).
+    def initialize(@proc : ->)
+      @context = Context.new
+
+      pointer = Crystal::System::Fiber.allocate_stack(StackPool::STACK_SIZE, protect: true)
+      @stack = Stack.new(pointer, StackPool::STACK_SIZE, reusable: true)
+
+      fiber_main = ->(f : Fiber) { f.run }
+      stack_ptr = @stack.first_addressable_pointer
+      makecontext(stack_ptr, fiber_main)
+
+      @name = "main_user_code"
+
+      Fiber.fibers.push(self)
+    end
+  {% end %}
+
   # :nodoc:
   def initialize(stack : Void*, thread)
     @proc = Proc(Void).new { }

--- a/src/fiber/execution_context.cr
+++ b/src/fiber/execution_context.cr
@@ -99,12 +99,12 @@ require "./execution_context/*"
 # and reattached to the same execution context or to another one (`Concurrent`,
 # `Parallel` or `Isolated`).
 module Fiber::ExecutionContext
-  @@thread_pool : ThreadPool?
+  @@thread_pool = uninitialized ThreadPool
   @@default : ExecutionContext::Parallel?
 
   # :nodoc:
   def self.thread_pool : ThreadPool
-    @@thread_pool.not_nil!("expected thread pool to have been setup")
+    @@thread_pool
   end
 
   # Returns the default `ExecutionContext` for the process, automatically
@@ -119,8 +119,12 @@ module Fiber::ExecutionContext
   end
 
   # :nodoc:
-  def self.init_default_context : Nil
+  def self.init : Nil
     @@thread_pool = ThreadPool.new
+  end
+
+  # :nodoc:
+  def self.init_default_context : Nil
     @@default = Parallel.default(1)
     @@monitor = Monitor.new
   end

--- a/src/fiber/execution_context/thread_pool.cr
+++ b/src/fiber/execution_context/thread_pool.cr
@@ -78,23 +78,19 @@ class Fiber
         thread = Thread.current
         detach(thread)
 
-        if thread == @main_thread
-          thread.internal_name = "?"
-          resume(main_thread_loop)
-        else
-          Thread.name = ""
-          thread.internal_name = "?"
-          resume(thread.main_fiber)
-        end
+        Thread.name = "" unless thread == @main_thread
+        thread.internal_name = "?"
+
+        resume(thread.main_fiber)
       end
 
-      private def main_thread_loop
-        @main_thread_loop ||= begin
-          # OPTIMIZE: allocate minimum stack size
-          pointer = Crystal::System::Fiber.allocate_stack(StackPool::STACK_SIZE, protect: true)
-          stack = Stack.new(pointer, StackPool::STACK_SIZE, reusable: true)
-          Fiber.new(nil, stack, ExecutionContext.default) { enter_thread_loop(@main_thread) }
-        end
+      def enter_main_thread_loop(fiber : Fiber) : Nil
+        # switch execution to the main user code fiber
+        resume(fiber)
+
+        # execution switched back to the main fiber, which means that the thread
+        # has checkin into the thread pool: enter the main loop
+        enter_thread_loop(@main_thread)
       end
 
       # Each thread has a general loop, which is used to park the thread while

--- a/src/fiber/execution_context/thread_pool.cr
+++ b/src/fiber/execution_context/thread_pool.cr
@@ -13,54 +13,51 @@ class Fiber
         getter thread : Thread
 
         def initialize(@thread : Thread)
-          @mutex = Thread::Mutex.new
           @condition_variable = Thread::ConditionVariable.new
         end
 
-        def synchronize(&)
-          @mutex.synchronize { yield }
-        end
-
         def wake
+          Crystal.trace :thread, "wake", thread: @thread
           @condition_variable.signal
         end
 
-        def wait
-          @condition_variable.wait(@mutex)
+        def wait(mutex)
+          Crystal.trace :thread, "wait"
+          @condition_variable.wait(mutex)
         end
 
-        def wait(timeout, &)
-          @condition_variable.wait(@mutex, timeout) { yield }
-        end
-
-        def linked?
-          !@previous.null?
+        def wait(mutex, timeout, &)
+          Crystal.trace :thread, "wait", timeout: timeout.to_nanoseconds
+          @condition_variable.wait(mutex, timeout) { yield }
         end
       end
 
       def initialize
         @mutex = Thread::Mutex.new
-        @condition_variable = Thread::ConditionVariable.new
         @pool = Crystal::PointerLinkedList(Parked).new
         @main_thread = Thread.current
       end
 
       protected def checkout(scheduler)
-        thread =
-          if parked = @mutex.synchronize { @pool.shift? }
-            parked.value.synchronize do
-              attach(parked.value.thread, scheduler)
-              parked.value.wake
-            end
-            parked.value.thread
-          else
-            # OPTIMIZE: start thread with minimum stack size
-            Thread.new do |thread|
-              attach(thread, scheduler)
-              enter_thread_loop(thread)
-            end
+        thread = nil
+
+        @mutex.synchronize do
+          if parked = @pool.shift?
+            thread = parked.value.thread
+
+            attach(thread, scheduler)
+            parked.value.wake
           end
-        Crystal.trace :sched, "thread.checkout", thread: thread
+        end
+
+        thread ||= Thread.new do |thread|
+          Crystal.trace :thread, "start"
+
+          attach(thread, scheduler)
+          enter_thread_loop(thread)
+        end
+
+        Crystal.trace :thread, "checkout", thread: thread
         thread
       end
 
@@ -76,14 +73,17 @@ class Fiber
       end
 
       protected def checkin : Nil
-        Crystal.trace :sched, "thread.checkin"
+        Crystal.trace :thread, "checkin"
+
         thread = Thread.current
         detach(thread)
 
         if thread == @main_thread
+          thread.internal_name = "?"
           resume(main_thread_loop)
         else
           Thread.name = ""
+          thread.internal_name = "?"
           resume(thread.main_fiber)
         end
       end
@@ -108,84 +108,91 @@ class Fiber
       # isolated context).
       private def enter_thread_loop(thread)
         parked = Parked.new(thread)
-        parked.synchronize do
-          loop do
-            if scheduler = thread.scheduler?
-              unless thread == @main_thread
-                Thread.name = scheduler.name
-              end
 
-              resume(scheduler.main_fiber)
+        while true
+          scheduler = wait_for_scheduler?(thread, pointerof(parked))
 
-              {% unless flag?(:interpreted) %}
-                if (stack = Thread.current.dead_fiber_stack?) && stack.reusable?
-                  # release pending fiber stack left after swapcontext; we don't
-                  # know which stack pool to return it to, and it may not even
-                  # have one (e.g. isolated fiber stack)
-                  Crystal::System::Fiber.free_stack(stack.pointer, stack.size)
+          unless scheduler
+            Crystal.trace :thread, "shutdown"
+            return
+          end
+
+          Thread.name = scheduler.name unless thread == @main_thread
+          thread.internal_name = scheduler.name
+
+          resume(scheduler.main_fiber)
+
+          {% unless flag?(:interpreted) %}
+            if (stack = Thread.current.dead_fiber_stack?) && stack.reusable?
+              # release pending fiber stack left after swapcontext; we don't
+              # know which stack pool to return it to, and it may not even
+              # have one (e.g. isolated fiber stack)
+              Crystal::System::Fiber.free_stack(stack.pointer, stack.size)
+            end
+          {% end %}
+        end
+      rescue exception
+        Crystal.trace :thread, "exception", class: exception.class.name, message: exception.message
+
+        # panic: the thread loop crashing is an unexpected runtime error
+        Crystal.print_error_buffered("BUG: %s#enter_thread_loop crashed", self.class.name, exception: exception)
+        LibC.exit(1)
+      end
+
+      private def wait_for_scheduler?(thread, parked)
+        # usually empty, save for the first iteration of a new thread
+        if scheduler = thread.scheduler?
+          return scheduler
+        end
+
+        @mutex.synchronize do
+          # always empty, but quick check just in case
+          if scheduler = thread.scheduler?
+            return scheduler
+          end
+
+          @pool.push(parked)
+
+          while true
+            if can_terminate?(thread)
+              parked.value.wait(@mutex, ExecutionContext.thread_keepalive) do
+                # reached timeout: synchronize with #checkout
+                if scheduler = thread.scheduler?
+                  return scheduler
                 end
-              {% end %}
-            end
 
-            @mutex.synchronize do
-              # pthread_cond_wait happens to return zero without being signaled
-              # (Darwin targets at least), so we make sure to only add the
-              # thread to the pool once:
-              unless parked.linked?
-                @pool.push pointerof(parked)
+                # no race: cleanup and terminate
+                @pool.delete(parked)
+                return
               end
-            end
-
-            if thread == @main_thread || {% flag?(:win32) && Crystal::EventLoop.has_constant?(:IOCP) %}
-              # never shutdown the main thread: the main fiber is running on its
-              # original stack, terminating the main thread would invalidate the
-              # main fiber stack (oops)
-              #
-              # FIXME: never shutdown a thread on windows: it would abort pending I/O
-              # operations (for example `Socket#accept`) that the thread started
-              parked.wait
             else
-              parked.wait(ExecutionContext.thread_keepalive) do
-                # reached timeout: try to shutdown thread, but another thread
-                # might dequeue from @pool in parallel: run checks to avoid any
-                # race condition:
-                if !thread.scheduler? && parked.linked?
-                  deleted = false
-
-                  @mutex.synchronize do
-                    if parked.linked?
-                      @pool.delete pointerof(parked)
-                      deleted = true
-                    end
-                  end
-
-                  if deleted
-                    # no attached scheduler and we removed ourselves from the
-                    # pool: we can safely shutdown (no races)
-                    Crystal.trace :sched, "thread.shutdown"
-                    return
-                  end
-
-                  # no attached scheduler but another thread removed ourselves
-                  # from the pool and is waiting to acquire parked.mutex to
-                  # handoff a scheduler: unsync so it can progress
-                  parked.wait
-                end
-              end
+              parked.value.wait(@mutex)
             end
-          rescue exception
-            Crystal.trace :sched, "thread.exception",
-              class: exception.class.name,
-              message: exception.message
 
-            Crystal.print_error_buffered("BUG: %s#enter_thread_loop crashed",
-              self.class.name, exception: exception)
+            if scheduler = thread.scheduler?
+              return scheduler
+            end
           end
         end
       end
 
+      private def can_terminate?(thread)
+        {% if flag?(:win32) || Crystal::EventLoop.has_constant?(:IOCP) %}
+          # never shutdown a thread on windows: it would abort pending I/O
+          # operations (for example `Socket#accept`) that the thread has started
+          #
+          # TODO: keep an async operation counter on the thread, so we may
+          # eventually terminate the thread (check on every keepalive timeout)
+          false
+        {% else %}
+          # never shutdown the main thread: the process would exit immediately
+          # while the main user code fiber is still running
+          thread != @main_thread
+        {% end %}
+      end
+
       private def resume(fiber) : Nil
-        Crystal.trace :sched, "thread.resume", fiber: fiber
+        Crystal.trace :thread, "resume", fiber: fiber
 
         # FIXME: duplicates Fiber::ExecutionContext::MultiThreaded::Scheduler#resume:
         attempts = 0

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -192,31 +192,31 @@ module GC
 
   # :nodoc:
   def self.malloc(size : LibC::SizeT) : Void*
-    Crystal.trace :gc, "malloc", size: size do
+    #Crystal.trace :gc, "malloc", size: size do
       ptr = LibGC.malloc(size)
       oom(size) if ptr.null? && size != 0
       ptr
-    end
+    #end
   end
 
   # :nodoc:
   def self.malloc_atomic(size : LibC::SizeT) : Void*
-    Crystal.trace :gc, "malloc", size: size, atomic: 1 do
+    #Crystal.trace :gc, "malloc", size: size, atomic: 1 do
       ptr = LibGC.malloc_atomic(size)
       oom(size) if ptr.null? && size != 0
       ptr
-    end
+    #end
   end
 
   # :nodoc:
   def self.realloc(ptr : Void*, size : LibC::SizeT) : Void*
-    Crystal.trace :gc, "realloc", size: size do
+    #Crystal.trace :gc, "realloc", size: size do
       new_ptr = LibGC.realloc(ptr, size)
       # `GC_realloc(ptr, 0)` legitimately returns NULL (free semantics), only
       # a NULL result for a non-zero size means out of memory
       oom(size) if new_ptr.null? && size != 0
       new_ptr
-    end
+    #end
   end
 
   def self.init : Nil
@@ -346,9 +346,9 @@ module GC
   end
 
   def self.free(pointer : Void*) : Nil
-    Crystal.trace :gc, "free" do
+    #Crystal.trace :gc, "free" do
       LibGC.free(pointer)
-    end
+    #end
   end
 
   def self.add_finalizer(object : Reference) : Nil


### PR DESCRIPTION
Main user code now runs in a dedicated fiber, like any other fiber, instead of the confusing behavior where the fiber's stack from the main thread would be resumed by another thread.

The main thread's fiber now runs the thread pool loop, just like every other thread.

Depends on #17400.

**ISSUE**: This patch causes the GC to leak memory. See comments below.