### PR TITLE
Fix: don't propagate trace environment variables to sub-processes

### DIFF
--- a/src/crystal/tracing.cr
+++ b/src/crystal/tracing.cr
@@ -166,10 +166,13 @@ module Crystal
           else
             @@handle = LibC.GetStdHandle(LibC::STD_ERROR_HANDLE).address
           end
+
+          # don't propagate to sub-processes
+          LibC.SetEnvironmentVariableW(System.wstr_literal "CRYSTAL_TRACE", nil)
+          LibC.SetEnvironmentVariableW(System.wstr_literal "CRYSTAL_TRACE_FILE", nil)
         {% else %}
-          if ptr = LibC.getenv("CRYSTAL_TRACE")
-            len = LibC.strlen(ptr)
-            parse_sections(Slice.new(ptr, len)) if len > 0
+          if (ptr = LibC.getenv("CRYSTAL_TRACE")) && (len = LibC.strlen(ptr)) > 0
+            parse_sections(Slice.new(ptr, len))
           end
 
           if (ptr = LibC.getenv("CRYSTAL_TRACE_FILE")) && (LibC.strlen(ptr) > 0)
@@ -177,6 +180,10 @@ module Crystal
           else
             @@handle = 2
           end
+
+          # don't propagate to sub-processes
+          LibC.unsetenv("CRYSTAL_TRACE")
+          LibC.unsetenv("CRYSTAL_TRACE_FILE")
         {% end %}
       end
 


### PR DESCRIPTION
We want to trace the current process, and the `CRYSTAL_TRACE` and `CRYSTAL_TRACE_FILE` environments variables are meant to configure the current process only.

Yet, a sub-process might also have been compiled with `-Dtracing` and would reuse the environment variables, leading to corrupted trace files.

I noticed this while running std specs for example that runs the current executable itself in places (e.g. process-utils).

NOTE: while `unsetenv` is notoriously thread unsafe, when tracing initializes there is only the main thread.