### PR TITLE
Fix: tracing 128 bit integers

### DIFF
--- a/src/crystal/system/print_error.cr
+++ b/src/crystal/system/print_error.cr
@@ -163,7 +163,7 @@ module Crystal::System
     end
   end
 
-  private def self.to_int_slice_impl(buf, num, base)
+  protected def self.to_int_slice_impl(buf, num, base)
     ptr_end = buf.to_unsafe + buf.size
     ptr = ptr_end
 

--- a/src/crystal/tracing.cr
+++ b/src/crystal/tracing.cr
@@ -105,6 +105,14 @@ module Crystal
           write System.to_int_slice(@int_buf.to_slice, value.address, 16, true, 2)
         end
 
+        def write(value : Int128) : Nil
+          write value.zero? ? "0" : System.to_int_slice_impl(@int_buf.to_slice, value, 10)
+        end
+
+        def write(value : UInt128) : Nil
+          write value.zero? ? "0" : System.to_int_slice_impl(@int_buf.to_slice, value, 10)
+        end
+
         def write(value : Int::Signed) : Nil
           write System.to_int_slice(@int_buf.to_slice, value, 10, true, 2)
         end

--- a/src/crystal/tracing.cr
+++ b/src/crystal/tracing.cr
@@ -48,7 +48,7 @@ module Crystal
 
         def initialize
           @buf = uninitialized UInt8[N]
-          @int_buf = uninitialized UInt8[20] # max 64-bit integers
+          @int_buf = uninitialized UInt8[40] # max 128-bit integers
           @size = 0
         end
 


### PR DESCRIPTION
During tracing, 128-bit integers used to be truncated to 64-bit integers, and be obviously wrong for larger values.